### PR TITLE
Fixed media pausing behaviour when clicking the conversation list

### DIFF
--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -38,16 +38,25 @@
     Whisper.ConversationStack = Whisper.View.extend({
         className: 'conversation-stack',
         open: function(conversation) {
-            var $el = this.$('#conversation-' + conversation.cid);
-            if ($el === null || $el.length === 0) {
-                var view = new Whisper.ConversationView({
-                    model: conversation,
-                    appWindow: this.model.appWindow
+            var id = 'conversation-' + conversation.cid;
+            if(id !== this.el.firstChild.id) {
+                jQuery(this.el.firstChild).find("video").each(function() {
+                    this.pause();
                 });
-                $el = view.$el;
+                jQuery(this.el.firstChild).find("audio").each(function() {
+                    this.pause();
+                });
+                var $el = this.$('#'+id);
+                if ($el === null || $el.length === 0) {
+                    var view = new Whisper.ConversationView({
+                        model: conversation,
+                        appWindow: this.model.appWindow
+                    });
+                    $el = view.$el;
+                }
+                $el.prependTo(this.el);
+                conversation.trigger('opened');
             }
-            $el.prependTo(this.el);
-            conversation.trigger('opened');
         }
     });
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
Windows 7, Chrome 51.0.2704.103 m
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->


This commit changes the inbox to stop video and audio elements when selecting a new conversation, and to not stop such elements when the same conversation was selected (fixes #391).