### PR TITLE
Fixed 'TypeError: Promise.resolve is not a constructor' in Firefox

### DIFF
--- a/js/crypto.js
+++ b/js/crypto.js
@@ -87,9 +87,9 @@ window.textsecure.crypto = new function() {
 				priv[0] |= 0x0001;
 
 			//TODO: fscking type conversion
-			return new Promise.resolve({ pubKey: prependVersion(toArrayBuffer(curve25519(priv))), privKey: privKey});
+			return Promise.resolve({ pubKey: prependVersion(toArrayBuffer(curve25519(priv))), privKey: privKey});
 		}
-	
+
 	}
 	var privToPub = function(privKey, isIdentity) { return testing_only.privToPub(privKey, isIdentity); }
 

--- a/js/webcrypto.js
+++ b/js/webcrypto.js
@@ -73,7 +73,7 @@ window.crypto.subtle = (function() {
 		function promise(implementation) {
 			var args = Array.prototype.slice.call(arguments);
 			args.shift();
-			return new Promise.resolve(toArrayBuffer(implementation.apply(this, args)));
+			return Promise.resolve(toArrayBuffer(implementation.apply(this, args)));
 		}
 
 		// public interface functions


### PR DESCRIPTION
The error is thrown in Firefox when test.html is simply opened (in file:// namespace)
For some reason it's not thrown in Chromium.
