### PR TITLE
Remove gray border around window

### DIFF
--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -4,7 +4,6 @@
 
 html {
   height: 100%;
-  border: solid 1px #ccc;
 }
 
 body {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -16,8 +16,7 @@
   box-sizing: border-box; }
 
 html {
-  height: 100%;
-  border: solid 1px #ccc; }
+  height: 100%; }
 
 body {
   position: relative;


### PR DESCRIPTION
Remove the 1px gray border around the window. This allows to the window to integrate seamlessly with custom window managers which use the background color for the titlebar.

The end result looks like [this](http://i.imgur.com/0yPtayt.png).