### PR TITLE
Fix avatar floating over debug log

### DIFF
--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -77,7 +77,6 @@
       line-height: 70px;
       margin-bottom: -60px;
       position: relative;
-      z-index: 10;
     }
   }
 }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -436,8 +436,7 @@ img.emoji {
       height: 70px;
       line-height: 70px;
       margin-bottom: -60px;
-      position: relative;
-      z-index: 10; } }
+      position: relative; } }
 
 .menu.conversation-menu button.drop-down {
   background: url("/images/arrow_drop_down.png") no-repeat center; }


### PR DESCRIPTION
bug introduced in: 0569d4c

This z-index property was previously to ensure the avatar floated above message
bubbles, but the message bubbles always have enough left margin so this
property is not needed.

fixes #650