### PR TITLE
Fix a bug that causes 100% CPU load in timestamp_view.js

### DIFF
--- a/js/views/timestamp_view.js
+++ b/js/views/timestamp_view.js
@@ -34,10 +34,17 @@
             } else { // more than a week ago
                 // Day of week + time
                 delay = 7 * 24 * 60 * 60 * 1000 - millis_since;
+
+                if (delay < -(60 * 1000)) {
+                  // more than one week and one minute ago
+                  // don't do any further updates as the displayed timestamp
+                  // won't change any more
+                  return;
+                }
             }
 
             if (delay) {
-                if (delay < 0) { delay = 0; }
+                if (delay < 0) { delay = 1000; }
                 this.timeout = setTimeout(this.update.bind(this), delay);
             }
         },


### PR DESCRIPTION
When `millis_since` becomes larger than one week, `delay` becomes
negative and is set to Zero. This causes an infinite loop and therefore
100% CPU usage (single thread).

##### Before
![signal-100percent-cpu](https://cloud.githubusercontent.com/assets/7175914/12625845/dfe2e62e-c535-11e5-8e9c-39deba8277f7.png)

##### After
![signal-after-fix](https://cloud.githubusercontent.com/assets/7175914/12625927/42770946-c536-11e5-8a65-833ea150d536.png)
