### PR TITLE
Fixed bubble timestamp update timer breakdown

### DIFF
--- a/js/views/timestamp_view.js
+++ b/js/views/timestamp_view.js
@@ -46,7 +46,8 @@
         getRelativeTimeSpanString: function(timestamp_) {
             // Convert to moment timestamp if it isn't already
             var timestamp = moment(timestamp_),
-                timediff = moment.duration(moment() - timestamp);
+                now = moment(),
+                timediff = moment.duration(now - timestamp);
 
             if (timediff.years() > 0) {
                 this.delay = null;
@@ -55,22 +56,22 @@
                 this.delay = null;
                 return timestamp.format(this._format.M);
             } else if (timediff.days() > 0) {
-                this.delay = moment(timestamp).add(timediff.days() + 1,'d').diff(moment());
+                this.delay = moment(timestamp).add(timediff.days() + 1,'d').diff(now);
                 return timestamp.format(this._format.d);
             } else if (timediff.hours() > 1) {
-                this.delay = moment(timestamp).add(timediff.hours() + 1,'h').diff(moment());
+                this.delay = moment(timestamp).add(timediff.hours() + 1,'h').diff(now);
                 return this.relativeTime(timediff.hours(), 'h');
             } else if (timediff.hours() === 1) {
-                this.delay = moment(timestamp).add(timediff.hours() + 1,'h').diff(moment());
+                this.delay = moment(timestamp).add(timediff.hours() + 1,'h').diff(now);
                 return this.relativeTime(timediff.hours(), 'h');
             } else if (timediff.minutes() > 1) {
-                this.delay = moment(timestamp).add(timediff.minutes() + 1,'m').diff(moment());
+                this.delay = moment(timestamp).add(timediff.minutes() + 1,'m').diff(now);
                 return this.relativeTime(timediff.minutes(), 'm');
             } else if (timediff.minutes() === 1) {
-                this.delay = moment(timestamp).add(timediff.minutes() + 1,'m').diff(moment());
+                this.delay = moment(timestamp).add(timediff.minutes() + 1,'m').diff(now);
                 return this.relativeTime(timediff.minutes(), 'm');
             } else {
-                this.delay = moment(timestamp).add(1,'m').diff(moment());
+                this.delay = moment(timestamp).add(1,'m').diff(now);
                 return this.relativeTime(timediff.seconds(), 's');
             }
         },


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My contribution is fully baked and ready to be merged as is
- [X] My changes are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [X] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [X] I will not install grunt, npm, bower, mocha, nor chai to write and test further tests

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

TimestampView's getRelativeTimeSpanString called moment() twice while calculating the timeout. If there was a minute/hour/day wrap between these 2 calls, the calculated delay was 0 and thus no timer was scheduled, since if (this.delay) evaluated to false.

Fixes: #857, #460

// FREEBIE


Stumbled across this while trying to find the cause of #924.