### PR TITLE
Conversation style improvements

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -266,21 +266,12 @@
             this.view.measureScrollPosition();
             window.autosize(this.$messageField);
 
-            var $discussionContainer = this.$('.discussion-container'),
-                $conversationHeader = this.$('.conversation-header'),
-                $attachmentPreviews = this.$('.attachment-previews'),
+            var $attachmentPreviews = this.$('.attachment-previews'),
                 $bottomBar = this.$('.bottom-bar');
 
             $bottomBar.outerHeight(
                     this.$messageField.outerHeight() +
                     $attachmentPreviews.outerHeight() + 1);
-            var $bottomBarNewHeight = $bottomBar.outerHeight();
-
-            //TODO: revisit this logic for new layout.
-            $discussionContainer.outerHeight(
-                    this.$el.outerHeight() -
-                    $bottomBarNewHeight -
-                    $conversationHeader.outerHeight() - 40);
 
             this.view.scrollToBottomIfNeeded();
         },

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -28,16 +28,30 @@
 
   .panel {
     height: 100%;
+    display: flex;
+    flex-direction: column;
 
     .discussion-container {
-      height: calc(100% - 2 * #{$header-height} - 60px);
+      flex-grow: 1;
+      position: relative;
+
+      .message-list {
+        position: absolute;
+        top: 0;
+        height: 100%;
+        width: 100%;
+
+        @media(min-width: $big-avatar-min-width) {
+          padding-left: 70px;
+        }
+      }
     }
   }
 }
 
 .group-member-list,
 .new-group-update,
-.message-list, .message-detail, .key-verification {
+.message-detail, .key-verification {
   height: 100%;
 }
 
@@ -282,7 +296,7 @@
     margin-left: 8px;
     max-width: 30em;
 
-    @media(max-width:900px) {
+    @media(max-width: $big-avatar-min-width - 1px) {
       max-width: calc(100% - 45px); // avatar size + padding
     }
 

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -1,17 +1,3 @@
-.conversation {
-  background-color: #ffffff;
-  margin: 10px;
-  padding: 20px;
-  border-radius: 10px;
-
-  .panel {
-    height: 100%;
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: rgba(0,0,0,0.15);
-  }
-}
 .conversation-title {
   display: block;
   line-height: $header-height;
@@ -29,11 +15,23 @@
 }
 
 .conversation {
+  background-color: #ffffff;
+  margin: 10px;
+  padding: 20px;
+  border-radius: 10px;
   height: calc(100% - 20px);
   border-radius: 10px;
 
-  .discussion-container {
-    height: calc(100% - 2 * #{$header-height} - 60px);
+  ::-webkit-scrollbar-thumb {
+    background: rgba(0,0,0,0.15);
+  }
+
+  .panel {
+    height: 100%;
+
+    .discussion-container {
+      height: calc(100% - 2 * #{$header-height} - 60px);
+    }
   }
 }
 

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -40,9 +40,29 @@
         top: 0;
         height: 100%;
         width: 100%;
+        margin: 0;
+        padding: 2em 8px 0;
+        overflow-y: auto;
 
         @media(min-width: $big-avatar-min-width) {
           padding-left: 70px;
+        }
+
+        &:before {
+          display: block;
+          margin: -25px auto 10px;
+          content: " ";
+          height: $loading-height;
+          width: $loading-height;
+          border: solid 3px transparent;
+        }
+
+        .timestamp {
+          cursor: pointer;
+
+          &:hover {
+            text-decoration: underline;
+          }
         }
       }
     }
@@ -238,31 +258,6 @@
     background: none;
     &:before { content: '...'; }
   }
-}
-
-.message-list {
-  position: relative;
-  margin: 0;
-  padding: 2em 0 0;
-  overflow-y: auto;
-
-  &:before {
-    display: block;
-    margin: -25px auto 10px;
-    content: " ";
-    height: $loading-height;
-    width: $loading-height;
-    border: solid 3px transparent;
-  }
-
-  .timestamp {
-    cursor: pointer;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
 }
 
 .message-detail,

--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -70,11 +70,14 @@
     height: 36px;
     line-height: 36px;
   }
-  @media(min-width:900px) {
+  @media(min-width: $big-avatar-min-width) {
     .avatar {
       width: 70px;
       height: 70px;
       line-height: 70px;
+      margin-bottom: -60px;
+      position: relative;
+      z-index: 10;
     }
   }
 }

--- a/stylesheets/_variables.scss
+++ b/stylesheets/_variables.scss
@@ -32,3 +32,5 @@ $bubble-border-radius: 20px;
 
 $unread-badge-size: 21px;
 $loading-height: 16px;
+
+$big-avatar-min-width: 900px;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -614,10 +614,24 @@ input.search {
         position: absolute;
         top: 0;
         height: 100%;
-        width: 100%; }
+        width: 100%;
+        margin: 0;
+        padding: 2em 8px 0;
+        overflow-y: auto; }
         @media (min-width: 900px) {
           .conversation .panel .discussion-container .message-list {
             padding-left: 70px; } }
