### PR TITLE
Added Save-As buttons for every attachment

### DIFF
--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -59,7 +59,7 @@
   var VideoView = MediaView.extend({ tagName: 'video' });
 
   Whisper.AttachmentView = Backbone.View.extend({
-    tagName: 'span',
+    tagName: 'div',
     className: 'attachment',
     initialize: function() {
         this.blob = new Blob([this.model.data], {type: this.model.contentType});
@@ -69,13 +69,11 @@
         this.fileType = parts[1];
     },
     events: {
+        'click .saveAttachment': 'saveFile',
         'click': 'onclick'
     },
     onclick: function(e) {
         switch (this.contentType) {
-            case 'audio':
-            case 'video':
-                return;
             case 'image':
                 var view = new Whisper.LightboxView({ model: this });
                 view.render();
@@ -84,10 +82,11 @@
                 break;
 
             default:
-                this.saveFile();
+                return;
         }
     },
-    saveFile: function() {
+    saveFile: function(e) {
+        e.stopPropagation();
         var blob = this.blob;
         var suggestedName;
         if (this.fileType) {
@@ -124,6 +123,11 @@
         view.$el.appendTo(this.$el);
         view.on('update', this.trigger.bind(this, 'update'));
         view.render();
+        
+        var $save = $('<div class="saveAttachment">');
+        $save.html(i18n('saveAs'));
+        $save.appendTo(this.$el);
+        
         return this;
     }
   });


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
  Windows 7, Chrome 51.0.2704.103 m
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests)

---
### Description

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

This PR adds a basic save-as button to the AttachmentView, and thus implements a method to save audio and video files.

![unbenannt](https://cloud.githubusercontent.com/assets/10261186/16543277/a76b7f00-40cc-11e6-8034-f2bf1bdf3760.PNG)
