### PR TITLE
Update the regex to handle more link types fixes #598

### DIFF
--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -5,7 +5,7 @@
     'use strict';
     window.Whisper = window.Whisper || {};
 
-    var URL_REGEX = /(^|[\s\n]|<br\/?>)((?:https?|ftp):\/\/[\-A-Z0-9\u00A0-\uD7FF\uE000-\uFDCF\uFDF0-\uFFFD+\u0026\u2019@#\/%?=()~_|!:,.;]*[\-A-Z0-9+\u0026@#\/%=~()_|])/gi;
+    var URL_REGEX = /((?:(file|ftp|http|https|Http|Https|rtsp|Rtsp):\/\/(?:(?:[\w0-9\$\-\_\.\+\!\*\'\(\)\,\;\?\&\=]|(?:\%[\w0-9]{2})){1,64}(?:\:(?:[\w0-9\$\-\_\.\+\!\*\'\(\)\,\;\?\&\=]|(?:\%[\w0-9]{2})){1,25})?\@)?)?((?:(?:[\w0-9][\w0-9\-]{0,64}\.)+(?:(?:aero|arpa|asia|a[cdefgilmnoqrstuwxz])|(?:biz|b[abdefghijmnorstvwyz])|(?:cat|com|coop|c[acdfghiklmnoruvxyz])|d[ejkmoz]|(?:edu|e[cegrstu])|f[ijkmor]|(?:gov|g[abdefghilmnpqrstuwy])|h[kmnrtu]|(?:info|int|i[delmnoqrst])|(?:jobs|j[emop])|k[eghimnrwyz]|l[abcikrstuvy]|(?:mil|mobi|museum|m[acdghklmnopqrstuvwxyz])|(?:name|net|n[acefgilopruz])|(?:org|om)|(?:pro|p[aefghklmnrstwy])|qa|r[eouw]|s[abcdeghijklmnortuvyz]|(?:tel|travel|t[cdfghjklmnoprtvwz])|u[agkmsyz]|v[aceginu]|w[fs]|y[etu]|z[amw]))|(?:(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[1-9][0-9]|[1-9])\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[1-9][0-9]|[1-9]|0)\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[1-9][0-9]|[1-9]|0)\.(?:25[0-5]|2[0-4][0-9]|[0-1][0-9]{2}|[1-9][0-9]|[0-9])))(?:\:\d{1,5})?)(\/(?:(?:[\w0-9\;\/\?\:\@\&\=\#\~\-\.\+\!\*\'\(\)\,\_])|(?:\%[\w0-9]{2}))*)?(?:\b|$)/
 
     var ErrorIconView = Whisper.View.extend({
         templateName: 'error-icon',
@@ -233,7 +233,9 @@
 
             if (body.length > 0) {
                 var escaped = body.html();
-                body.html(escaped.replace(/\n/g, '<br>').replace(URL_REGEX, "$1<a href='$2' target='_blank'>$2</a>"));
+                escaped = escaped.replace(/\n/g, '<br>'); // create newlines
+                escaped = escaped.replace(URL_REGEX, "<a href='$&' target='_blank'>$&</a>"); // linkify URLS
+                body.html(escaped)
             }
 
             this.renderSent();

--- a/test/views/message_view_test.js
+++ b/test/views/message_view_test.js
@@ -53,8 +53,7 @@ describe('MessageView', function() {
     assert.strictEqual(div.find(view.$el).length, 0);
   });
 
-  it('allows links', function() {
-    var url = 'http://example.com';
+  function testLink (url) {
     message.set('body', url);
     var view = new Whisper.MessageView({model: message});
     view.render();
@@ -62,6 +61,26 @@ describe('MessageView', function() {
     assert.strictEqual(link.length, 1);
     assert.strictEqual(link.text(), url);
     assert.strictEqual(link.attr('href'), url);
+  }
+
+  it('allows links with parens', function() {
+    var url = 'http://example.com'
+    message.set('body', '(' + url + ')');
+    var view = new Whisper.MessageView({model: message});
+    view.render();
+    var link = view.$el.find('.body a');
+    assert.strictEqual(link.length, 1);
+    assert.strictEqual(link.text(), url);
+    assert.strictEqual(link.attr('href'), url);
+  })
+
+  it('allows links', function() {
+    testLink('http://example.com');
+    testLink('https://example.com');
+    testLink('https://sub.example.com)');
+    testLink('http://sub.example.com');
+    testLink('example.com');
+    testLink('sub.example.com');
   });
 
   it('disallows xss', function() {


### PR DESCRIPTION
### Contributor checklist
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
 * Amiga OS 3.1, Chrom{e,ium} Z.Y
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description

This fixes most of what is deemed problematic in #598, except unicode characters, which aren't part of the official spec. Got the regex from here: http://grepcode.com/file/repository.grepcode.com/java/ext/com.google.android/android/2.0_r1/android/text/util/Regex.java#Regex.0WEB_URL_PATTERN

