### PR TITLE
NaCL -> Native Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ TextSecure Chromium Implementation
 ==================================
 
 This is very early stuff and exists primarily to get the crypto in place.
-It is currently chromium-only as it uses NaCL for Curve25519 stuff, but I'd be
-glad to accept a pull that abstracts out the NaCL-specific stuff to optionally
+It is currently chromium-only as it uses [Native Client](https://developer.chrome.com/native-client) for Curve25519 stuff, but I'd be
+glad to accept a pull that abstracts out the Native Client-specific stuff to optionally
 use a JS implementation for FF.
 Note that the code is currently quite messy (its all in one file!), but it
 needs to work first, then it can be heavily cleaned up later.


### PR DESCRIPTION
NaCL is the name for both Google's native client technology and a popular cypto library.  Any abstractions of the "Curve25519 stuff" would likely be in the form of an emscripten port of NaCL so I clarified which is which : )
