### PR TITLE
Picture size to 4MB and edge to 2048

### DIFF
--- a/js/views/file_input_view.js
+++ b/js/views/file_input_view.js
@@ -78,9 +78,9 @@
                 img.onload = function () {
                     URL.revokeObjectURL(url);
 
-                    var maxSize = 420 * 1024;
-                    var maxHeight = 1280;
-                    var maxWidth = 1280;
+                    var maxSize = 4000 * 1024;
+                    var maxHeight = 2048;
+                    var maxWidth = 2048;
                     if (img.width <= maxWidth && img.height <= maxHeight &&
                         file.size <= maxSize) {
                         resolve(file);
@@ -139,7 +139,7 @@
                 var blobType = file.type === 'image/gif' ? 'gif' : type;
                 switch (blobType) {
                     case 'image':
-                        limitKb = 420; break;
+                        limitKb = 4000; break;
                     case 'gif':
                         limitKb = 5000; break;
                     case 'audio':


### PR DESCRIPTION
Closes #1032 and catches up with Android

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Fedora 25, Chromium 55.0.2883.87 Fedora Project (64-bit)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
As described in #1032 it's necessary to push the max picture edge up to 2048. It catches up with Signal-Android.

Source: https://github.com/WhisperSystems/Signal-Android/commit/b54a271a753fd31dcea77e258e5df5188f1da156
