### PR TITLE
Fixed bug920

### DIFF
--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -37,7 +37,7 @@
             });
             new RadioButtonGroupView({
                 el: this.$('.theme-settings'),
-                defaultValue: 'message',
+                defaultValue: 'android',
                 name: 'theme-setting'
             });
             if (textsecure.storage.user.getDeviceId() != '1') {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * OS X 10.11.6 (15G1004), Chrome Version 53.0.2785.116 (64-bit)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%

----------------------------------------

### Description
Fixes bug920. Before setting the theme for the first time, no theme appears to be selected in the settings menu, even if Android is the default one.

https://github.com/WhisperSystems/Signal-Desktop/issues/920

//FREEBIE