### PR TITLE
Prevent expiration timer update on group update

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -395,7 +395,7 @@
                             message.set({expireTimer: dataMessage.expireTimer});
                         }
 
-                        if (!message.isEndSession()) {
+                        if (!message.isEndSession() && !message.isGroupUpdate()) {
                             if (dataMessage.expireTimer) {
                                 if (dataMessage.expireTimer !== conversation.get('expireTimer')) {
                                   conversation.addExpirationTimerUpdate(


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on that platform:
 * OSX 10.11.6, Google Chrome Version 55.0.2883.95 (64-bit)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description

Prevent expiration timer update on group update. It occurs when a message with a different expiration time than the current one is received.

The issue report highlights the scenario of a member leaving a group
(group update [quit] sent with expiration time = 0).

Fix https://github.com/WhisperSystems/Signal-Android/issues/5996
Fix https://github.com/WhisperSystems/Signal-iOS/issues/1566

