### PR TITLE
Removes orange borders glitch (visible in dark design)

### DIFF
--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -484,3 +484,8 @@ input[type=text], input[type=search], textarea {
     margin-left: 20px;
   }
 }
+
+//yellow border fix
+.inbox:focus {
+    outline: none;
+}

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -439,6 +439,9 @@ input[type=text]:active, input[type=text]:focus, input[type=search]:active, inpu
     background: #2090ea;
     margin-left: 20px; }
 
+.inbox:focus {
+  outline: none; }
+
 @keyframes progress-bar-stripes {
   from {
     background-position: 40px 0; }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Ubuntu 16.04, Chromium 53.0.2785.143
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->
When clicking inside the conversations container, a thin orange border appears.
It is also present in the light themes, but only in the dark theme you can really see this slightly annoying border.

Before:
![screenshot at 2016-12-05 23 28 07](https://cloud.githubusercontent.com/assets/20602537/20905975/527432fe-bb46-11e6-85c9-ee40fa5eee45.png)
![screenshot at 2016-12-05 23 28 27](https://cloud.githubusercontent.com/assets/20602537/20905999/6742e22a-bb46-11e6-8ead-1376724f5905.png)

After:
![screenshot at 2016-12-05 23 30 59](https://cloud.githubusercontent.com/assets/20602537/20905989/5d905a8c-bb46-11e6-8185-303c3a7cf549.png)

FREEBIE