### PR TITLE
Fixed bug caused by calling fetch with an index name that doesn't exist in the store

### DIFF
--- a/components/indexeddb-backbonejs-adapter/backbone-indexeddb.js
+++ b/components/indexeddb-backbonejs-adapter/backbone-indexeddb.js
@@ -437,7 +437,6 @@
                     readCursor = index.openCursor(bounds, window.IDBCursor.NEXT || "next");
                 }
             } else {
-
                 // No conditions, use the index
                 if (options.range) {
                     lower = options.range[0] > options.range[1] ? options.range[1] : options.range[0];

--- a/js/components.js
+++ b/js/components.js
@@ -21795,7 +21795,6 @@ return jQuery;
                     readCursor = index.openCursor(bounds, window.IDBCursor.NEXT || "next");
                 }
             } else {
-
                 // No conditions, use the index
                 if (options.range) {
                     lower = options.range[0] > options.range[1] ? options.range[1] : options.range[0];


### PR DESCRIPTION
fetchActive was trying to retrieve the index "inbox", which didn't exist in the store. This caused `index = store.index(options.index.name);` to throw `Uncaught NotFoundError: Failed to execute 'index' on 'IDBObjectStore': The specified index was not found.`
