### PR TITLE
Ignore missing members in incoming group updates

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -36987,19 +36987,9 @@ Internal.SessionLock.queueJobForNumber = function queueJobForNumber(number, runJ
                 if (numbers.filter(textsecure.utils.isNumberSane).length < numbers.length)
                     throw new Error("Invalid number in new group members");
 
-                if (group.numbers.filter(function(number) { return numbers.indexOf(number) < 0 }).length > 0)
-                    throw new Error("Attempted to remove numbers from group with an UPDATE");
-
                 var added = numbers.filter(function(number) { return group.numbers.indexOf(number) < 0; });
 
-                return textsecure.storage.groups.addNumbers(groupId, added).then(function(newGroup) {
-                    if (numbers.filter(function(number) { return newGroup.indexOf(number) < 0; }).length != 0 ||
-                        newGroup.filter(function(number) { return numbers.indexOf(number) < 0; }).length != 0) {
-                        throw new Error("Error calculating group member difference");
-                    }
-
-                    return added;
-                });
+                return textsecure.storage.groups.addNumbers(groupId, added);
             });
         },
 

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -345,10 +345,10 @@
                                     groupId    : dataMessage.group.id,
                                     name       : dataMessage.group.name,
                                     avatar     : dataMessage.group.avatar,
-                                    members    : dataMessage.group.members,
+                                    members    : _.union(dataMessage.group.members, conversation.get('members')),
                                 };
                                 group_update = conversation.changedAttributes(_.pick(dataMessage.group, 'name', 'avatar')) || {};
-                                var difference = _.difference(dataMessage.group.members, conversation.get('members'));
+                                var difference = _.difference(attributes.members, conversation.get('members'));
                                 if (difference.length > 0) {
                                     group_update.joined = difference;
                                 }

--- a/libtextsecure/storage/groups.js
+++ b/libtextsecure/storage/groups.js
@@ -139,19 +139,9 @@
                 if (numbers.filter(textsecure.utils.isNumberSane).length < numbers.length)
                     throw new Error("Invalid number in new group members");
 
-                if (group.numbers.filter(function(number) { return numbers.indexOf(number) < 0 }).length > 0)
-                    throw new Error("Attempted to remove numbers from group with an UPDATE");
-
                 var added = numbers.filter(function(number) { return group.numbers.indexOf(number) < 0; });
 
-                return textsecure.storage.groups.addNumbers(groupId, added).then(function(newGroup) {
-                    if (numbers.filter(function(number) { return newGroup.indexOf(number) < 0; }).length != 0 ||
-                        newGroup.filter(function(number) { return numbers.indexOf(number) < 0; }).length != 0) {
-                        throw new Error("Error calculating group member difference");
-                    }
-
-                    return added;
-                });
+                return textsecure.storage.groups.addNumbers(groupId, added);
             });
         },
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Fedora 25, Chromium 55
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
When an incoming group update is missing some of the group members we know of, just ignore these and proceed with adding members / updating group avatar and name. Previously, updateNumbers would throw an Error, so the whole group update was discarded.

Signal-Android handles this the same way in [GroupMessageProcessor.handleGroupUpdate()](https://github.com/WhisperSystems/Signal-Android/blob/a9651e2e9c1e567beb8ad53dd68207d56a35a83a/src/org/thoughtcrime/securesms/groups/GroupMessageProcessor.java#L133-L135).