### PR TITLE
Password is always "[object ArrayBuffer"

### DIFF
--- a/js/options.js
+++ b/js/options.js
@@ -24,7 +24,7 @@ $('#number').on('change', function() {//TODO
 
 var single_device = false;
 var signaling_key = getRandomBytes(32 + 20);
-var password = btoa(getRandomBytes(16));
+var password = btoa(getString(getRandomBytes(16)));
 password = password.substring(0, password.length - 2);
 
 $('#init-go-single-client').click(function() {


### PR DESCRIPTION
In [`options.js:27`](https://github.com/TheBlueMatt/textsecure-chrome/blob/000a5e1440590381441390ba2b9eee71fa73907e/js/options.js#L27), the password is generated as `btoa(getRandomBytes(16))`.

As documented [on MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window.btoa), `btoa` accepts a string argument. However, since [`getRandomBytes`](https://github.com/TheBlueMatt/textsecure-chrome/blob/master/js/helpers.js#L392) returns an `ArrayBuffer`, it is implicitly converted to a string by calling `.toString()` on it - which for an `ArrayBuffer` returns `"[object ArrayBuffer]"`.

In the next line, the last 2 characters of the Base64 encoded password are then removed, effectively setting `password` to `W29iamVjdCBBcnJheUJ1ZmZlcl` (or `[object ArrayBuffer` when decoded).

A possible fix for this would be something like:

``` javascript
var password = btoa(getString(getRandomBytes(16)));
```
