### PR TITLE
Added ✓ to delivered messages

### DIFF
--- a/stylesheets/index.css
+++ b/stylesheets/index.css
@@ -83,16 +83,3 @@ li.entry img {
   padding: 5px;
   border-radius: 3px;
 }
-
-.timestamp {
-  font-size: 0.75em;
-  display: block;
-}
-
-.incoming .timestamp {
-  color: gray;
-}
-
-.outgoing .timestamp {
-  color: whitesmoke;
-}

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -184,6 +184,16 @@ ul.discussion {
   width: 100%;
   float: left;
   margin-bottom: 10px; }
+  .entry .timestamp {
+    font-size: 0.75em;
+    display: block; }
+    .entry .timestamp:incoming {
+      color: gray; }
+    .entry .timestamp:outgoing {
+      color: whitesmoke; }
+  .entry.delivered .timestamp::after {
+    margin-left: 4px;
+    content: "✓"; }
 
 .bubble {
   border-radius: 16px;

--- a/stylesheets/view/_conversation.scss
+++ b/stylesheets/view/_conversation.scss
@@ -19,6 +19,26 @@ ul.discussion {
   width:100%;
   float:left;
   margin-bottom:10px;
+
+  .timestamp {
+    font-size: 0.75em;
+    display: block;
+
+    &:incoming {
+      color: gray;
+    }
+
+    &:outgoing {
+      color: whitesmoke;
+    }
+  }
+
+  &.delivered .timestamp {
+    &::after {
+      margin-left: 4px;
+      content: "✓";
+    }
+  }
 }
 
 .bubble {


### PR DESCRIPTION
Looks like this:

![image](https://cloud.githubusercontent.com/assets/801452/5533180/62fe3c9e-8a08-11e4-9e03-d2edc6180ad4.png)

If you wanted to use an icon library instead of unicode, let me know. I also moved the .timestamp classes from index.css to manifest.scss because it seemed like a better fit. 
