### PR TITLE
Set textare size to fill container

### DIFF
--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -533,7 +533,7 @@
 
   .send-message {
     display: block;
-    width: calc(100% - 2 * #{$button-width} - 20px);
+    width: calc(100% - #{$button-width});
     min-height: $header-height - 1px;
     max-height: 100px;
     padding: 10px;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -923,6 +923,7 @@ input.search {
     cursor: pointer; }
 
 .bottom-bar {
+  $button-width: 36px;
   margin-top: 4px;
   height: 36px;
   border-top: 1px solid #f3f3f3;
@@ -933,7 +934,7 @@ input.search {
     position: absolute;
     top: 0;
     height: 100%;
-    width: 36px;
+    width: $button-width;
     padding: 0;
     border: 0;
     outline: 0;
@@ -957,7 +958,7 @@ input.search {
   .bottom-bar .send-btn {
     float: right;
     height: 36px;
-    width: 36px;
+    width: $button-width;
     border: none;
     outline: none;
     background: url("/images/send.png") no-repeat;
@@ -970,7 +971,7 @@ input.search {
     height: 100%; }
   .bottom-bar .send-message {
     display: block;
-    width: calc(100% - 2 * 36px - 20px);
+    width: calc(100% - #{$button-width});
     min-height: 35px;
     max-height: 100px;
     padding: 10px;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -958,7 +958,7 @@ input.search {
   .bottom-bar .send-btn {
     float: right;
     height: 36px;
-    width: $button-width;
+    width: 36px;
     border: none;
     outline: none;
     background: url("/images/send.png") no-repeat;


### PR DESCRIPTION
Widens the texterarea to fill the surrounding container (suspect the old button on the right side got sorted out)

// FREEBIE

Before:
![before](https://cloud.githubusercontent.com/assets/7095883/11642099/7a5bafe6-9d3c-11e5-8149-77e504cc5776.png)
After:
![after](https://cloud.githubusercontent.com/assets/7095883/11642127/7eaea53a-9d3c-11e5-842c-4ef428bc25d1.png)
