### PR TITLE
Change ports order to solve #1071

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -34,7 +34,7 @@
     });
 
     var SERVER_URL = 'https://textsecure-service-staging.whispersystems.org';
-    var SERVER_PORTS = [80, 4433, 8443];
+    var SERVER_PORTS = [4433, 8443, 80];
     var ATTACHMENT_SERVER_URL = 'https://whispersystems-textsecure-attachments-staging.s3.amazonaws.com';
     var messageReceiver;
     window.getSocketStatus = function() {


### PR DESCRIPTION
### First time contributor checklist
- [X] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [X ] My contribution is fully baked and ready to be merged as is
- [ X] My changes are rebased on the latest master branch
- [ X] My commits are in nice logical chunks
- [ ] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [ ] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [ ] I have tested my contribution on these platforms:
 * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
 * Amiga OS 3.1, Chrom{e,ium} Z.Y
- [ ] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [ ] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
Change ports order so that the desktop client will first try on 4433, then 8443 and finally 80 in order to solve #1071 (traffic on port 80 is usually behind a lot of proxy/firewalls and other devices which may redirect the traffic in such way that the Desktop Client keeps hitting the timeout on port 80).
