### PR TITLE
Add copy and paste for images

### DIFF
--- a/js/views/file_input_view.js
+++ b/js/views/file_input_view.js
@@ -35,7 +35,8 @@
             'click .choose-file': 'open',
             'drop': 'openDropped',
             'dragover': 'showArea',
-            'dragleave': 'hideArea'
+            'dragleave': 'hideArea',
+            'paste': 'onPaste'
         },
 
         open: function(e) {
@@ -281,6 +282,19 @@
             e.stopPropagation();
             e.preventDefault();
             this.$el.removeClass('dropoff');
+        },
+        onPaste: function(e) {
+            var items = e.originalEvent.clipboardData.items;
+            var imgBlob = null;
+            for (var i = 0; i < items.length; i++) {
+                if (items[i].type.split('/')[0] === 'image') {
+                   imgBlob = items[i].getAsFile();
+                }
+            }
+            if (imgBlob !== null) {
+                this.file = imgBlob;
+                this.previewImages();
+            }
         }
     });
 })();


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
* Windows 10, Chrome 55
 * Arch Linux, Chromium 52
- [ ] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description

This pull request adds copy and paste support of images to the input box of conversation windows.

Tested this on two different computers with two different browsers. Tested by copying and pasting an image, then some text, then a different image, then different text, then another different image, then another different text.

