### PR TITLE
Moving the error badge to the right corner in ios theme

### DIFF
--- a/stylesheets/_ios.scss
+++ b/stylesheets/_ios.scss
@@ -155,4 +155,10 @@ $ios-border-color: rgba(0,0,0,0.1);
   .hourglass {
     @include hourglass(#999);
   }
+  .socket-status {
+    position: absolute;
+    padding-top:-3px;
+    top:0;
+    right:5px;
+  }
 }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1543,6 +1543,11 @@ li.entry .error-icon-container {
     -webkit-mask: url("/images/hourglass_empty.svg") no-repeat center;
     -webkit-mask-size: 100%;
     background-color: #999; }
+.ios .socket-status {
+  position: absolute;
+  padding-top: -3px;
+  top: 0;
+  right: 5px; }
 
 .android #header {
   background-color: #2090ea;


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Ubuntu 16.04, Chromium 53.0.2785.143
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->
Moving the error badge to the right corner in ios theme:
Could fix #971
// FREEBIE

![screenshot at 2016-11-21 21 17 50](https://cloud.githubusercontent.com/assets/20602537/20499223/cc503346-b030-11e6-871a-cf478f6cb56e.png)
