### PR TITLE
Add mozSystem option to ajax requests to enable cross-domain request

### DIFF
--- a/js/libaxolotl-worker.js
+++ b/js/libaxolotl-worker.js
@@ -116,7 +116,7 @@ else if (ENVIRONMENT_IS_SHELL) {
 }
 else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   Module['read'] = function read(url) {
-    var xhr = new XMLHttpRequest();
+    var xhr = new XMLHttpRequest({mozSystem: true});
     xhr.open('GET', url, false);
     xhr.send(null);
     return xhr.responseText;
@@ -3858,7 +3858,7 @@ function copyTempDouble(ptr) {
         }
         LazyUint8Array.prototype.cacheLength = function LazyUint8Array_cacheLength() {
           // Find length
-          var xhr = new XMLHttpRequest();
+          var xhr = new XMLHttpRequest({mozSystem: true});
           xhr.open('HEAD', url, false);
           xhr.send(null);
           if (!(xhr.status >= 200 && xhr.status < 300 || xhr.status === 304)) throw new Error("Couldn't load " + url + ". Status: " + xhr.status);
@@ -3875,7 +3875,7 @@ function copyTempDouble(ptr) {
             if (to > datalength-1) throw new Error("only " + datalength + " bytes available! programmer error!");
 
             // TODO: Use mozResponseArrayBuffer, responseStream, etc. if available.
-            var xhr = new XMLHttpRequest();
+            var xhr = new XMLHttpRequest({mozSystem: true});
             xhr.open('GET', url, false);
             if (datalength !== chunkSize) xhr.setRequestHeader("Range", "bytes=" + from + "-" + to);
 
@@ -4789,7 +4789,7 @@ function copyTempDouble(ptr) {
           Browser.mouseY = y;
         }
       },xhrLoad:function (url, onload, onerror) {
-        var xhr = new XMLHttpRequest();
+        var xhr = new XMLHttpRequest({mozSystem: true});
         xhr.open('GET', url, true);
         xhr.responseType = 'arraybuffer';
         xhr.onload = function xhr_onload() {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -214,7 +214,7 @@ else if (ENVIRONMENT_IS_SHELL) {
 }
 else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   Module['read'] = function read(url) {
-    var xhr = new XMLHttpRequest();
+    var xhr = new XMLHttpRequest({mozSystem: true});
     xhr.open('GET', url, false);
     xhr.send(null);
     return xhr.responseText;
@@ -3956,7 +3956,7 @@ function copyTempDouble(ptr) {
         }
         LazyUint8Array.prototype.cacheLength = function LazyUint8Array_cacheLength() {
           // Find length
-          var xhr = new XMLHttpRequest();
+          var xhr = new XMLHttpRequest({mozSystem: true});
           xhr.open('HEAD', url, false);
           xhr.send(null);
           if (!(xhr.status >= 200 && xhr.status < 300 || xhr.status === 304)) throw new Error("Couldn't load " + url + ". Status: " + xhr.status);
@@ -3973,7 +3973,7 @@ function copyTempDouble(ptr) {
             if (to > datalength-1) throw new Error("only " + datalength + " bytes available! programmer error!");
   
             // TODO: Use mozResponseArrayBuffer, responseStream, etc. if available.
-            var xhr = new XMLHttpRequest();
+            var xhr = new XMLHttpRequest({mozSystem: true});
             xhr.open('GET', url, false);
             if (datalength !== chunkSize) xhr.setRequestHeader("Range", "bytes=" + from + "-" + to);
   
@@ -4887,7 +4887,7 @@ function copyTempDouble(ptr) {
           Browser.mouseY = y;
         }
       },xhrLoad:function (url, onload, onerror) {
-        var xhr = new XMLHttpRequest();
+        var xhr = new XMLHttpRequest({mozSystem: true});
         xhr.open('GET', url, true);
         xhr.responseType = 'arraybuffer';
         xhr.onload = function xhr_onload() {
@@ -29937,7 +29937,7 @@ Curve25519Worker.prototype = {
             Util.XHR = function() {
                 // No dependencies please, ref: http://www.quirksmode.org/js/xmlhttp.html
                 var XMLHttpFactories = [
-                    function () {return new XMLHttpRequest()},
+                    function () {return new XMLHttpRequest({mozSystem: true})},
                     function () {return new ActiveXObject("Msxml2.XMLHTTP")},
                     function () {return new ActiveXObject("Msxml3.XMLHTTP")},
                     function () {return new ActiveXObject("Microsoft.XMLHTTP")}
@@ -36211,7 +36211,7 @@ var TextSecureServer = (function() {
     function promise_ajax(url, options) {
         return new Promise(function (resolve, reject) {
             console.log(options.type, url);
-            var xhr = new XMLHttpRequest();
+            var xhr = new XMLHttpRequest({mozSystem: true});
             xhr.open(options.type, url, true /*async*/);
 
             if ( options.responseType ) {

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -28,7 +28,7 @@ var TextSecureServer = (function() {
     function promise_ajax(url, options) {
         return new Promise(function (resolve, reject) {
             console.log(options.type, url);
-            var xhr = new XMLHttpRequest();
+            var xhr = new XMLHttpRequest({mozSystem: true});
             xhr.open(options.type, url, true /*async*/);
 
             if ( options.responseType ) {

--- a/libtextsecure/libaxolotl.js
+++ b/libtextsecure/libaxolotl.js
@@ -116,7 +116,7 @@ else if (ENVIRONMENT_IS_SHELL) {
 }
 else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   Module['read'] = function read(url) {
-    var xhr = new XMLHttpRequest();
+    var xhr = new XMLHttpRequest({mozSystem: true});
     xhr.open('GET', url, false);
     xhr.send(null);
     return xhr.responseText;
@@ -3858,7 +3858,7 @@ function copyTempDouble(ptr) {
         }
         LazyUint8Array.prototype.cacheLength = function LazyUint8Array_cacheLength() {
           // Find length
-          var xhr = new XMLHttpRequest();
+          var xhr = new XMLHttpRequest({mozSystem: true});
           xhr.open('HEAD', url, false);
           xhr.send(null);
           if (!(xhr.status >= 200 && xhr.status < 300 || xhr.status === 304)) throw new Error("Couldn't load " + url + ". Status: " + xhr.status);
@@ -3875,7 +3875,7 @@ function copyTempDouble(ptr) {
             if (to > datalength-1) throw new Error("only " + datalength + " bytes available! programmer error!");
   
             // TODO: Use mozResponseArrayBuffer, responseStream, etc. if available.
-            var xhr = new XMLHttpRequest();
+            var xhr = new XMLHttpRequest({mozSystem: true});
             xhr.open('GET', url, false);
             if (datalength !== chunkSize) xhr.setRequestHeader("Range", "bytes=" + from + "-" + to);
   
@@ -4789,7 +4789,7 @@ function copyTempDouble(ptr) {
           Browser.mouseY = y;
         }
       },xhrLoad:function (url, onload, onerror) {
-        var xhr = new XMLHttpRequest();
+        var xhr = new XMLHttpRequest({mozSystem: true});
         xhr.open('GET', url, true);
         xhr.responseType = 'arraybuffer';
         xhr.onload = function xhr_onload() {
@@ -29839,7 +29839,7 @@ Curve25519Worker.prototype = {
             Util.XHR = function() {
                 // No dependencies please, ref: http://www.quirksmode.org/js/xmlhttp.html
                 var XMLHttpFactories = [
-                    function () {return new XMLHttpRequest()},
+                    function () {return new XMLHttpRequest({mozSystem: true})},
                     function () {return new ActiveXObject("Msxml2.XMLHTTP")},
                     function () {return new ActiveXObject("Msxml3.XMLHTTP")},
                     function () {return new ActiveXObject("Microsoft.XMLHTTP")}


### PR DESCRIPTION
This option is ignored by Chrome\* and only works in privileged Firefox
WebApps. (see
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest)

This pr supersedes #574.
