### PR TITLE
add disappearing messages time of 10 minutes

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -419,6 +419,10 @@
       "message": "5m",
       "description": "Very short format indicating current timer setting in the conversation header"
     },
+    "timerOption_10_minutes_abbreviated": {
+      "message": "10m",
+      "description": "Very short format indicating current timer setting in the conversation header"
+    },
     "timerOption_30_minutes_abbreviated": {
       "message": "30m",
       "description": "Very short format indicating current timer setting in the conversation header"

--- a/js/expiring_messages.js
+++ b/js/expiring_messages.js
@@ -47,6 +47,7 @@
         [ 30, 'seconds'  ],
         [ 1,  'minute'   ],
         [ 5,  'minutes'  ],
+        [ 10, 'minutes'  ],
         [ 30, 'minutes'  ],
         [ 1,  'hour'     ],
         [ 6,  'hours'    ],


### PR DESCRIPTION
This adds 10 mintues to the list of times for disappearing messages, making
the list feel more complete.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages


----------------------------------------

### Description
This is the Desktop equivalent of https://github.com/WhisperSystems/Signal-Android/pull/6016 and https://github.com/WhisperSystems/SignalServiceKit/pull/90

