### PR TITLE
Change input type of search field to "search"

### DIFF
--- a/background.html
+++ b/background.html
@@ -13,7 +13,7 @@
       <span class='socket-status'></span>
       <div class='tool-bar clearfix'>
         <!-- <button class='show-new-conversation'></button> -->
-        <input type='text' class='search' placeholder='Search for people or groups'>
+        <input type='search' class='search' placeholder='Search for people or groups'>
       </div>
     </div>
     <div class='gutter'>


### PR DESCRIPTION
Generates a simple clear element when typing. Closes https://github.com/WhisperSystems/Signal-Desktop/issues/420 
Will work in all HTML 5.0 compatible browsers.

// FREEBIE

![clear dialog](https://cloud.githubusercontent.com/assets/7095883/11614753/28d328d4-9c4c-11e5-98cf-c096d23e0a47.png)
