### PR TITLE
Removed duplicate case statement in api.js

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -36346,9 +36346,6 @@ var TextSecureServer = (function() {
                 case 413:
                     message = "Rate limit exceeded, please try again later.";
                     break;
-                case 403:
-                    message = "Invalid code, please try again.";
-                    break;
                 case 417:
                     // TODO: This shouldn't be a thing?, but its in the API doc?
                     message = "Number already registered.";

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -163,9 +163,6 @@ var TextSecureServer = (function() {
                 case 413:
                     message = "Rate limit exceeded, please try again later.";
                     break;
-                case 403:
-                    message = "Invalid code, please try again.";
-                    break;
                 case 417:
                     // TODO: This shouldn't be a thing?, but its in the API doc?
                     message = "Number already registered.";


### PR DESCRIPTION
This 403 message was overshadowing the arguably more useful case statement
below.

// FREEBIE