### PR TITLE
Use singular form for per-conversation safety numbers

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -14,7 +14,7 @@
       "message": "Submit"
     },
     "verifyContact": {
-      "message": "You may wish to $tag_start$ verify $tag_end$ this contact.",
+      "message": "You may wish to $tag_start$ verify $tag_end$ your safety number with this contact.",
       "description": "Use $tag_start$ and $tag_end$ to wrap the word or phrase in this sentence that the user should click on in order to navigate to the verification screen. These placeholders will be replaced with appropriate HTML code.",
       "placeholders": {
         "tag_start": {
@@ -27,23 +27,23 @@
     },
     "acceptNewKey": {
       "message": "Accept",
-      "description": "Label for a button to accept a new safety numbers"
+      "description": "Label for a button to accept a new safety number"
     },
     "verify": {
       "message": "Verify"
     },
     "newIdentity": {
-      "message": "New safety numbers",
+      "message": "New safety number",
       "description": "Header for a key change dialog"
     },
     "identityChanged": {
-      "message": "This contact's safety numbers have changed. This could either mean that someone is trying to intercept your communication, or this contact simply re-installed Signal. You may wish to verify their new safety numbers below."
+      "message": "Your safety number with this contact has changed. This could either mean that someone is trying to intercept your communication, or this contact simply reinstalled Signal. You may wish to verify the new safety number below."
     },
     "outgoingKeyConflict": {
-      "message": "This contact's safety numbers have changed. Click to process and display."
+      "message": "Your safety number with this contact has changed. Click to process and display."
     },
     "incomingKeyConflict": {
-      "message": "Received message with new safety numbers. Click to process and display."
+      "message": "Received message with a new safety number. Click to process and display."
     },
     "incomingError": {
       "message": "Error handling incoming message."
@@ -122,10 +122,10 @@
         "description": "This is a menu item for resetting the session, using the imperative case, as in a command."
     },
     "verifySafetyNumbers": {
-        "message": "Verify safety numbers"
+        "message": "Verify safety number"
     },
     "theirIdentityUnknown": {
-        "message": "You haven't exchanged any messages with this contact yet. Safety numbers will be available after the first message."
+        "message": "You haven't exchanged any messages with this contact yet. Your safety number with them will be available after the first message."
     },
     "deleteMessages": {
         "message": "Delete messages",
@@ -280,7 +280,7 @@
         "description": "Hides the details of a key change"
     },
     "learnMore": {
-        "message": "Learn more about verifying safety numbers.",
+        "message": "Learn more about verifying safety numbers",
         "description": "Text that links to a support article on verifying safety numbers"
     },
     "expiredWarning": {
@@ -455,14 +455,14 @@
     },
     "safetyNumbersSettingHeader": {
       "message": "Safety numbers approval",
-      "description": "Description for safety numbers setting"
+      "description": "Header for safety numbers setting"
     },
     "safetyNumbersSettingDescription": {
-      "message": "Require approval of new safety numbers when they change.",
+      "message": "Require approval of new safety numbers when they change",
       "description": "Description for safety numbers setting"
     },
     "keychanged": {
-      "message": "$name$'s safety numbers have changed",
+      "message": "Your safety number with $name$ has changed.",
       "description": "",
       "placeholders": {
         "name": {
@@ -472,7 +472,7 @@
       }
     },
     "yourSafetyNumberWith": {
-      "message": "Your safety numbers with $name$",
+      "message": "Your safety number with $name$",
       "description": "Heading for safety number view",
       "placeholders": {
         "name": {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [ ] I have tested my contribution on these platforms:
 * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
 * Amiga OS 3.1, Chrom{e,ium} Z.Y
- [ ] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [ ] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->
This PR corresponds to https://github.com/WhisperSystems/Signal-Android/pull/5894, which changes the form used for safety numbers from plural to singular ("safety number"). This change has been agreed on by Moxie.

I haven't changed any string names, as I've noticed that the existing ones for the most part haven't been adjusted for Safety Numbers anyway. If you want me to adjust them, please say so.

// FREEBIE