### PR TITLE
Correctly set resizing and resizeTimer in listview onResize()

### DIFF
--- a/js/views/list_view.js
+++ b/js/views/list_view.js
@@ -26,9 +26,9 @@
         onResize: function(e) {
             this.resizing = true;
             clearTimeout(this.resizeTimer);
-            resizeTimer = setTimeout(function() {
-                resizing = false;
-            }, 500);
+            this.resizeTimer = setTimeout((function() {
+                this.resizing = false;
+            }).bind(this), 500);
             this.$el.scrollTop(this.scrollPercent * this.$el.height());
         },
 


### PR DESCRIPTION
Previously, global variables were being set, rather then setting properties on
the list object. This means that this.resizing was always true after the first
window resize, and global variables were being leaked.

// FREEBIE