### PR TITLE
Fix two strings that didn't use term 'linking'

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -123,7 +123,7 @@
     },
     "installSignalLink": {
         "message": "First, install <a $a_params$>Signal</a> on your Android phone.<br /> We'll link your devices and keep your messages in sync.",
-        "description": "Prompt the user to install Signal on Android before pairing",
+        "description": "Prompt the user to install Signal on Android before linking",
         "placeholders": {
           "a_params": {
             "content": "$1",
@@ -170,6 +170,6 @@
         "description": "The final button for the install process, after the user has entered a name for their device"
     },
     "installTooManyDevices": {
-        "message": "Sorry, you have too many devices registered already. Try removing some."
+        "message": "Sorry, you have too many devices linked already. Try removing some."
     }
 }


### PR DESCRIPTION
Fixes two strings that didn't use the term _linking_. As we know that's correct term to use in this multi-device context ([1](https://github.com/WhisperSystems/Signal-Android/issues/3830), [2](https://github.com/WhisperSystems/Signal-Android/pull/3831), [3](https://github.com/WhisperSystems/Signal-Android/blob/759f9d80169bf8d6de7d973366e4bbc5cc890900/res/values/strings.xml#L392)).