### PR TITLE
Making textareas less ugly

### DIFF
--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -16,6 +16,10 @@ body {
   font-size: 14px;
 }
 
+form, input, textarea {
+    font-family: $roboto;
+}
+
 .clearfix:before,
 .clearfix:after {
   display: table;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -27,6 +27,9 @@ body {
   font-family: Roboto, "Helvetica Neue", Arial, Helvetica, sans-serif;
   font-size: 14px; }
 
+form, input, textarea {
+  font-family: Roboto, "Helvetica Neue", Arial, Helvetica, sans-serif; }
+
 .clearfix:before,
 .clearfix:after {
   display: table;


### PR DESCRIPTION
On Linux, the textarea for writing message was super ugly, using monospaced font for no reason.

So I made it less ugly! 

:dancer: 