### PR TITLE
Add templates for issues and pull requests

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,37 @@
+<!--
+Please note that this is an issue tracker
+
+For support go to the Support Center:
+http://support.whispersystems.org/
+or email support@whispersystems.org
+
+For discussion go to the community forum:
+https://whispersystems.discoursehosting.net
+
+Delete any sections that aren't relevant.
+-->
+
+<!-- mark with x between the [ ] -->
+- [ ] I have searched open and closed issues for duplicates
+
+
+### Bug description
+
+
+### Steps to reproduce
+- add your steps here
+- as a list
+- using hyphens
+
+### Screenshots
+<!-- you can drag and drop images here -->
+
+
+### Platform info
+<!-- replace examples with your info -->
+**Operating System**: My Operating System A
+**Browser**: My Browser X.Y.Z
+**Signal version:** Z.Y.Y
+
+### Link to debug log
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- You can remove this section if you have contributed before -->
+### First time contributor checklist
+<!-- mark with x between the brackets -->
+- [ ] I have read the [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
+- [ ] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
+
+### Contributor checklist
+<!-- mark with x between the brackets -->
+- [ ] My changes are rebased on the latest master branch
+- [ ] My contribution is fully baked and is ready to be merged as is
+- [ ] I have run the tests on these platforms:
+ * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
+ * Amiga OS 3.1, Chrom{e,ium} Z.Y
+- [ ] My commits are in nice logical chunks
+- [ ] I followed the [best practices](http://chris.beams.io/posts/git-commit/) when writing my commit messages
+- [ ] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message
+
+----------
+
+### Description


### PR DESCRIPTION
GitHub recently [introduced](https://github.com/blog/2111-issue-and-pull-request-templates) templates for issues and PRs.

The issue template will hopefully guide the submitter to give all the necessary information in the first post. See [an example](https://github.com/WhisperSystems/Signal-Android/issues/5264) at the Android repository.

The PR template will remind the contributor with checklists. I based it on the [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md). See [an example](https://github.com/WhisperSystems/Signal-Android/pull/5260) at the Android repository.

Both templates are in `.github/` directory to avoid cluttering the root directory.