### PR TITLE
fix wobbly order of conversations

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -190,7 +190,7 @@
             if (lastMessage) {
               this.set({
                 lastMessage : lastMessage.getNotificationText(),
-                timestamp   : lastMessage.get('sent_at')
+                timestamp   : lastMessage.get('received_at')
               });
             } else {
               this.set({ lastMessage: '', timestamp: null });


### PR DESCRIPTION
The 'x timeunits' string in the conversation list corresponded to the received timestamp, while the actual order of the list corresponded to the sent timestamp. This leads to inconsistent behaviour if the sent and received stamps differ.

Fixes #812

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * W 10 Pro N, Chrome 56.0.2924.87

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->
