### PR TITLE
Fix #583 from/to label translatable

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -95,6 +95,14 @@
         "message": "Nachrichten-Details",
         "description": ""
     },
+    "from": {
+        "message": "Von",
+        "description": "Label for the sender of a message"
+    },
+    "to": {
+        "message": "An",
+        "description": "Label for the receiver of a message"
+    },
     "verify": {
         "message": "Verifizieren",
         "description": ""

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -68,6 +68,14 @@
     "messageDetail": {
         "message": "Message Detail"
     },
+    "from": {
+        "message": "From",
+        "description": "Label for the sender of a message"
+    },
+    "to": {
+        "message": "To",
+        "description": "Label for the receiver of a message"
+    },
     "sent": {
         "message": "Sent",
         "description": "Label for the time a message was sent"

--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -111,7 +111,7 @@
             this.$el.html(Mustache.render(_.result(this, 'template', ''), {
                 sent_at     : moment(this.model.get('sent_at')).toString(),
                 received_at : this.model.isIncoming() ? moment(this.model.get('received_at')).toString() : null,
-                tofrom      : this.model.isIncoming() ? 'From' : 'To',
+                tofrom      : this.model.isIncoming() ? i18n('from') : i18n('to'),
                 errors      : this.errors['undefined'],
                 title       : i18n('messageDetail'),
                 sent        : i18n('sent'),


### PR DESCRIPTION
I just added i18n calls and the corresponding keys for en + de.
#583