### PR TITLE
Add a tooltip for version number

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -32,6 +32,7 @@ Describe here the issue that you are experiencing.
 <!-- replace examples with your info -->
 **Operating System**: My Operating System A
 **Browser**: My Browser X.Y.Z
+<!-- to see Signal's version number move your mouse cursor over the title "Signal" on the top left corner of the app -->
 **Signal version:** Z.Y.Y
 
 ### Link to debug log

--- a/background.html
+++ b/background.html
@@ -18,7 +18,7 @@
               <span class='socket-status' title='Restart Signal'></span>
             </div>
           </div>
-          <h1>Signal</h1>
+          <h1 title='v. {{ version }}'>Signal</h1>
           <div class='tool-bar clearfix'>
             <input type='search' class='search' placeholder='{{ searchForPeopleOrGroups }}'>
             <span class='search-icon'></span>

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -108,6 +108,7 @@
             submitDebugLog          : i18n('submitDebugLog'),
             settings                : i18n('settings'),
             restartSignal           : i18n('restartSignal'),
+            version                 : chrome.runtime.getManifest().version
         },
         events: {
             'click': 'closeMenu',


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Ubuntu 15.10, Chromium 49.0.2623.108
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
It's not clear where to get the version number when reporting bugs (see #775, #784 and #785). Yeah, it's in the debug log, but it's buried in technobabble, and sometimes debug logs are not posted at all.

This puts the version number in a simple tooltip when mouse is hovering over the Signal title.
![version-tooltip](https://cloud.githubusercontent.com/assets/174176/14984082/9e017ecc-1149-11e6-91f5-7a9be60b0413.png)
