### PR TITLE
Messagedetailviewtimestampfix

### DIFF
--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -74,8 +74,8 @@
                 });
             }
             this.$el.html(Mustache.render(_.result(this, 'template', ''), {
-                sent_at     : moment(this.model.get('sent_at')).toString(),
-                received_at : this.model.isIncoming() ? moment(this.model.get('received_at')).toString() : null,
+                sent_at     : moment(this.model.get('sent_at')).format('LLLL'),
+                received_at : this.model.isIncoming() ? moment(this.model.get('received_at')).format('LLLL') : null,
                 tofrom      : this.model.isIncoming() ? i18n('from') : i18n('to'),
                 errors      : unknownErrors,
                 title       : i18n('messageDetail'),


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * W10
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

Fixes #954.

before:

![before](https://cloud.githubusercontent.com/assets/10261186/19747763/f45ad0ce-9bdd-11e6-9d28-68ca617e5321.PNG)


after:
![after](https://cloud.githubusercontent.com/assets/10261186/19747759/e4fe65fa-9bdd-11e6-8687-f863e85a709e.PNG)
