### PR TITLE
Soften corners of search box + adjust padding.

### DIFF
--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -122,7 +122,8 @@ input.search {
     width: 270px;
     background: rgba(255,255,255,0.2);
     margin: 10px;
-    padding: 5px;
+    padding: 5px 7px;
+    border-radius: 5px;
 
     &::-webkit-input-placeholder {
       color: white;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -469,7 +469,8 @@ input.search {
   width: 270px;
   background: rgba(255, 255, 255, 0.2);
   margin: 10px;
-  padding: 5px; }
+  padding: 5px 7px;
+  border-radius: 5px; }
   .tool-bar input.search::-webkit-input-placeholder {
     color: white; }
   .tool-bar input.search.active, .tool-bar input.search:active, .tool-bar input.search:focus {


### PR DESCRIPTION
Given the rounded corners of all other "root" elements in the main window, the search box felt a bit out of place with the sharp edges. Just added a little border radius and a touch more padding to compensate.

![](https://i.imgur.com/6imMQNV.png)