### PR TITLE
Non existent contacts are added and still present in the search results

### DIFF
--- a/js/views/conversation_search_view.js
+++ b/js/views/conversation_search_view.js
@@ -97,12 +97,19 @@
         createConversation: function() {
             var conversation = this.new_contact_view.model;
             if (this.new_contact_view.model.isValid()) {
-                ConversationController.findOrCreatePrivateById(
-                    this.new_contact_view.model.id
-                ).then(function(conversation) {
-                    this.trigger('open', conversation);
-                    this.initNewContact();
-                    this.resetTypeahead();
+                var accountManager = window.getAccountManager();
+                accountManager.server.getKeysForNumber(conversation.id)
+                .then(function(response) {
+                    ConversationController.findOrCreatePrivateById(
+                          this.new_contact_view.model.id
+                     ).then(function(conversation) {
+                          this.trigger('open', conversation);
+                          this.initNewContact();
+                          this.resetTypeahead();
+                    }.bind(this));
+                }.bind(this), function(error) {
+                    this.new_contact_view.$('.number').text(error);
+                    this.$input.focus();
                 }.bind(this));
             } else {
                 this.new_contact_view.$('.number').text("Invalid number");


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
  - macOS 10.12 (16A323), Chrome 53.0.2785.143 (64-bit)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%

---
### Description

Adding a not registered number as a new contact should be avoided. Before the new contact was added and a new conversation was created. If a message is sent to this number, it is impossible to remove the conversation from the list and the number is always available in the search results.
This fixes https://github.com/WhisperSystems/Signal-Desktop/issues/939 checking if the keys for the number are available, if not an error message is shown below the number.
Now it's simply showing the error without any parsing.

<img width="720" alt="screen shot 2016-10-09 at 17 31 37" src="https://cloud.githubusercontent.com/assets/9964820/19221994/67407512-8e46-11e6-9d50-9d907c1af3a8.png">

// FREEBIE
