### PR TITLE
Add RTL languages support for messages

### DIFF
--- a/background.html
+++ b/background.html
@@ -101,7 +101,7 @@
                   <button class='paperclip thumbnail'></button>
                   <input type='file' class='file-input'>
               </div>
-              <textarea class='send-message' placeholder='{{ send-message }}' rows='1'></textarea>
+              <textarea class='send-message' placeholder='{{ send-message }}' rows='1' dir='auto'></textarea>
           </form>
       </div>
     </div>
@@ -137,7 +137,7 @@
       <div class='bubble' style='background-color: {{ avatar.color }};'>
           <div class='sender'>{{ sender }}</div>
           <div class='attachments'></div>
-          <p class='content'>{{ message }}</p>
+          <p class='content' dir='auto'>{{ message }}</p>
           <div class='meta'>
             <span class='timestamp' data-timestamp={{ timestamp }}></span>
             <span class='status hide'></span>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Windows 7, Chrome 50.0.2661.102
 * Windows 7, Chrome 51.0.2704.79
 * Windows 7, Chrome 51.0.2704.103
 * Windows 7, Chrome 51.0.2704.106
- [ ] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description

I added auto direction attribute to message container to support RTL languages.
As it mentioned in this bug issue:
https://github.com/WhisperSystems/Signal-Desktop/issues/766

I created new pull request to fix this issue in right way (and not as I did before). I also added RTL support for message box textarea, and I saw you have problems with BitHub rewards so it's freebie.

I tested it with Hebrew characters, maybe we should test it with Arabic etc. 

![rtl](https://cloud.githubusercontent.com/assets/4103710/16354202/a19ec3d6-3a94-11e6-9d84-c8ed466112ea.png)
![message](https://cloud.githubusercontent.com/assets/4103710/16354225/346733b0-3a95-11e6-82be-39bc8152548c.PNG)

BTW, there is a bug in Chrome when using dir='auto' in textarea with LTR placeholder string, the text cursor position is wrong. I opened an issue about it:
https://bugs.chromium.org/p/chromium/issues/detail?id=623270 
