### PR TITLE
Add drag and drop support for text

### DIFF
--- a/js/views/file_input_view.js
+++ b/js/views/file_input_view.js
@@ -234,6 +234,8 @@
         },
 
         openDropped: function(e) {
+            if (e.originalEvent.dataTransfer.types[0] != "Files") return;
+
             e.stopPropagation();
             e.preventDefault();
             this.file = e.originalEvent.dataTransfer.files[0];
@@ -242,12 +244,16 @@
         },
 
         showArea: function(e) {
+            if (e.originalEvent.dataTransfer.types[0] != "Files") return;
+
             e.stopPropagation();
             e.preventDefault();
             this.$el.addClass("dropoff");
         },
 
         hideArea: function(e) {
+            if (e.originalEvent.dataTransfer.types[0] != "Files") return;
+
             e.stopPropagation();
             e.preventDefault();
             this.$el.removeClass("dropoff");

--- a/js/views/file_input_view.js
+++ b/js/views/file_input_view.js
@@ -234,29 +234,29 @@
         },
 
         openDropped: function(e) {
-            if (e.originalEvent.dataTransfer.types[0] != "Files") return;
+            if (e.originalEvent.dataTransfer.types[0] != 'Files') return;
 
             e.stopPropagation();
             e.preventDefault();
             this.file = e.originalEvent.dataTransfer.files[0];
             this.previewImages();
-            this.$el.removeClass("dropoff");
+            this.$el.removeClass('dropoff');
         },
 
         showArea: function(e) {
-            if (e.originalEvent.dataTransfer.types[0] != "Files") return;
+            if (e.originalEvent.dataTransfer.types[0] != 'Files') return;
 
             e.stopPropagation();
             e.preventDefault();
-            this.$el.addClass("dropoff");
+            this.$el.addClass('dropoff');
         },
 
         hideArea: function(e) {
-            if (e.originalEvent.dataTransfer.types[0] != "Files") return;
+            if (e.originalEvent.dataTransfer.types[0] != 'Files') return;
 
             e.stopPropagation();
             e.preventDefault();
-            this.$el.removeClass("dropoff");
+            this.$el.removeClass('dropoff');
         }
     });
 })();


### PR DESCRIPTION
By adding the drag and drop support for media files, the default
event handlers were overwritten. Thus drag and drop did not support
text. Now, the drag and drop listeners revert to the default behaviour
when the user does not drag a file.

Resolves: #478