### PR TITLE
Fix 2nd person conjugation in expiration timer messages

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -347,9 +347,19 @@
       "message": "Unblock this contact to send a message.",
       "description": "Brief message shown when trying to message a blocked number"
     },
-    "changedTheTimer": {
+    "youChangedTheTimer": {
+      "message": "You set the timer to $time$.",
+      "description": "Message displayed when you change the message expiration timer in a conversation.",
+      "placeholders": {
+        "time": {
+          "content": "$1",
+          "example": "10m"
+        }
+      }
+    },
+    "theyChangedTheTimer": {
       "message": "$name$ set the timer to $time$.",
-      "description": "Message displayed when someone changes the message expiration timer in a conversation.",
+      "description": "Message displayed when someone else changes the message expiration timer in a conversation.",
       "placeholders": {
         "name": {
           "content": "$1",
@@ -446,10 +456,6 @@
           "example": "1w"
         }
       }
-    },
-    "you": {
-      "message": "You",
-      "description": "A gender-neutral second-person prounoun used as a subject, as in, 'You set the timer to 5 seconds'"
     },
     "safetyNumbersSettingHeader": {
       "message": "Safety numbers approval",

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -56,14 +56,20 @@
         },
         render_attributes: function() {
             var seconds = this.model.get('expirationTimerUpdate').expireTimer;
-            var name = this.conversation.getTitle();
+            var timerMessage;
             if (this.conversation.id === textsecure.storage.user.getNumber()) {
-                name = i18n('you');
+                timerMessage = {
+                  content: i18n('youChangedTheTimer',
+                             Whisper.ExpirationTimerOptions.getName(seconds))
+                };
+            } else {
+                timerMessage = {
+                  content: i18n('theyChangedTheTimer', [
+                             this.conversation.getTitle(),
+                             Whisper.ExpirationTimerOptions.getName(seconds)])
+                };
             }
-            return {
-              content: i18n('changedTheTimer', [name,
-                         Whisper.ExpirationTimerOptions.getName(seconds)])
-            };
+            return timerMessage;
         }
     });
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Ubuntu 16.04, Chromium 52.0.2743.116
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
The verb **to set** has the same conjugation for the 2nd and 3rd persons. Therefore
```
You set the timer to 5 seconds.
Cat set the timer to 5 seconds.
```
works OK when you combine the string **'You'** with the string **'$name$ set the timer to $time$'**

But other verbs might have different conjugation for the 2nd and 3rd persons. For example:
```
You walk into a bar.
Cat walkS into a bar.
```

Now imagine other languages than English, and you're gonna have bad time if it's assumed that all verbs in all tenses have the same conjugation for the 2nd and 3rd persons.

Fixes one of these: https://www.transifex.com/liliakai/signal-desktop/translate/#issues (dunno how to give a direct link to the specific issue)

See also: https://github.com/WhisperSystems/Signal-Android/issues/5658