### PR TITLE
Add attachment_views_test.js tests

### DIFF
--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -90,19 +90,22 @@
                 this.saveFile();
         }
     },
-    saveFile: function() {
-        var blob = this.blob;
-        var suggestedName = 'signal';
+    suggestedName: function() {
+        var suggestion = 'signal';
         if (this.timestamp) {
-            suggestedName += moment(this.timestamp).format('-YYYY-MM-DD-HHmmss');
+            suggestion += moment(this.timestamp).format('-YYYY-MM-DD-HHmmss');
         }
         if (this.fileType) {
-            suggestedName += '.' + this.fileType;
+            suggestion += '.' + this.fileType;
         }
+        return suggestion;
+    },
+    saveFile: function() {
+        var blob = this.blob;
         var w = extension.windows.getViews()[0];
         if (w && w.chrome && w.chrome.fileSystem) {
             w.chrome.fileSystem.chooseEntry({
-                type: 'saveFile', suggestedName: suggestedName
+                type: 'saveFile', suggestedName: this.suggestedName()
             }, function(entry) {
                 if (!entry) {
                     return;

--- a/test/index.html
+++ b/test/index.html
@@ -538,6 +538,7 @@
   <script type="text/javascript" src="views/whisper_view_test.js"></script>
   <script type="text/javascript" src="views/group_update_view_test.js"></script>
   <script type="text/javascript" src="views/message_view_test.js"></script>
+  <script type="text/javascript" src="views/attachment_view_test.js"></script>
   <script type="text/javascript" src="views/timestamp_view_test.js"></script>
   <script type="text/javascript" src="views/list_view_test.js"></script>
   <script type="text/javascript" src="views/conversation_search_view_test.js"></script>

--- a/test/views/attachment_view.js
+++ b/test/views/attachment_view.js
@@ -1,9 +1,0 @@
-describe('AttachmentView', function() {
-
-  it('should display an error for an unsupported type', function() {
-    var attachment = { contentType: 'html/text' };
-    var view = new Whisper.AttachmentView({model: attachment}).render();
-    assert.match(view.$el.text(), /Sorry, your attachment has a type, html, that is not currently supported./);
-  });
-
-});

--- a/test/views/attachment_view_test.js
+++ b/test/views/attachment_view_test.js
@@ -1,0 +1,27 @@
+describe('AttachmentView', function() {
+
+  it('should render a data url for arbitrary content', function() {
+    var attachment = { contentType: 'arbitrary/content' };
+    var view = new Whisper.AttachmentView({model: attachment}).render();
+    assert.equal(view.el.firstChild.tagName, "A");
+  });
+
+  it('should render an image for images', function() {
+    var now = new Date().getTime();
+    var attachment = { contentType: 'image/png', data: 'grumpy cat' };
+    var view = new Whisper.AttachmentView({model: attachment, timestamp: now}).render();
+    assert.equal(view.el.firstChild.tagName, "IMG");
+  });
+
+  it('shoud have correct filename format', function() {
+    var epoch = new Date((new Date(0)).getTimezoneOffset() * 60 * 1000);
+    var attachment = { contentType: 'image/png', data: 'grumpy cat' };
+    var result = new Whisper.AttachmentView({
+      model: attachment,
+      timestamp: epoch
+    }).suggestedName();
+
+    var expected = '1970-01-01-000000';
+    assert(result === 'signal-' + expected + '.png');
+  });
+});


### PR DESCRIPTION
These tests were pulled out of #1026, they turn the `attachment_view_test.js` tests back on, and modernize them. The coverage of `attachment_view.js` changed from 10% to 48%.

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 *  Arch Linux 4.8.13-1 with Chrome  52.0.2743.116 (64-bit).
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them