### PR TITLE
Parse URL in message view, fix issue #598

### DIFF
--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -5,7 +5,7 @@
     'use strict';
     window.Whisper = window.Whisper || {};
 
-    var URL_REGEX = /(^|[\s\n]|<br\/?>)((?:https?|ftp):\/\/[\-A-Z0-9\u00A0-\uD7FF\uE000-\uFDCF\uFDF0-\uFFFD+\u0026\u2019@#\/%?=()~_|!:,.;]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi;
+    var URL_REGEX = /((https?|ftp)\:\/\/)?([a-z0-9+!*(),;?&=\$_.-]+(\:[a-z0-9+!*(),;?&=\$_.-]+)?@)?([a-z0-9-.]*)\.([a-z]{2,4})(\:[0-9]{2,5})?(\/([a-z0-9+\$_-]\.?)+)*\/?((?:\:|\?)?[a-z+&\$_.-][a-z0-9';:@&%=+\/\$_.-]*)?(#[a-z_.-][a-z0-9+\$_.-]*)?/gi;
 
     var ErrorIconView = Whisper.View.extend({
         templateName: 'error-icon',
@@ -140,7 +140,7 @@
 
             var content = this.$('.content');
             var escaped = content.html();
-            content.html(escaped.replace(/\n/g, '<br>').replace(URL_REGEX, "$1<a href='$2' target='_blank'>$2</a>"));
+            content.html(escaped.replace(/\n/g, '<br>').replace(URL_REGEX, "<a href='$&' target='_blank'>$&</a>"));
 
             this.renderSent();
             this.renderDelivered();

--- a/test/views/message_view_test.js
+++ b/test/views/message_view_test.js
@@ -64,6 +64,51 @@ describe('MessageView', function() {
     assert.strictEqual(link.attr('href'), url);
   });
 
+  it('should linkify url without scheme properly', function(){
+    var url = 'example.com';
+    message.set('body', url);
+    var view = new Whisper.MessageView({model: message});
+    view.render();
+    var link = view.$el.find('.content a');
+    assert.strictEqual(link.length, 1);
+    assert.strictEqual(link.text(), url);
+    assert.strictEqual(link.attr('href'), url);
+  });
+
+  it('should linkify parenthetical url properly', function(){
+    var url = 'https://example.com';
+    var parentheticalLink = '(' + url + ')';
+    message.set('body', parentheticalLink);
+    var view = new Whisper.MessageView({model: message});
+    view.render();
+    var link = view.$el.find('.content a');
+    assert.strictEqual(link.length, 1);
+    assert.strictEqual(link.text(), url);
+    assert.strictEqual(link.attr('href'), url);
+  });
+
+  it('should linkify url with apostrophe and colon in GET params properly', function(){
+    var url = "https://example.com/Param:abc'xyz";
+    message.set('body', url);
+    var view = new Whisper.MessageView({model: message});
+    view.render();
+    var link = view.$el.find('.content a');
+    assert.strictEqual(link.length, 1);
+    assert.strictEqual(link.text(), url);
+    assert.strictEqual(link.attr('href'), url);
+  });
+
+  it('should linkify multiple URLs', function(){
+    var url1 = "http://example.com/";
+    var url2 = "http://example2.com/";
+    var msg = url1 + 'and' + url2;
+    message.set('body', msg);
+    var view = new Whisper.MessageView({model: message});
+    view.render();
+    var links = view.$el.find('.content a');
+    assert.strictEqual(links.length, 2);
+  });
+
   it('disallows xss', function() {
     var xss = '<script>alert("pwnd")</script>';
     message.set('body', xss);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
  - GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
  - Amiga OS 3.1, Chrom{e,ium} Z.Y
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

---
### Description

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

I modified the REGEX used to detect URLs inside js/views/message_view.js and the content.replace().  The regex now captures special characters like apostrophes and colons properly.  Parenthetical links can also capture, i.e. (example.com), [example.com], and ))example.com 
