### PR TITLE
Make it possible to copy the debug log gist link - Add the issue submission link

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2,6 +2,18 @@
     "debugLogExplanation": {
       "message": "This log will be posted publicly online for contributors to view. You may examine and edit it before submitting."
     },
+    "reportIssue": {
+      "message": "You can report an issue $tag_start$here$tag_end$.",
+      "description": "Use $tag_start$ and $tag_end$ to wrap the word in this sentence that the user should click on in order to open the issue submission page.",
+      "placeholders": {
+        "tag_start": {
+          "content": "<a class='report-link' href='#'>"
+        },
+        "tag_end": {
+          "content": "</a>"
+        }
+      }
+    },
     "gotIt": {
       "message": "Got it!",
       "description": "Label for a button that dismisses a dialog. The user clicks it to confirm that they understand the message in the dialog."

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -9,6 +9,10 @@
     "submit": {
       "message": "Submit"
     },
+    "open": {
+      "message": "Open",
+      "description": "Label for a button that opens a link in a new tab."
+    },
     "verifyContact": {
       "message": "You may wish to $tag_start$ verify $tag_end$ this contact.",
       "description": "Use $tag_start$ and $tag_end$ to wrap the word or phrase in this sentence that the user should click on in order to navigate to the verification screen. These placeholders will be replaced with appropriate HTML code.",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,7 +3,7 @@
       "message": "This log will be posted publicly online for contributors to view. You may examine and edit it before submitting."
     },
     "reportIssue": {
-      "message": "You can report an issue $tag_start$here$tag_end$.",
+      "message": "You can report an issue $tag_start$ here $tag_end$.",
       "description": "Use $tag_start$ and $tag_end$ to wrap the word in this sentence that the user should click on in order to open the issue submission page.",
       "placeholders": {
         "tag_start": {

--- a/background.html
+++ b/background.html
@@ -321,7 +321,8 @@
         <button class='close'>{{ cancel }}</button>
       </div>
       <div class='result'>
-        <a class='hide' target='_blank'></a>
+        <input type='text' class='hide link' readonly/>
+        <button class='hide open'>{{ open }}</button>
         <div class='hide'><button class='close'>{{ close }}</button></div>
       </div>
     </div>

--- a/background.html
+++ b/background.html
@@ -323,6 +323,7 @@
       <div class='result'>
         <input type='text' class='hide link' readonly/>
         <button class='hide open'>{{ open }}</button>
+        <div class='hide report'>{{{ reportIssue }}}</div>
         <div class='hide'><button class='close'>{{ close }}</button></div>
       </div>
     </div>

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -15,7 +15,7 @@
                 e.preventDefault();
                 $(this).select();
             });
-            this.$('.report-link').text(this.$('.report-link').text().trim())
+            this.$('.report-link').text(this.$('.report-link').text().trim());
         },
         events: {
             'click .submit': 'submit',

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -15,6 +15,7 @@
                 e.preventDefault();
                 $(this).select();
             });
+            this.$('.report-link').text(this.$('.report-link').text().trim())
         },
         events: {
             'click .submit': 'submit',

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -11,6 +11,10 @@
         initialize: function() {
             this.render();
             this.$('textarea').val(console.get());
+            this.$('.link').on('mouseup', function (e) {
+                e.preventDefault();
+                $(this).select();
+            });
         },
         events: {
             'click .submit': 'submit',
@@ -21,6 +25,7 @@
             cancel: i18n('cancel'),
             submit: i18n('submit'),
             close: i18n('gotIt'),
+            open: i18n('open'),
             debugLogExplanation: i18n('debugLogExplanation')
         },
         close: function(e) {
@@ -35,9 +40,12 @@
             }
             console.post(log).then(function(url) {
                 this.$('.loading').removeClass('loading');
-                var link = this.$('.result').find('a');
-                link.attr('href', url).text(url);
+                this.$('.link').val(url);
+                this.$('.open').click(function() {
+                    window.open(url);
+                });
                 this.$('.result .hide').removeClass('hide');
+                this.$('.link').select().focus();
             }.bind(this));
             this.$('.buttons, textarea').remove();
             this.$('.result').addClass('loading');

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -18,7 +18,8 @@
         },
         events: {
             'click .submit': 'submit',
-            'click .close': 'close'
+            'click .close': 'close',
+            'click .report-link': 'report'
         },
         render_attributes: {
             title: i18n('submitDebugLog'),
@@ -26,7 +27,8 @@
             submit: i18n('submit'),
             close: i18n('gotIt'),
             open: i18n('open'),
-            debugLogExplanation: i18n('debugLogExplanation')
+            debugLogExplanation: i18n('debugLogExplanation'),
+            reportIssue: i18n('reportIssue')
         },
         close: function(e) {
             e.preventDefault();
@@ -49,6 +51,9 @@
             }.bind(this));
             this.$('.buttons, textarea').remove();
             this.$('.result').addClass('loading');
+        },
+        report: function(e) {
+            window.open("https://github.com/WhisperSystems/Signal-Desktop/issues/new");
         }
     });
 

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -351,6 +351,12 @@ img.emoji {
   .debug-log button:hover, .debug-log input[type=submit]:hover {
     color: black;
     box-shadow: 0 0 10px -3px rgba(97, 97, 97, 0.7); }
+.debug-log .link {
+  width: 22em;
+  text-align: center; }
+.debug-log .open {
+  padding: 0.2em 0.4em;
+  margin: 0 0 0 0.5em; }
 .debug-log .result {
   text-align: center; }
   .debug-log .result a {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -357,6 +357,8 @@ img.emoji {
 .debug-log .open {
   padding: 0.2em 0.4em;
   margin: 0 0 0 0.5em; }
+.debug-log .report {
+  margin-top: 0.5em; }
 .debug-log .result {
   text-align: center; }
   .debug-log .result a {


### PR DESCRIPTION
<!-- You can remove this section if you have contributed before -->
### First time contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] My changes are rebased on the latest master branch
- [x] My contribution is fully baked and is ready to be merged as is
- [x] I have run the tests on these platforms:
 * Win 8.1, Chrome 50.0.2661.18
- [x] My commits are in nice logical chunks
- [x] I followed the [best practices](http://chris.beams.io/posts/git-commit/) when writing my commit messages
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
Fixes #405 
* Make the gist link selectable by displaying it inside a read-only text box.
* Add a button to open the gist link in a new tab.
* Add Signal-Desktop's issue submission link to the debug log dialog.