### PR TITLE
Let container-div fit in key-verification-window

### DIFF
--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -54,6 +54,9 @@
     padding: 0 1em;
     -webkit-user-select: text;
   }
+  .container {
+    height : calc(100% - (36px + 5px + 1px + 4px));
+  }
 }
 
 .message-detail {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -622,6 +622,9 @@ input.search {
     font-family: monospace;
     padding: 0 1em;
     -webkit-user-select: text; }
+  .key-verification .container {
+    height : calc(100% - (36px + 5px + 1px + 4px));
+  }
 
 .message-detail .container {
   height: calc(100% - (36px + 4px)); }


### PR DESCRIPTION
Resolves #416

Before:
![before](https://cloud.githubusercontent.com/assets/6809794/11755269/634b34e4-a051-11e5-8567-2735e0d17f03.png)
After:
![after](https://cloud.githubusercontent.com/assets/6809794/11755271/677ed5a2-a051-11e5-9772-3743f4162748.png)

// FREEBIE