### PR TITLE
Bug491

### DIFF
--- a/js/views/conversation_search_view.js
+++ b/js/views/conversation_search_view.js
@@ -100,9 +100,9 @@
                 ConversationController.findOrCreatePrivateById(
                     this.new_contact_view.model.id
                 ).then(function(conversation) {
-                    this.trigger('open', conversation);
                     this.initNewContact();
                     this.resetTypeahead();
+                    this.trigger('open', conversation);
                 }.bind(this));
             } else {
                 this.new_contact_view.$('.number').text("Invalid number");

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -321,7 +321,7 @@
         destroyMessages: function(e) {
             this.confirm(i18n('deleteConversationConfirmation')).then(function() {
                 this.model.destroyMessages();
-                this.remove();
+                this.reset();
             }.bind(this)).catch(function() {
                 // clicked cancel, nothing to do.
             });

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -125,6 +125,7 @@
 
             this.listenTo(this.searchView, 'hide', function() {
                 this.searchView.$el.hide();
+                this.inboxListView.render();
                 this.inboxListView.$el.show();
             });
             this.listenTo(this.searchView, 'show', function() {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
  - OS X 10.11.6 (15G1004), Chrome Version 53.0.2785.143 (64-bit)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%

---
### Description

This should fix a couple of bugs related with the search box described in https://github.com/WhisperSystems/Signal-Desktop/issues/491.
1) When inserting a new contact, the conversation was shown correctly but the wrong conversation was highlighted in the list. This is fixed by triggering the open conversation after calling the initNewContact method and not before.
2) When deleting all the messages from a conversation, another conversation, if present in the list, was highlighted, but the main panel was still showing the old conversation. This is fixed by forcing a reset after calling the destroyMessaged method.
3) The bug described in https://github.com/WhisperSystems/Signal-Desktop/issues/491 is fixed by forcing a render of inboxListView before calling the show() method.
