### PR TITLE
Add user-agent string to DebugLog // fixes #404

### DIFF
--- a/js/debugLog.js
+++ b/js/debugLog.js
@@ -18,7 +18,7 @@
             debugLog.push(str);
         };
         console.get = function() {
-            return debugLog.join('\n');
+            return window.navigator.userAgent + '\n' + debugLog.join('\n');
         };
         console.post = function(log) {
             if (log === undefined) {


### PR DESCRIPTION
The user-agent string includes the information needed (OS + Chrome version) and the console.get() function seems just right, because the debugLog itself is not manipulated.

#404