### PR TITLE
Add disappearing message time of 3 weeks

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -391,6 +391,10 @@
       "message": "1 week",
       "description": "Label for a selectable option in the message expiration timer menu"
     },
+    "timerOption_3_week": {
+      "message": "3 week",
+      "description": "Label for a selectable option in the message expiration timer menu"
+    },
     "disappearingMessages": {
       "message": "Disappearing messages",
       "description": "Conversation menu option to enable disappearing messages"
@@ -441,6 +445,10 @@
     },
     "timerOption_1_week_abbreviated": {
       "message": "1w",
+      "description": "Very short format indicating current timer setting in the conversation header"
+    },
+    "timerOption_3_week_abbreviated": {
+      "message": "3w",
       "description": "Very short format indicating current timer setting in the conversation header"
     },
     "timerSetTo": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -392,7 +392,7 @@
       "description": "Label for a selectable option in the message expiration timer menu"
     },
     "timerOption_3_week": {
-      "message": "3 week",
+      "message": "3 weeks",
       "description": "Label for a selectable option in the message expiration timer menu"
     },
     "disappearingMessages": {

--- a/js/expiring_messages.js
+++ b/js/expiring_messages.js
@@ -59,6 +59,7 @@
         [ 12, 'hours'    ],
         [ 1,  'day'      ],
         [ 1,  'week'     ],
+        [ 3,  'week'     ],
     ].map(function(o) {
       var duration = moment.duration(o[0], o[1]); // 5, 'seconds'
       return {

--- a/js/expiring_messages.js
+++ b/js/expiring_messages.js
@@ -59,7 +59,7 @@
         [ 12, 'hours'    ],
         [ 1,  'day'      ],
         [ 1,  'week'     ],
-        [ 3,  'week'     ],
+        [ 3,  'weeks'     ],
     ].map(function(o) {
       var duration = moment.duration(o[0], o[1]); // 5, 'seconds'
       return {


### PR DESCRIPTION
This adds 3 weeks to the selectable times for disappearing messages.
1 week maximum is too short for certain uses.

(I added the word // FREEBIE)

- [X] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My contribution is fully baked and ready to be merged as is
- [X] My changes are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [X] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [X] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

This is the Desktop equivalent of
[WhisperSystems/Signal-Android#6219](https://github.com/WhisperSystems/Signal-Android/pull/6219)
[WhisperSystems/SignalServiceKit#115](https://github.com/WhisperSystems/SignalServiceKit/pull/115)