### PR TITLE
Font size should be adjustable

### DIFF
--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -68,26 +68,22 @@
             this.render();
         },
         events: { 'keydown': 'zoomText' },
-        zoomText: function(event) {
-            if (!event.ctrlKey)
+        zoomText: function(e) {
+            if (!e.ctrlKey)
                 return;
-            var keyCode = event.which || event.keyCode;
-            console.log(keyCode);
+            var keyCode = e.which || e.keyCode;
             var maxSize = 22; // if bigger text goes outside send-message textarea
             var minSize = 14;
-            if (keyCode === 189) {
-                console.log('font should decrease');
+            if (keyCode === 189 || keyCode == 109) {
                 if (this.currentSize > minSize) {
                     this.currentSize--;
                 }
-            } else if (keyCode === 187) {
-                console.log('font should increase');
+            } else if (keyCode === 187 || keyCode == 107) {
                 if (this.currentSize < maxSize) {
                     this.currentSize++;
                 }
             }
-            console.log(this.currentSize);
-            this.$el.css('font-size', this.currentSize + 'px');
+            this.render();
         },
         render: function() {
             this.$el.css('font-size', this.currentSize + 'px');
@@ -106,7 +102,8 @@
         initialize: function (options) {
             this.render();
             this.applyTheme();
-            new Whisper.FontSizeView({ el: this.el });
+            this.$el.attr('tabindex', '1');
+            new Whisper.FontSizeView({ el: this.$el });
             this.conversation_stack = new Whisper.ConversationStack({
                 el: this.$('.conversation-stack'),
                 model: { appWindow: options.appWindow }

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -67,21 +67,27 @@
             this.currentSize = this.defaultSize;
             this.render();
         },
-        events: { 'mousewheel': 'zoomText' },
-        zoomText: function(e) {
-            if (e.ctrlKey === true) {
-                if (e.originalEvent.deltaY > 0) {
-                    if (this.currentSize > this.minSize) {
-                        this.currentSize--;
-                        this.render();
-                    }
-                } else if (e.originalEvent.deltaY < 0) {
-                    if (this.currentSize < this.maxSize) {
-                        this.currentSize++;
-                        this.render();
-                    }
+        events: { 'keydown': 'zoomText' },
+        zoomText: function(event) {
+            if (!event.ctrlKey)
+                return;
+            var keyCode = event.which || event.keyCode;
+            console.log(keyCode);
+            var maxSize = 22; // if bigger text goes outside send-message textarea
+            var minSize = 14;
+            if (keyCode === 189) {
+                console.log('font should decrease');
+                if (this.currentSize > minSize) {
+                    this.currentSize--;
+                }
+            } else if (keyCode === 187) {
+                console.log('font should increase');
+                if (this.currentSize < maxSize) {
+                    this.currentSize++;
                 }
             }
+            console.log(this.currentSize);
+            this.$el.css('font-size', this.currentSize + 'px');
         },
         render: function() {
             this.$el.css('font-size', this.currentSize + 'px');


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * OS X 10.11.6 (15G1004), Chrome Version 53.0.2785.143 (64-bit)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%

----------------------------------------

### Description
Here my solution for the https://github.com/WhisperSystems/Signal-Desktop/issues/864. To change the font size, you need first to select the send-message textarea (the area where you input the message) and then with CTRL+"+" one increases the font size, and with CTRL+"-" the font size is decreased. I've only set the keycodes 187 for + and 189 for -, numkeys + and - should be added. Check the log to see the corresponding keycode when pressing the button.
Maximum font size is set to 22 now because bigger fonts went outside the message text area.

//FREEBIE