### PR TITLE
Add iOS build information link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,12 @@ mobile, **you must build a mobile client that targets the staging server**
 
 ## Linking
 
-Currently only the Android client supports multi-device linking.
 
-0. Build Signal for Android from source, and change its `TEXTSECURE_URL` to point
+0. Build Signal for Android or iOS from source, and change its `TEXTSECURE_URL` to point
    at `textsecure-service-staging.whispersystems.org`. This task is 1% search and
-   replace, 99% [setting up your build environment](https://github.com/WhisperSystems/Signal-Android/blob/master/BUILDING.md).
+   replace, 99% setting up your build environment. Instructions are available for both
+   the [Android](https://github.com/WhisperSystems/Signal-Android/blob/master/BUILDING.md)
+   and [iOS](https://github.com/WhisperSystems/Signal-iOS/blob/master/BUILDING.md) projects.
 1. Upon installing the extension you will be presented with a qr code.
 2. On your phone, open Signal and navigate to Settings > Devices. Tap the "+"
    button and scan the qr code.


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages

----------------------------------------

### Description
CONTRIBUTING.md said that the iOS app cannot be linked to the Desktop app, but it can now! I have updated the text accordingly, and added a link to the iOS BUILDING.md file.