### PR TITLE
Assume group numbers have the same country code as us, if none is specified

### DIFF
--- a/js/helpers.js
+++ b/js/helpers.js
@@ -296,3 +296,15 @@ window.textsecure.registerSecondDevice = function(encodedDeviceInit, cryptoInfo,
         });
     });
 };
+
+window.textsecure.verifyNumber = function(number) {
+    if (number[0] === '+') {
+      // assume that the country code is specified
+      return libphonenumber.util.verifyNumber(number);
+    } else {
+      // assume that the country code should match our own
+      var me = textsecure.utils.unencodeNumber(textsecure.storage.getUnencrypted("number_id"))[0];
+      var myRegionCode = libphonenumber.util.getRegionCodeForNumber(me);
+      return libphonenumber.util.verifyNumber(number, myRegionCode);
+    }
+}

--- a/js/storage/groups.js
+++ b/js/storage/groups.js
@@ -41,7 +41,7 @@
             var haveMe = false;
             var finalNumbers = [];
             for (var i in numbers) {
-                var number = libphonenumber.util.verifyNumber(numbers[i]);
+                var number = window.textsecure.verifyNumber(numbers[i]);
                 if (number == me)
                     haveMe = true;
                 if (finalNumbers.indexOf(number) < 0) {
@@ -72,7 +72,7 @@
                 return undefined;
 
             try {
-                number = libphonenumber.util.verifyNumber(number);
+                number = window.textsecure.verifyNumber(number);
             } catch (e) {
                 return group.numbers;
             }
@@ -97,7 +97,7 @@
                 return undefined;
 
             for (var i in numbers) {
-                var number = libphonenumber.util.verifyNumber(numbers[i]);
+                var number = window.textsecure.verifyNumber(numbers[i]);
                 if (group.numbers.indexOf(number) < 0) {
                     group.numbers.push(number);
                     addGroupToNumber(groupId, number);

--- a/js/views/new_conversation_view.js
+++ b/js/views/new_conversation_view.js
@@ -30,15 +30,7 @@ var Whisper = Whisper || {};
     verifyNumber: function() {
       try {
         var val = this.$el.val();
-        if (val[0] === '+') {
-          // assume that the country code is specified
-          var number = libphonenumber.util.verifyNumber(val);
-        } else {
-          // assume that the country code should match our own
-          var me = textsecure.utils.unencodeNumber(textsecure.storage.getUnencrypted("number_id"))[0];
-          var myRegionCode = libphonenumber.util.getRegionCodeForNumber(me);
-          var number = libphonenumber.util.verifyNumber(val, myRegionCode);
-        }
+        var number = window.textsecure.verifyNumber(val);
         this.removeError();
         return number;
       } catch(ex) {

--- a/js/views/new_group_view.js
+++ b/js/views/new_group_view.js
@@ -10,7 +10,7 @@ var Whisper = Whisper || {};
 
     tagClass: function(item) {
       try {
-        if (libphonenumber.util.verifyNumber(item)) {
+        if (window.textsecure.verifyNumber(item)) {
           return;
         }
       } catch(ex) {}


### PR DESCRIPTION
I moved number verification to helper.js, so that group messages and one-on-one messages use the same logic. 

Are group messages working right now? Whenever I try and send one, the recipient gets an error on [this line of background.js](https://github.com/WhisperSystems/TextSecure-Browser/blob/master/js/background.js#L168). `conversation.save()` returns false, and any success and error callbacks that I add are never called. I've reinstalled the app, gone back a week in commits, and nothing seems to help.
