### PR TITLE
Add an option to destroy an individual message in the detail view

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -131,6 +131,10 @@
         "message": "Delete messages",
         "description": "Menu item for deleting messages, title case."
     },
+    "deleteMessage": {
+        "message": "Delete message",
+        "description": "Menu item for deleting a message, title case."
+    },
     "deleteConversationConfirmation": {
         "message": "Permanently delete this conversation?",
         "description": "Confirmation dialog text that asks the user if they really wish to delete the conversation. Answer buttons use the strings 'ok' and 'cancel'. The deletion is permanent, i.e. it cannot be undone."

--- a/background.html
+++ b/background.html
@@ -263,6 +263,9 @@
           </div>
         </div>
       {{ /hasConflict }}
+      <div class='info'>
+        <button class='submit destroy-message'>{{destroy-message}}</button>
+      </div>
       <div class='message-container'></div>
       <div class='info'>
         <table>

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -274,6 +274,7 @@
                 conversation: this.model
             });
             this.listenBack(view);
+            this.listenTo(view, 'back', this.resetPanel);
             view.render();
         },
 

--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -37,6 +37,9 @@
 
             this.listenTo(this.model, 'change', this.render);
         },
+        events: {
+          'click .destroy-message': 'destroy',
+        },
         contacts: function() {
             if (this.model.isIncoming()) {
                 var number = this.model.get('source');
@@ -65,6 +68,10 @@
             });
             this.$('.conflicts').append(view.el);
         },
+        destroy: function (e) {
+          this.model.destroy()
+          this.trigger('back')
+        },
         render: function() {
             this.errors = _.groupBy(this.model.get('errors'), 'number');
             var unknownErrors = this.errors['undefined'];
@@ -78,6 +85,7 @@
                 received_at : this.model.isIncoming() ? moment(this.model.get('received_at')).format('LLLL') : null,
                 tofrom      : this.model.isIncoming() ? i18n('from') : i18n('to'),
                 errors      : unknownErrors,
+                'destroy-message' : i18n('deleteMessage'),
                 title       : i18n('messageDetail'),
                 sent        : i18n('sent'),
                 received    : i18n('received'),

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -100,6 +100,9 @@
 }
 
 .message-detail {
+  .destroy-message {
+    background-color: red;
+  }
   .key-conflict-dialogue {
     border-radius: $border-radius;
     margin: 20px 0;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -999,6 +999,8 @@ input.search {
     display: inline-block;
     max-width: 100%; }
 
+.message-detail .destroy-message {
+  background-color: red; }
 .message-detail .key-conflict-dialogue {
   border-radius: 5px;
   margin: 20px 0; }

--- a/test/index.html
+++ b/test/index.html
@@ -279,6 +279,7 @@
           {{ /received_at }}
             <tr> <td class='tofrom label'>{{tofrom}}</td> </tr>
         </table>
+        <button class='grey submit delete-message'>Delete</button>
         <div class='contacts'>
         </div>
       </div>


### PR DESCRIPTION
### Contributor checklist
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
 * Amiga OS 3.1, Chrom{e,ium} Z.Y
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
This adds an option to destroy an individual message in the detail view.

The user must click into the message item and then click 'delete message.' I believe that the UX could be improved --  there could be a confirmation dialog (although there is no confirmation dialog for individual message deletion on the phone), and maybe there ought to be more padding and/or a different placement of the button.

Ideas welcome, thanks! Fixes https://github.com/WhisperSystems/Signal-Desktop/issues/303
