### PR TITLE
Fix spelling mistakes

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -127,8 +127,8 @@ module.exports = function(grunt) {
                 'whispersystems-textsecure-attachments.s3.amazonaws.com');
             } else if (srcpath.match('expire.js')) {
               var gitinfo = grunt.config.get('gitinfo');
-              var commited = gitinfo.local.branch.current.lastCommitTime;
-              var time = Date.parse(commited) + 1000 * 60 * 60 * 24 * 90;
+              var committed = gitinfo.local.branch.current.lastCommitTime;
+              var time = Date.parse(committed) + 1000 * 60 * 60 * 24 * 90;
               return content.replace(
                 /var BUILD_EXPIRATION = 0/,
                 "var BUILD_EXPIRATION = " + time

--- a/components/backbone/backbone.js
+++ b/components/backbone/backbone.js
@@ -589,7 +589,7 @@
   // -------------------
 
   // If models tend to represent a single row of data, a Backbone Collection is
-  // more analagous to a table full of data ... or a small slice or page of that
+  // more analogous to a table full of data ... or a small slice or page of that
   // table, or a collection of rows that belong together for a particular reason
   // -- all of the messages in this particular folder, all of the documents
   // belonging to this particular author, and so on. Collections maintain

--- a/components/bytebuffer/dist/ByteBufferAB.js
+++ b/components/bytebuffer/dist/ByteBufferAB.js
@@ -142,7 +142,7 @@
         ByteBuffer.DEFAULT_CAPACITY = 16;
 
         /**
-         * Default endianess of `false` for big endian.
+         * Default endianness of `false` for big endian.
          * @type {boolean}
          * @expose
          */

--- a/components/chai/chai.js
+++ b/components/chai/chai.js
@@ -4381,7 +4381,7 @@ module.exports = function getEnumerableProperties(object) {
  */
 
 /*!
- * Module dependancies
+ * Module dependencies
  */
 
 var flag = require('./flag')
@@ -5189,7 +5189,7 @@ function objectToString(o) {
  */
 
 /*!
- * Module dependancies
+ * Module dependencies
  */
 
 var inspect = require('./inspect');
@@ -5408,7 +5408,7 @@ module.exports = function (ctx, name, getter) {
  */
 
 /*!
- * Module dependancies
+ * Module dependencies
  */
 
 var flag = require('./flag');

--- a/components/indexeddb-backbonejs-adapter/backbone-indexeddb.js
+++ b/components/indexeddb-backbonejs-adapter/backbone-indexeddb.js
@@ -57,7 +57,7 @@
 
         this.dbRequest.onsuccess = function (e) {
             this.db = e.target.result; // Attach the connection ot the queue.
-            var currentIntDBVersion = (parseInt(this.db.version) ||  0); // we need convert beacuse chrome store in integer and ie10 DP4+ in int;
+            var currentIntDBVersion = (parseInt(this.db.version) ||  0); // we need convert because chrome store in integer and ie10 DP4+ in int;
             var lastMigrationInt = (parseInt(lastMigrationPathVersion) || 0);  // And make sure we compare numbers with numbers.
 
             if (currentIntDBVersion === lastMigrationInt) { //if support new event onupgradeneeded will trigger the ready function
@@ -577,7 +577,7 @@
 
     // Method used by Backbone for sync of data with data store. It was initially designed to work with "server side" APIs, This wrapper makes
     // it work with the local indexedDB stuff. It uses the schema attribute provided by the object.
-    // The wrapper keeps an active Executuon Queue for each "schema", and executes querues agains it, based on the object type (collection or
+    // The wrapper keeps an active Execution Queue for each "schema", and executes queries against it, based on the object type (collection or
     // single model), but also the method... etc.
     // Keeps track of the connections
     var Databases = {};

--- a/components/intl-tel-input/build/js/intlTelInput.js
+++ b/components/intl-tel-input/build/js/intlTelInput.js
@@ -253,7 +253,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             }
             // format
             if (val) {
-                // this wont be run after _updateDialCode as that's only called if no val
+                // this won't be run after _updateDialCode as that's only called if no val
                 this._updateVal(val, false);
             }
         },
@@ -305,7 +305,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             if (this.options.autoFormat) {
                 // format number and update flag on keypress
                 // use keypress event as we want to ignore all input except for a select few keys,
-                // but we dont want to ignore the navigation keys like the arrows etc.
+                // but we don't want to ignore the navigation keys like the arrows etc.
                 // NOTE: no point in refactoring this to only bind these listeners on focus/blur because then you would need to have those 2 listeners running the whole time anyway...
                 this.telInput.on("keypress" + this.ns, function(e) {
                     // 32 is space, and after that it's all chars (not meta/nav keys)
@@ -315,10 +315,10 @@ https://github.com/Bluefieldscom/intl-tel-input.git
                     if (e.which >= keys.SPACE && !e.metaKey && window.intlTelInputUtils && !that.telInput.prop("readonly")) {
                         e.preventDefault();
                         // allowed keys are just numeric keys and plus
-                        // we must allow plus for the case where the user does select-all and then hits plus to start typing a new number. we could refine this logic to first check that the selection contains a plus, but that wont work in old browsers, and I think it's overkill anyway
+                        // we must allow plus for the case where the user does select-all and then hits plus to start typing a new number. we could refine this logic to first check that the selection contains a plus, but that won't work in old browsers, and I think it's overkill anyway
                         var isAllowedKey = e.which >= keys.ZERO && e.which <= keys.NINE || e.which == keys.PLUS, input = that.telInput[0], noSelection = that.isGoodBrowser && input.selectionStart == input.selectionEnd, max = that.telInput.attr("maxlength"), val = that.telInput.val(), // assumes that if max exists, it is >0
                         isBelowMax = max ? val.length < max : true;
-                        // first: ensure we dont go over maxlength. we must do this here to prevent adding digits in the middle of the number
+                        // first: ensure we don't go over maxlength. we must do this here to prevent adding digits in the middle of the number
                         // still reformat even if not an allowed key as they could by typing a formatting char, but ignore if there's a selection as doesn't make sense to replace selection with illegal char and then immediately remove it
                         if (isBelowMax && (isAllowedKey || noSelection)) {
                             var newChar = isAllowedKey ? String.fromCharCode(e.which) : null;
@@ -337,7 +337,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             // handle keyup event
             // for autoFormat: we use keyup to catch cut/paste events and also delete events (after the fact)
             this.telInput.on("keyup" + this.ns, function(e) {
-                // the "enter" key event from selecting a dropdown item is triggered here on the input, because the document.keydown handler that initially handles that event triggers a focus on the input, and so the keyup for that same key event gets triggered here. weird, but just make sure we dont bother doing any re-formatting in this case (we've already done preventDefault in the keydown handler, so it wont actually submit the form or anything).
+                // the "enter" key event from selecting a dropdown item is triggered here on the input, because the document.keydown handler that initially handles that event triggers a focus on the input, and so the keyup for that same key event gets triggered here. weird, but just make sure we don't bother doing any re-formatting in this case (we've already done preventDefault in the keydown handler, so it won't actually submit the form or anything).
                 // ALSO: ignore keyup if readonly
                 if (e.which == keys.ENTER || that.telInput.prop("readonly")) {} else if (that.options.autoFormat && window.intlTelInputUtils) {
                     var isCtrl = e.which == keys.CTRL || e.which == keys.CMD1 || e.which == keys.CMD2, input = that.telInput[0], // noSelection defaults to false for bad browsers, else would be reformatting on all ctrl keys e.g. select-all/copy
@@ -373,7 +373,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             var val = this.telInput.val(), numericBefore = this._getNumeric(val), originalLeftChar, // raw DOM element
             input = this.telInput[0], digitsOnRight = 0;
             if (this.isGoodBrowser) {
-                // cursor strategy: maintain the number of digits on the right. we use the right instead of the left so that A) we dont have to account for the new digit (or digits if paste event), and B) we're always on the right side of formatting suffixes
+                // cursor strategy: maintain the number of digits on the right. we use the right instead of the left so that A) we don't have to account for the new digit (or digits if paste event), and B) we're always on the right side of formatting suffixes
                 digitsOnRight = this._getDigitsOnRight(val, input.selectionEnd);
                 // if handling a new number character: insert it in the right place
                 if (newNumericChar) {
@@ -629,7 +629,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             var formatted;
             if (this.options.autoFormat && window.intlTelInputUtils) {
                 formatted = intlTelInputUtils.formatNumber(val, this.selectedCountryData.iso2, addSuffix, this.options.preventInvalidNumbers);
-                // ensure we dont go over maxlength. we must do this here to truncate any formatting suffix, and also handle paste events
+                // ensure we don't go over maxlength. we must do this here to truncate any formatting suffix, and also handle paste events
                 var max = this.telInput.attr("maxlength");
                 if (max && formatted.length > max) {
                     formatted = formatted.substr(0, max);
@@ -643,7 +643,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
         // check if need to select a new flag based on the given number
         _updateFlagFromNumber: function(number) {
             // if we're in nationalMode and we're on US/Canada, make sure the number starts with a +1 so _getDialCode will be able to extract the area code
-            // update: if we dont yet have selectedCountryData, but we're here (trying to update the flag from the number), that means we're initialising the plugin with a number that already has a dial code, so fine to ignore this bit
+            // update: if we don't yet have selectedCountryData, but we're here (trying to update the flag from the number), that means we're initialising the plugin with a number that already has a dial code, so fine to ignore this bit
             if (this.options.nationalMode && this.selectedCountryData && this.selectedCountryData.dialCode == "1" && number.substr(0, 1) != "+") {
                 number = "+1" + number;
             }
@@ -867,9 +867,9 @@ https://github.com/Bluefieldscom/intl-tel-input.git
         loadUtils: function(path) {
             var utilsScript = path || this.options.utilsScript;
             if (!$.fn[pluginName].loadedUtilsScript && utilsScript) {
-                // don't do this twice! (dont just check if the global intlTelInputUtils exists as if init plugin multiple times in quick succession, it may not have finished loading yet)
+                // don't do this twice! (don't just check if the global intlTelInputUtils exists as if init plugin multiple times in quick succession, it may not have finished loading yet)
                 $.fn[pluginName].loadedUtilsScript = true;
-                // dont use $.getScript as it prevents caching
+                // don't use $.getScript as it prevents caching
                 $.ajax({
                     url: utilsScript,
                     success: function() {

--- a/components/mock-socket/dist/mock-socket.js
+++ b/components/mock-socket/dist/mock-socket.js
@@ -580,7 +580,7 @@ SocketService.prototype = {
   */
   notify: function(namespace) {
 
-    // This strips the namespace from the list of args as we dont want to pass that into the callback.
+    // This strips the namespace from the list of args as we don't want to pass that into the callback.
     var argumentsForCallback = Array.prototype.slice.call(arguments, 1);
 
     if(!this.verifyNamespaceArg(namespace)) {
@@ -601,7 +601,7 @@ SocketService.prototype = {
   */
   notifyOnlyFor: function(context, namespace) {
 
-    // This strips the namespace from the list of args as we dont want to pass that into the callback.
+    // This strips the namespace from the list of args as we don't want to pass that into the callback.
     var argumentsForCallback = Array.prototype.slice.call(arguments, 2);
 
     if(!this.verifyNamespaceArg(namespace)) {

--- a/components/momentjs/moment.js
+++ b/components/momentjs/moment.js
@@ -1342,10 +1342,10 @@
                     ++week;
                 }
             } else if (w.e != null) {
-                // local weekday -- counting starts from begining of week
+                // local weekday -- counting starts from beginning of week
                 weekday = w.e + dow;
             } else {
-                // default to begining of week
+                // default to beginning of week
                 weekday = dow;
             }
         }

--- a/components/protobuf/dist/ProtoBuf.js
+++ b/components/protobuf/dist/ProtoBuf.js
@@ -3786,7 +3786,7 @@
             };
 
             /**
-             * Creates ths specified protocol types at the current pointer position.
+             * Creates the specified protocol types at the current pointer position.
              * @param {Array.<Object.<string,*>>} defs Messages, enums or services to create
              * @return {ProtoBuf.Builder} this
              * @throws {Error} If a message definition is invalid

--- a/js/components.js
+++ b/js/components.js
@@ -6489,7 +6489,7 @@ function propFilter( props, specialEasing ) {
 			value = hooks.expand( value );
 			delete props[ name ];
 
-			// not quite $.extend, this wont overwrite keys already present.
+			// not quite $.extend, this won't overwrite keys already present.
 			// also - reusing 'index' from above because we have the correct "name"
 			for ( index in value ) {
 				if ( !( index in props ) ) {
@@ -10291,7 +10291,7 @@ return jQuery;
         ByteBuffer.DEFAULT_CAPACITY = 16;
 
         /**
-         * Default endianess of `false` for big endian.
+         * Default endianness of `false` for big endian.
          * @type {boolean}
          * @expose
          */
@@ -17211,7 +17211,7 @@ return jQuery;
             };
 
             /**
-             * Creates ths specified protocol types at the current pointer position.
+             * Creates the specified protocol types at the current pointer position.
              * @param {Array.<Object.<string,*>>} defs Messages, enums or services to create
              * @return {ProtoBuf.Builder} this
              * @throws {Error} If a message definition is invalid
@@ -20338,7 +20338,7 @@ return jQuery;
   // -------------------
 
   // If models tend to represent a single row of data, a Backbone Collection is
-  // more analagous to a table full of data ... or a small slice or page of that
+  // more analogous to a table full of data ... or a small slice or page of that
   // table, or a collection of rows that belong together for a particular reason
   // -- all of the messages in this particular folder, all of the documents
   // belonging to this particular author, and so on. Collections maintain
@@ -21415,7 +21415,7 @@ return jQuery;
 
         this.dbRequest.onsuccess = function (e) {
             this.db = e.target.result; // Attach the connection ot the queue.
-            var currentIntDBVersion = (parseInt(this.db.version) ||  0); // we need convert beacuse chrome store in integer and ie10 DP4+ in int;
+            var currentIntDBVersion = (parseInt(this.db.version) ||  0); // we need convert because chrome store in integer and ie10 DP4+ in int;
             var lastMigrationInt = (parseInt(lastMigrationPathVersion) || 0);  // And make sure we compare numbers with numbers.
 
             if (currentIntDBVersion === lastMigrationInt) { //if support new event onupgradeneeded will trigger the ready function
@@ -21935,7 +21935,7 @@ return jQuery;
 
     // Method used by Backbone for sync of data with data store. It was initially designed to work with "server side" APIs, This wrapper makes
     // it work with the local indexedDB stuff. It uses the schema attribute provided by the object.
-    // The wrapper keeps an active Executuon Queue for each "schema", and executes querues agains it, based on the object type (collection or
+    // The wrapper keeps an active Execution Queue for each "schema", and executes queries against it, based on the object type (collection or
     // single model), but also the method... etc.
     // Keeps track of the connections
     var Databases = {};
@@ -24694,10 +24694,10 @@ goog.exportSymbol("libphonenumber.PhoneNumberFormat.NATIONAL",libphonenumber.Pho
                     ++week;
                 }
             } else if (w.e != null) {
-                // local weekday -- counting starts from begining of week
+                // local weekday -- counting starts from beginning of week
                 weekday = w.e + dow;
             } else {
-                // default to begining of week
+                // default to beginning of week
                 weekday = dow;
             }
         }
@@ -26542,7 +26542,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             }
             // format
             if (val) {
-                // this wont be run after _updateDialCode as that's only called if no val
+                // this won't be run after _updateDialCode as that's only called if no val
                 this._updateVal(val, false);
             }
         },
@@ -26594,7 +26594,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             if (this.options.autoFormat) {
                 // format number and update flag on keypress
                 // use keypress event as we want to ignore all input except for a select few keys,
-                // but we dont want to ignore the navigation keys like the arrows etc.
+                // but we don't want to ignore the navigation keys like the arrows etc.
                 // NOTE: no point in refactoring this to only bind these listeners on focus/blur because then you would need to have those 2 listeners running the whole time anyway...
                 this.telInput.on("keypress" + this.ns, function(e) {
                     // 32 is space, and after that it's all chars (not meta/nav keys)
@@ -26604,10 +26604,10 @@ https://github.com/Bluefieldscom/intl-tel-input.git
                     if (e.which >= keys.SPACE && !e.metaKey && window.intlTelInputUtils && !that.telInput.prop("readonly")) {
                         e.preventDefault();
                         // allowed keys are just numeric keys and plus
-                        // we must allow plus for the case where the user does select-all and then hits plus to start typing a new number. we could refine this logic to first check that the selection contains a plus, but that wont work in old browsers, and I think it's overkill anyway
+                        // we must allow plus for the case where the user does select-all and then hits plus to start typing a new number. we could refine this logic to first check that the selection contains a plus, but that won't work in old browsers, and I think it's overkill anyway
                         var isAllowedKey = e.which >= keys.ZERO && e.which <= keys.NINE || e.which == keys.PLUS, input = that.telInput[0], noSelection = that.isGoodBrowser && input.selectionStart == input.selectionEnd, max = that.telInput.attr("maxlength"), val = that.telInput.val(), // assumes that if max exists, it is >0
                         isBelowMax = max ? val.length < max : true;
-                        // first: ensure we dont go over maxlength. we must do this here to prevent adding digits in the middle of the number
+                        // first: ensure we don't go over maxlength. we must do this here to prevent adding digits in the middle of the number
                         // still reformat even if not an allowed key as they could by typing a formatting char, but ignore if there's a selection as doesn't make sense to replace selection with illegal char and then immediately remove it
                         if (isBelowMax && (isAllowedKey || noSelection)) {
                             var newChar = isAllowedKey ? String.fromCharCode(e.which) : null;
@@ -26626,7 +26626,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             // handle keyup event
             // for autoFormat: we use keyup to catch cut/paste events and also delete events (after the fact)
             this.telInput.on("keyup" + this.ns, function(e) {
-                // the "enter" key event from selecting a dropdown item is triggered here on the input, because the document.keydown handler that initially handles that event triggers a focus on the input, and so the keyup for that same key event gets triggered here. weird, but just make sure we dont bother doing any re-formatting in this case (we've already done preventDefault in the keydown handler, so it wont actually submit the form or anything).
+                // the "enter" key event from selecting a dropdown item is triggered here on the input, because the document.keydown handler that initially handles that event triggers a focus on the input, and so the keyup for that same key event gets triggered here. weird, but just make sure we don't bother doing any re-formatting in this case (we've already done preventDefault in the keydown handler, so it won't actually submit the form or anything).
                 // ALSO: ignore keyup if readonly
                 if (e.which == keys.ENTER || that.telInput.prop("readonly")) {} else if (that.options.autoFormat && window.intlTelInputUtils) {
                     var isCtrl = e.which == keys.CTRL || e.which == keys.CMD1 || e.which == keys.CMD2, input = that.telInput[0], // noSelection defaults to false for bad browsers, else would be reformatting on all ctrl keys e.g. select-all/copy
@@ -26662,7 +26662,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             var val = this.telInput.val(), numericBefore = this._getNumeric(val), originalLeftChar, // raw DOM element
             input = this.telInput[0], digitsOnRight = 0;
             if (this.isGoodBrowser) {
-                // cursor strategy: maintain the number of digits on the right. we use the right instead of the left so that A) we dont have to account for the new digit (or digits if paste event), and B) we're always on the right side of formatting suffixes
+                // cursor strategy: maintain the number of digits on the right. we use the right instead of the left so that A) we don't have to account for the new digit (or digits if paste event), and B) we're always on the right side of formatting suffixes
                 digitsOnRight = this._getDigitsOnRight(val, input.selectionEnd);
                 // if handling a new number character: insert it in the right place
                 if (newNumericChar) {
@@ -26918,7 +26918,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
             var formatted;
             if (this.options.autoFormat && window.intlTelInputUtils) {
                 formatted = intlTelInputUtils.formatNumber(val, this.selectedCountryData.iso2, addSuffix, this.options.preventInvalidNumbers);
-                // ensure we dont go over maxlength. we must do this here to truncate any formatting suffix, and also handle paste events
+                // ensure we don't go over maxlength. we must do this here to truncate any formatting suffix, and also handle paste events
                 var max = this.telInput.attr("maxlength");
                 if (max && formatted.length > max) {
                     formatted = formatted.substr(0, max);
@@ -26932,7 +26932,7 @@ https://github.com/Bluefieldscom/intl-tel-input.git
         // check if need to select a new flag based on the given number
         _updateFlagFromNumber: function(number) {
             // if we're in nationalMode and we're on US/Canada, make sure the number starts with a +1 so _getDialCode will be able to extract the area code
-            // update: if we dont yet have selectedCountryData, but we're here (trying to update the flag from the number), that means we're initialising the plugin with a number that already has a dial code, so fine to ignore this bit
+            // update: if we don't yet have selectedCountryData, but we're here (trying to update the flag from the number), that means we're initialising the plugin with a number that already has a dial code, so fine to ignore this bit
             if (this.options.nationalMode && this.selectedCountryData && this.selectedCountryData.dialCode == "1" && number.substr(0, 1) != "+") {
                 number = "+1" + number;
             }
@@ -27156,9 +27156,9 @@ https://github.com/Bluefieldscom/intl-tel-input.git
         loadUtils: function(path) {
             var utilsScript = path || this.options.utilsScript;
             if (!$.fn[pluginName].loadedUtilsScript && utilsScript) {
-                // don't do this twice! (dont just check if the global intlTelInputUtils exists as if init plugin multiple times in quick succession, it may not have finished loading yet)
+                // don't do this twice! (don't just check if the global intlTelInputUtils exists as if init plugin multiple times in quick succession, it may not have finished loading yet)
                 $.fn[pluginName].loadedUtilsScript = true;
-                // dont use $.getScript as it prevents caching
+                // don't use $.getScript as it prevents caching
                 $.ajax({
                     url: utilsScript,
                     success: function() {

--- a/js/libaxolotl-worker.js
+++ b/js/libaxolotl-worker.js
@@ -150,7 +150,7 @@ else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   }
 }
 else {
-  // Unreachable because SHELL is dependant on the others
+  // Unreachable because SHELL is dependent on the others
   throw 'Unknown runtime environment. Where are we?';
 }
 

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -264,7 +264,7 @@ else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   }
 }
 else {
-  // Unreachable because SHELL is dependant on the others
+  // Unreachable because SHELL is dependent on the others
   throw 'Unknown runtime environment. Where are we?';
 }
 
@@ -26534,7 +26534,7 @@ Curve25519Worker.prototype = {
         ByteBuffer.DEFAULT_CAPACITY = 16;
 
         /**
-         * Default endianess of `false` for big endian.
+         * Default endianness of `false` for big endian.
          * @type {boolean}
          * @expose
          */
@@ -33454,7 +33454,7 @@ Curve25519Worker.prototype = {
             };
 
             /**
-             * Creates ths specified protocol types at the current pointer position.
+             * Creates the specified protocol types at the current pointer position.
              * @param {Array.<Object.<string,*>>} defs Messages, enums or services to create
              * @return {ProtoBuf.Builder} this
              * @throws {Error} If a message definition is invalid
@@ -34058,7 +34058,7 @@ axolotlInternal.crypto = function() {
 
         HKDF: function(input, salt, info) {
             // Specific implementation of RFC 5869 that only returns the first 3 32-byte chunks
-            // TODO: We dont always need the third chunk, we might skip it
+            // TODO: We don't always need the third chunk, we might skip it
             return axolotlInternal.crypto.sign(salt, input).then(function(PRK) {
                 var infoBuffer = new ArrayBuffer(info.byteLength + 1 + 32);
                 var infoArray = new Uint8Array(infoBuffer);
@@ -34641,7 +34641,7 @@ window.axolotl.protocol = function(storage_interface) {
             return;
 
         // After this has run, we can still receive messages on ratchet chains which
-        // were already open (unless we know we dont need them),
+        // were already open (unless we know we don't need them),
         // but we cannot send messages or step the ratchet
 
         // Delete current sending ratchet
@@ -34878,7 +34878,7 @@ window.axolotl.protocol = function(storage_interface) {
     *** Public crypto API ***
     *************************/
     //TODO: SHARP EDGE HERE
-    //XXX: Also, you MUST call the session close function before processing another message....except its a promise...so you literally cant!
+    //XXX: Also, you MUST call the session close function before processing another message....except its a promise...so you literally can't!
     // returns decrypted plaintext and a function that must be called if the message indicates session close
     self.decryptWhisperMessage = function(encodedNumber, messageBytes) {
         return doDecryptWhisperMessage(encodedNumber, toArrayBuffer(messageBytes));
@@ -37510,7 +37510,7 @@ OutgoingMessage.prototype = {
             return this.getKeysForNumber(number, updateDevices)
                 .then(this.reloadDevicesAndSend(number, true))
                 .catch(function(error) {
-                    this.registerError(number, "Failed to retreive new device keys for number " + number, error);
+                    this.registerError(number, "Failed to retrieve new device keys for number " + number, error);
                 }.bind(this));
         }.bind(this));
     }

--- a/libtextsecure/components.js
+++ b/libtextsecure/components.js
@@ -1085,7 +1085,7 @@
         ByteBuffer.DEFAULT_CAPACITY = 16;
 
         /**
-         * Default endianess of `false` for big endian.
+         * Default endianness of `false` for big endian.
          * @type {boolean}
          * @expose
          */
@@ -8005,7 +8005,7 @@
             };
 
             /**
-             * Creates ths specified protocol types at the current pointer position.
+             * Creates the specified protocol types at the current pointer position.
              * @param {Array.<Object.<string,*>>} defs Messages, enums or services to create
              * @return {ProtoBuf.Builder} this
              * @throws {Error} If a message definition is invalid

--- a/libtextsecure/libaxolotl.js
+++ b/libtextsecure/libaxolotl.js
@@ -150,7 +150,7 @@ else if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   }
 }
 else {
-  // Unreachable because SHELL is dependant on the others
+  // Unreachable because SHELL is dependent on the others
   throw 'Unknown runtime environment. Where are we?';
 }
 
@@ -26420,7 +26420,7 @@ Curve25519Worker.prototype = {
         ByteBuffer.DEFAULT_CAPACITY = 16;
 
         /**
-         * Default endianess of `false` for big endian.
+         * Default endianness of `false` for big endian.
          * @type {boolean}
          * @expose
          */
@@ -33340,7 +33340,7 @@ Curve25519Worker.prototype = {
             };
 
             /**
-             * Creates ths specified protocol types at the current pointer position.
+             * Creates the specified protocol types at the current pointer position.
              * @param {Array.<Object.<string,*>>} defs Messages, enums or services to create
              * @return {ProtoBuf.Builder} this
              * @throws {Error} If a message definition is invalid
@@ -33944,7 +33944,7 @@ axolotlInternal.crypto = function() {
 
         HKDF: function(input, salt, info) {
             // Specific implementation of RFC 5869 that only returns the first 3 32-byte chunks
-            // TODO: We dont always need the third chunk, we might skip it
+            // TODO: We don't always need the third chunk, we might skip it
             return axolotlInternal.crypto.sign(salt, input).then(function(PRK) {
                 var infoBuffer = new ArrayBuffer(info.byteLength + 1 + 32);
                 var infoArray = new Uint8Array(infoBuffer);
@@ -34527,7 +34527,7 @@ window.axolotl.protocol = function(storage_interface) {
             return;
 
         // After this has run, we can still receive messages on ratchet chains which
-        // were already open (unless we know we dont need them),
+        // were already open (unless we know we don't need them),
         // but we cannot send messages or step the ratchet
 
         // Delete current sending ratchet
@@ -34764,7 +34764,7 @@ window.axolotl.protocol = function(storage_interface) {
     *** Public crypto API ***
     *************************/
     //TODO: SHARP EDGE HERE
-    //XXX: Also, you MUST call the session close function before processing another message....except its a promise...so you literally cant!
+    //XXX: Also, you MUST call the session close function before processing another message....except its a promise...so you literally can't!
     // returns decrypted plaintext and a function that must be called if the message indicates session close
     self.decryptWhisperMessage = function(encodedNumber, messageBytes) {
         return doDecryptWhisperMessage(encodedNumber, toArrayBuffer(messageBytes));

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -169,7 +169,7 @@ OutgoingMessage.prototype = {
             return this.getKeysForNumber(number, updateDevices)
                 .then(this.reloadDevicesAndSend(number, true))
                 .catch(function(error) {
-                    this.registerError(number, "Failed to retreive new device keys for number " + number, error);
+                    this.registerError(number, "Failed to retrieve new device keys for number " + number, error);
                 }.bind(this));
         }.bind(this));
     }

--- a/libtextsecure/test/blanket_mocha.js
+++ b/libtextsecure/test/blanket_mocha.js
@@ -309,7 +309,7 @@ parseStatement: true, parseSourceElement: true */
         }
 
         // 'const' is specialized as Keyword in V8.
-        // 'yield' and 'let' are for compatiblity with SpiderMonkey and ES.next.
+        // 'yield' and 'let' are for compatibility with SpiderMonkey and ES.next.
         // Some others are from future reserved words.
 
         switch (id.length) {
@@ -5100,7 +5100,7 @@ _blanket.extend({
                     inputFileName: url
                 },function(instrumented){
                     try{
-                        if (_blanket.options("debug")) {console.log("BLANKET-instrument of:"+url+" was successfull.");}
+                        if (_blanket.options("debug")) {console.log("BLANKET-instrument of:"+url+" was successful.");}
                         _blanket.utils.blanketEval(instrumented);
                         cb();
                         _blanket.requiringFile(url,true);

--- a/libtextsecure/test/test.js
+++ b/libtextsecure/test/test.js
@@ -6489,7 +6489,7 @@ function propFilter( props, specialEasing ) {
 			value = hooks.expand( value );
 			delete props[ name ];
 
-			// not quite $.extend, this wont overwrite keys already present.
+			// not quite $.extend, this won't overwrite keys already present.
 			// also - reusing 'index' from above because we have the correct "name"
 			for ( index in value ) {
 				if ( !( index in props ) ) {
@@ -9786,7 +9786,7 @@ SocketService.prototype = {
   */
   notify: function(namespace) {
 
-    // This strips the namespace from the list of args as we dont want to pass that into the callback.
+    // This strips the namespace from the list of args as we don't want to pass that into the callback.
     var argumentsForCallback = Array.prototype.slice.call(arguments, 1);
 
     if(!this.verifyNamespaceArg(namespace)) {
@@ -9807,7 +9807,7 @@ SocketService.prototype = {
   */
   notifyOnlyFor: function(context, namespace) {
 
-    // This strips the namespace from the list of args as we dont want to pass that into the callback.
+    // This strips the namespace from the list of args as we don't want to pass that into the callback.
     var argumentsForCallback = Array.prototype.slice.call(arguments, 2);
 
     if(!this.verifyNamespaceArg(namespace)) {
@@ -20293,7 +20293,7 @@ module.exports = function getEnumerableProperties(object) {
  */
 
 /*!
- * Module dependancies
+ * Module dependencies
  */
 
 var flag = require('./flag')
@@ -21101,7 +21101,7 @@ function objectToString(o) {
  */
 
 /*!
- * Module dependancies
+ * Module dependencies
  */
 
 var inspect = require('./inspect');
@@ -21320,7 +21320,7 @@ module.exports = function (ctx, name, getter) {
  */
 
 /*!
- * Module dependancies
+ * Module dependencies
  */
 
 var flag = require('./flag');

--- a/native/ed25519/sha512/sph_sha2.h
+++ b/native/ed25519/sha512/sph_sha2.h
@@ -104,7 +104,7 @@ void sph_sha224(void *cc, const void *data, size_t len);
 /**
  * Terminate the current SHA-224 computation and output the result into the
  * provided buffer. The destination buffer must be wide enough to
- * accomodate the result (28 bytes). The context is automatically
+ * accommodate the result (28 bytes). The context is automatically
  * reinitialized.
  *
  * @param cc    the SHA-224 context
@@ -115,7 +115,7 @@ void sph_sha224_close(void *cc, void *dst);
 /**
  * Add a few additional bits (0 to 7) to the current computation, then
  * terminate it and output the result in the provided buffer, which must
- * be wide enough to accomodate the result (28 bytes). If bit number i
+ * be wide enough to accommodate the result (28 bytes). If bit number i
  * in <code>ub</code> has value 2^i, then the extra bits are those
  * numbered 7 downto 8-n (this is the big-endian convention at the byte
  * level). The context is automatically reinitialized.
@@ -167,7 +167,7 @@ void sph_sha256(void *cc, const void *data, size_t len);
 /**
  * Terminate the current SHA-256 computation and output the result into the
  * provided buffer. The destination buffer must be wide enough to
- * accomodate the result (32 bytes). The context is automatically
+ * accommodate the result (32 bytes). The context is automatically
  * reinitialized.
  *
  * @param cc    the SHA-256 context
@@ -178,7 +178,7 @@ void sph_sha256_close(void *cc, void *dst);
 /**
  * Add a few additional bits (0 to 7) to the current computation, then
  * terminate it and output the result in the provided buffer, which must
- * be wide enough to accomodate the result (32 bytes). If bit number i
+ * be wide enough to accommodate the result (32 bytes). If bit number i
  * in <code>ub</code> has value 2^i, then the extra bits are those
  * numbered 7 downto 8-n (this is the big-endian convention at the byte
  * level). The context is automatically reinitialized.
@@ -256,7 +256,7 @@ void sph_sha384(void *cc, const void *data, size_t len);
 /**
  * Terminate the current SHA-384 computation and output the result into the
  * provided buffer. The destination buffer must be wide enough to
- * accomodate the result (48 bytes). The context is automatically
+ * accommodate the result (48 bytes). The context is automatically
  * reinitialized.
  *
  * @param cc    the SHA-384 context
@@ -267,7 +267,7 @@ void sph_sha384_close(void *cc, void *dst);
 /**
  * Add a few additional bits (0 to 7) to the current computation, then
  * terminate it and output the result in the provided buffer, which must
- * be wide enough to accomodate the result (48 bytes). If bit number i
+ * be wide enough to accommodate the result (48 bytes). If bit number i
  * in <code>ub</code> has value 2^i, then the extra bits are those
  * numbered 7 downto 8-n (this is the big-endian convention at the byte
  * level). The context is automatically reinitialized.
@@ -327,7 +327,7 @@ void sph_sha512(void *cc, const void *data, size_t len);
 /**
  * Terminate the current SHA-512 computation and output the result into the
  * provided buffer. The destination buffer must be wide enough to
- * accomodate the result (64 bytes). The context is automatically
+ * accommodate the result (64 bytes). The context is automatically
  * reinitialized.
  *
  * @param cc    the SHA-512 context
@@ -338,7 +338,7 @@ void sph_sha512_close(void *cc, void *dst);
 /**
  * Add a few additional bits (0 to 7) to the current computation, then
  * terminate it and output the result in the provided buffer, which must
- * be wide enough to accomodate the result (64 bytes). If bit number i
+ * be wide enough to accommodate the result (64 bytes). If bit number i
  * in <code>ub</code> has value 2^i, then the extra bits are those
  * numbered 7 downto 8-n (this is the big-endian convention at the byte
  * level). The context is automatically reinitialized.

--- a/native/ed25519/sha512/sph_types.h
+++ b/native/ed25519/sha512/sph_types.h
@@ -161,7 +161,7 @@
  * computations may be performed in parallel, provided that they do not
  * operate on the same context. Moreover, a running computation can be
  * cloned by copying the context (with a simple <code>memcpy()</code>):
- * the context and its clone are then independant and may be updated
+ * the context and its clone are then independent and may be updated
  * with new data and/or closed without interfering with each other.
  * Similarly, a context structure can be moved in memory at will:
  * context structures contain no pointer, in particular no pointer to
@@ -560,7 +560,7 @@ typedef __arch_dependant__ sph_s64;
 
 /**
  * When defined, this macro indicates that unaligned memory accesses
- * are possible with only a minor penalty, and thus should be prefered
+ * are possible with only a minor penalty, and thus should be preferred
  * over strategies which first copy data to an aligned buffer.
  */
 #define SPH_UNALIGNED

--- a/test/blanket_mocha.js
+++ b/test/blanket_mocha.js
@@ -309,7 +309,7 @@ parseStatement: true, parseSourceElement: true */
         }
 
         // 'const' is specialized as Keyword in V8.
-        // 'yield' and 'let' are for compatiblity with SpiderMonkey and ES.next.
+        // 'yield' and 'let' are for compatibility with SpiderMonkey and ES.next.
         // Some others are from future reserved words.
 
         switch (id.length) {
@@ -5100,7 +5100,7 @@ _blanket.extend({
                     inputFileName: url
                 },function(instrumented){
                     try{
-                        if (_blanket.options("debug")) {console.log("BLANKET-instrument of:"+url+" was successfull.");}
+                        if (_blanket.options("debug")) {console.log("BLANKET-instrument of:"+url+" was successful.");}
                         _blanket.utils.blanketEval(instrumented);
                         cb();
                         _blanket.requiringFile(url,true);

--- a/test/test.js
+++ b/test/test.js
@@ -10451,7 +10451,7 @@ module.exports = function getEnumerableProperties(object) {
  */
 
 /*!
- * Module dependancies
+ * Module dependencies
  */
 
 var flag = require('./flag')
@@ -11259,7 +11259,7 @@ function objectToString(o) {
  */
 
 /*!
- * Module dependancies
+ * Module dependencies
  */
 
 var inspect = require('./inspect');
@@ -11478,7 +11478,7 @@ module.exports = function (ctx, name, getter) {
  */
 
 /*!
- * Module dependancies
+ * Module dependencies
  */
 
 var flag = require('./flag');


### PR DESCRIPTION
Mostly spotted using https://github.com/lucasdemarchi/codespell

The only change outside of a comment is the one in the `Gruntfile.js`, and is simply adding a missing double letter to a temporary variable name.

This patch is a bit big, but I had no idea how to split it *(commit messages don't have a subsystem prefix for instance)* and I'm too tired to look further.
I'm also too tired to figure out if any of those files are actually pulled from some other repos *(you should be using submodules if you are :P)*.

Anyway, don't hesitate to tell me if I was wrong, I'd be happy to respin this patch into a set and/or drop some changes.