### PR TITLE
Increase image constraints to 6 MB / max edge of 4096

### DIFF
--- a/js/views/file_input_view.js
+++ b/js/views/file_input_view.js
@@ -78,9 +78,9 @@
                 img.onload = function () {
                     URL.revokeObjectURL(url);
 
-                    var maxSize = 4000 * 1024;
-                    var maxHeight = 2048;
-                    var maxWidth = 2048;
+                    var maxSize = 6000 * 1024;
+                    var maxHeight = 4096;
+                    var maxWidth = 4096;
                     if (img.width <= maxWidth && img.height <= maxHeight &&
                         file.size <= maxSize) {
                         resolve(file);
@@ -139,9 +139,9 @@
                 var blobType = file.type === 'image/gif' ? 'gif' : type;
                 switch (blobType) {
                     case 'image':
-                        limitKb = 4000; break;
+                        limitKb = 6000; break;
                     case 'gif':
-                        limitKb = 5000; break;
+                        limitKb = 6000; break;
                     case 'audio':
                         limitKb = 100000; break;
                     case 'video':


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Fedora 25, Chromium 55
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
Sorry for modifying this again, but the Android limits have been bumped up a second time in WhisperSystems/Signal-Android@d2be49af

// FREEBIE