### PR TITLE
Added basic localization for timestamps

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -308,5 +308,69 @@
     "syncFailed": {
         "message": "Import failed. Make sure your computer and your phone are connected to the internet.",
         "description": "Informational text displayed if a sync operation times out."
-    }
+    },
+    "timestamp_s": {
+       "description": "",
+       "message": "now"
+    },
+    "timestamp_m": {
+      "description": "",
+      "message": "1 min"
+    },
+    "timestamp_mm": {
+       "description": "",
+       "message": "%d min"
+    },
+    "timestamp_h": {
+       "description": "",
+       "message": "1 hour"
+    },
+    "timestamp_hh": {
+       "description": "",
+       "message": "%d hours"
+    },
+    "timestampFormat_y" : {
+       "description": "",
+       "message": "MMM D, YYYY"
+    },
+    "timestampFormat_m" : {
+       "description": "",
+       "message": "MMM D"
+    },
+    "timestampFormat_d" : {
+       "description": "",
+       "message": "ddd"
+    },
+    "extendedTimestamp_s": {
+       "description": "",
+       "message": "now"
+    },
+    "extendedTimestamp_m": {
+       "description": "",
+       "message": "1 minute ago"
+    },
+    "extendedTimestamp_mm": {
+       "description": "",
+       "message": "%d minute ago"
+    },
+    "extendedTimestamp_h": {
+       "description": "",
+       "message": "1 hour ago"
+    },
+    "extendedTimestamp_hh": {
+       "description": "",
+       "message": "%d hours ago"
+    },
+    "extendedTimestampFormat_y" : {
+       "description": "",
+       "message": "MMM D, YYYY LT"
+    },
+    "extendedTimestampFormat_m" : {
+       "description": "",
+       "message": "MMM D LT"
+    },
+    "extendedTimestampFormat_d" : {
+       "description": "",
+       "message": "ddd LT"
+   }
 }

--- a/js/views/timestamp_view.js
+++ b/js/views/timestamp_view.js
@@ -66,45 +66,22 @@
             }
         },
         relativeTime : function (number, string, isFuture) {
-            return this._relativeTime[string].replace(/%d/i, number);
-        },
-        _relativeTime : {
-            s:  "now",
-            m:  "1 min",
-            mm: "%d min",
-            h:  "1 hour",
-            hh: "%d hours",
-            d:  "1 day",
-            dd: "%d days",
-            M:  "1 month",
-            MM: "%d months",
-            y:  "1 year",
-            yy: "%d years"
+            return i18n("timestamp_"+string).replace(/%d/i, number);
         },
         _format: {
-            y: 'MMM D, YYYY',
-            m: 'MMM D',
-            d: 'ddd'
+            y: i18n('timestampFormat_y'),
+            m: i18n('timestampFormat_m'),
+            d: i18n('timestampFormat_d')
         }
     });
     Whisper.ExtendedTimestampView = Whisper.TimestampView.extend({
-        _relativeTime : {
-            s:  "now",
-            m:  "1 minute ago",
-            mm: "%d minutes ago",
-            h:  "1 hour ago",
-            hh: "%d hours ago",
-            d:  "1 day ago",
-            dd: "%d days ago",
-            M:  "1 month ago",
-            MM: "%d months ago",
-            y:  "1 year ago",
-            yy: "%d years ago"
+        relativeTime : function (number, string, isFuture) {
+            return i18n("extendedTimestamp_"+string).replace(/%d/i, number);
         },
         _format: {
-            y: 'MMM D, YYYY LT',
-            m: 'MMM D LT',
-            d: 'ddd LT'
+            y: i18n('extendedTimestampFormat_y'),
+            m: i18n('extendedTimestampFormat_m'),
+            d: i18n('extendedTimestampFormat_d')
         }
     });
 })();


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
Windows 7, Chrome 51.0.2704.103 m
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

The timestamps in the conversation list and conversations were not localized.
This commit implements basic localization by adding the timestamps' strings and formatstrings to the i18n-infrastructure.

Since moment.js supports localization itself, i did not add days and months, so that you may import moment's localizations (and use them globally) instead of a custom solution.