### PR TITLE
Change attachment naming scheme - closes gh-860

### DIFF
--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -4,6 +4,12 @@
 (function () {
   'use strict';
 
+  var timestampFormat = function(dateobj) {
+      var date = dateobj.toISOString().slice(0, 10);
+      var time = dateobj.toISOString().slice(11, 19).split(':');
+      return date + '-' + time[0] + time[1] + time[2];
+  };
+
   var FileView = Backbone.View.extend({
       tagName: 'a',
       initialize: function(dataUrl) {
@@ -67,6 +73,8 @@
         var parts = this.model.contentType.split('/');
         this.contentType = parts[0];
         this.fileType = parts[1];
+
+        this.timestamp = this.model.timestamp;
     },
     events: {
         'click': 'onclick'
@@ -91,7 +99,7 @@
         var blob = this.blob;
         var suggestedName;
         if (this.fileType) {
-            suggestedName = 'signal.' + this.fileType;
+            suggestedName = 'signal-' + timestampFormat(new Date(this.timestamp)) + '.' + this.fileType;
         }
         var w = extension.windows.getViews()[0];
         if (w && w.chrome && w.chrome.fileSystem) {

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -259,7 +259,7 @@
         },
         loadAttachments: function() {
             this.model.get('attachments').forEach(function(attachment) {
-                var view = new Whisper.AttachmentView({ model: attachment });
+                var view = new Whisper.AttachmentView({ model: attachment, timestamp: this.model.get('timestamp') });
                 this.listenTo(view, 'update', function() {
                     if (!view.el.parentNode) {
                         this.trigger('beforeChangeHeight');

--- a/test/index.html
+++ b/test/index.html
@@ -538,6 +538,7 @@
   <script type="text/javascript" src="views/whisper_view_test.js"></script>
   <script type="text/javascript" src="views/group_update_view_test.js"></script>
   <script type="text/javascript" src="views/message_view_test.js"></script>
+  <script type="text/javascript" src="views/attachment_view_test.js"></script>
   <script type="text/javascript" src="views/timestamp_view_test.js"></script>
   <script type="text/javascript" src="views/list_view_test.js"></script>
   <script type="text/javascript" src="views/conversation_search_view_test.js"></script>

--- a/test/views/attachment_view.js
+++ b/test/views/attachment_view.js
@@ -1,9 +1,0 @@
-describe('AttachmentView', function() {
-
-  it('should display an error for an unsupported type', function() {
-    var attachment = { contentType: 'html/text' };
-    var view = new Whisper.AttachmentView({model: attachment}).render();
-    assert.match(view.$el.text(), /Sorry, your attachment has a type, html, that is not currently supported./);
-  });
-
-});

--- a/test/views/attachment_view_test.js
+++ b/test/views/attachment_view_test.js
@@ -1,0 +1,46 @@
+describe('AttachmentView', function() {
+
+  it('should give a data url for arbitrary content', function() {
+    var attachment = { contentType: 'arbitrary/content' };
+    var view = new Whisper.AttachmentView({model: attachment}).render();
+    assert.match(view.$el.find("a[href]").attr("href"), /http:\/\/localhost/);
+  });
+
+  it('should have proper properties', function() {
+    var now = new Date().getTime();
+    var attachment = { contentType: 'image/png', data: 'grumpy cat', timestamp: now };
+    var view = new Whisper.AttachmentView({model: attachment});
+
+    assert.match(view.contentType, /image/);
+    assert.match(view.fileType, /png/);
+    assert.equal(view.timestamp, now);
+    assert.isTrue(view.blob instanceof Blob);
+  });
+
+  it('shoud have correct filename format', function() {
+    var filename;
+
+    // mock out filesystem access
+    extension.windows.getViews = function () {
+      return [window];
+    };
+
+    var window = {
+      chrome: {
+        fileSystem: {
+          chooseEntry: function(data, cb) {
+            // get the filename
+            filename = data.suggestedName;
+          }
+        }
+      }
+    };
+
+    var epoch = new Date(0).getTime();
+    var attachment = { contentType: 'image/png', data: 'grumpy cat', timestamp: epoch};
+    var view = new Whisper.AttachmentView({model: attachment}).saveFile();
+
+    var expected = '1970-01-01-000000';
+    assert(filename === 'signal-' + expected + '.png');
+  });
+});


### PR DESCRIPTION

Fix attachment naming, add attachment view tests.

Attachments are now saved as `signal-yyyy-MM-dd-HHmmss.fileType`

This turns the `attachment_view_test.js` tests back on, and modernizes them.


### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 *  Arch Linux 4.8.13-1 with Chrome  52.0.2743.116 (64-bit).
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them