### PR TITLE
Added RTL support to messages

### DIFF
--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -142,6 +142,9 @@
             var escaped = content.html();
             content.html(escaped.replace(/\n/g, '<br>').replace(URL_REGEX, "$1<a href='$2' target='_blank'>$2</a>"));
 
+            // Add auto direction attribute to message container to suppurt RTL languages
+            content.attr("dir", "auto");
+            
             this.renderSent();
             this.renderDelivered();
             this.renderErrors();

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -144,7 +144,7 @@
 
             // Add auto direction attribute to message container to suppurt RTL languages
             content.attr("dir", "auto");
-            
+
             this.renderSent();
             this.renderDelivered();
             this.renderErrors();


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Windows 7, Chrome 50.0.2661.102
 * Windows 7, Chrome 51.0.2704.79
- [ ] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description

I added auto direction attribute to message container to support RTL languages.
As it mentioned in this bug issue:
https://github.com/WhisperSystems/Signal-Desktop/issues/766

I tested it with Hebrew characters, maybe we should test it with Arabic etc. 

![rtl](https://cloud.githubusercontent.com/assets/4103710/15748879/175ddb74-28e9-11e6-93be-ced3e5865ee6.PNG)