### PR TITLE
Fix typo of quality argument in image compression

### DIFF
--- a/js/views/file_input_view.js
+++ b/js/views/file_input_view.js
@@ -101,8 +101,8 @@
                             canvas.toDataURL('image/jpeg', quality)
                         );
                         quality = quality * maxSize / blob.size;
-                        if (quality < 50) {
-                            quality = 50;
+                        if (quality < 0.5) {
+                            quality = 0.5;
                         }
                     } while (i > 0 && blob.size > maxSize);
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Ubuntu 15.10, Chromium 49.0.2623.108
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

The quality argument that's passed to `canvas.toDataURL()` should be a float in the range 0.0 to 1.0. Other values (e.g. 50) are discarded silently and a default is used. In other words, before this the reduction of the image's file size depended mostly on the scaling part.

Special thanks to @skulumani's :cat2:s. This is the [second time](https://whispersystems.discoursehosting.net/t/max-image-restrictions-on-signal-desktop/310/6) they have helped to fix [bugs](https://github.com/WhisperSystems/Signal-Android/issues/3347) in Signal's image compression.

You can test this with https://i.imgur.com/rMKbpLf.jpg

Fixes #713

// FREEBIE