+        .conversation .panel .discussion-container .message-list:before {
+          display: block;
+          margin: -25px auto 10px;
+          content: " ";
+          height: 16px;
+          width: 16px;
+          border: solid 3px transparent; }
+        .conversation .panel .discussion-container .message-list .timestamp {
+          cursor: pointer; }
+          .conversation .panel .discussion-container .message-list .timestamp:hover {
+            text-decoration: underline; }
 
 .group-member-list,
 .new-group-update,
@@ -753,23 +767,6 @@ input.search {
   background: none; }
   .outgoing.entry.pending .status:before {
     content: '...'; }
-
-.message-list {
-  position: relative;
-  margin: 0;
-  padding: 2em 0 0;
-  overflow-y: auto; }
-  .message-list:before {
-    display: block;
-    margin: -25px auto 10px;
-    content: " ";
-    height: 16px;
-    width: 16px;
-    border: solid 3px transparent; }
-  .message-list .timestamp {
-    cursor: pointer; }
-    .message-list .timestamp:hover {
-      text-decoration: underline; }
 
 .message-detail,
 .message-list {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -576,16 +576,6 @@ input.search {
     border-color: transparent transparent #2eace0 transparent;
     top: -30px; }
 
-.conversation {
-  background-color: #ffffff;
-  margin: 10px;
-  padding: 20px;
-  border-radius: 10px; }
-  .conversation .panel {
-    height: 100%; }
-  .conversation ::-webkit-scrollbar-thumb {
-    background: rgba(0, 0, 0, 0.15); }
-
 .conversation-title {
   display: block;
   line-height: 36px;
@@ -602,10 +592,18 @@ input.search {
   color: #999; }
 
 .conversation {
+  background-color: #ffffff;
+  margin: 10px;
+  padding: 20px;
+  border-radius: 10px;
   height: calc(100% - 20px);
   border-radius: 10px; }
-  .conversation .discussion-container {
-    height: calc(100% - 2 * 36px - 60px); }
+  .conversation ::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.15); }
+  .conversation .panel {
+    height: 100%; }
+    .conversation .panel .discussion-container {
+      height: calc(100% - 2 * 36px - 60px); }
 
 .group-member-list,
 .new-group-update,

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -434,7 +434,10 @@ img.emoji {
     .conversation-header .avatar {
       width: 70px;
       height: 70px;
-      line-height: 70px; } }
+      line-height: 70px;
+      margin-bottom: -60px;
+      position: relative;
+      z-index: 10; } }
 
 .menu.conversation-menu button.drop-down {
   background: url("/images/arrow_drop_down.png") no-repeat center; }
@@ -601,13 +604,24 @@ input.search {
   .conversation ::-webkit-scrollbar-thumb {
     background: rgba(0, 0, 0, 0.15); }
   .conversation .panel {
-    height: 100%; }
+    height: 100%;
+    display: flex;
+    flex-direction: column; }
     .conversation .panel .discussion-container {
-      height: calc(100% - 2 * 36px - 60px); }
+      flex-grow: 1;
+      position: relative; }
+      .conversation .panel .discussion-container .message-list {
+        position: absolute;
+        top: 0;
+        height: 100%;
+        width: 100%; }
+        @media (min-width: 900px) {
+          .conversation .panel .discussion-container .message-list {
+            padding-left: 70px; } }
 
 .group-member-list,
 .new-group-update,
-.message-list, .message-detail, .key-verification {
+.message-detail, .key-verification {
   height: 100%; }
 
 .key-verification {
@@ -784,7 +798,7 @@ input.search {
     word-wrap: break-word;
     margin-left: 8px;
     max-width: 30em; }
-    @media (max-width: 900px) {
+    @media (max-width: 899px) {
       .message-detail .bubble,
       .message-list .bubble {
         max-width: calc(100% - 45px); } }


### PR DESCRIPTION
This PR comes in 5 (hopefully) easily reviewable chunks. (I can squash together into 1 commit before you take this in if neccesary).

In essence this just improves styling for the conversation view, notably:
* simplified resizing code by switching to using flex layout, and only needing to resize the footer area in conversation.
* tidied up a lot of the styling by consolidating selectors.
* centre bubbles when max size is reached (rather than aligning to left)
* tidy up the padding around the header and footer for conversation.