### PR TITLE
Improve Responsiveness on Install Screen

### DIFF
--- a/options.html
+++ b/options.html
@@ -10,66 +10,86 @@
   <div id='install' class='main'>
     <script type='text/x-tmpl-mustache' id='install_flow_template'>
       <div id='step1' class='step'>
-        <img id='signal-icon' src='/images/icon_250.png'/>
-        <div class='nav'>
-          <h1>{{ installWelcome }}</h1>
-          <p>{{ installTagline }}</p>
-          <div> <a class='button step2'>{{ installGetStartedButton }}</a> </div>
-          <span class='dot step1 selected'></span>
-          <span class='dot step2'></span>
-          <span class='dot step3'></span>
+        <div class='inner'>
+          <div class='step-body'>
+            <img id='signal-icon' src='/images/icon_250.png'/>
+          </div>
+          <div class='nav'>
+            <h1>{{ installWelcome }}</h1>
+            <p>{{ installTagline }}</p>
+            <div> <a class='button step2'>{{ installGetStartedButton }}</a> </div>
+            <span class='dot step1 selected'></span>
+            <span class='dot step2'></span>
+            <span class='dot step3'></span>
+          </div>
         </div>
       </div>
 
       <div id='step2' class='step'>
-        <img id='signal-phone' src='/images/signal-phone.png'>
-        <div class='nav'>
-          <p>{{{ installSignalLink }}}</p>
-          <div> <a class='button step3'>{{ installIHaveSignalButton }}</a> </div>
-          <span class='dot step1'></span>
-          <span class='dot step2 selected'></span>
-          <span class='dot step3'></span>
+        <div class='inner'>
+          <div class='step-body'>
+            <img id='signal-phone' src='/images/signal-phone.png'>
+            <p>{{{ installSignalLink }}}</p>
+          </div>
+          <div class='nav'>
+            <div> <a class='button step3'>{{ installIHaveSignalButton }}</a> </div>
+            <span class='dot step1'></span>
+            <span class='dot step2 selected'></span>
+            <span class='dot step3'></span>
+          </div>
         </div>
       </div>
 
       <div id='step3' class='step'>
-        <div id="qr"></div>
-        <p>{{ installAndroidInstructions }}</p>
-        <div class='nav'>
-          <span class='dot step1'></span>
-          <span class='dot step2'></span>
-          <span class='dot step3 selected'></span>
+        <div class='inner'>
+          <div class='step-body'>
+            <div id="qr"></div>
+            <p>{{ installAndroidInstructions }}</p>
+          </div>
+          <div class='nav'>
+            <span class='dot step1'></span>
+            <span class='dot step2'></span>
+            <span class='dot step3 selected'></span>
+          </div>
         </div>
       </div>
 
       <form id='step4' class='step'>
-          <p>{{ installLinkingWithNumber }}</p>
-          <h2 class='number'></h2>
-          <img id='signal-computer' src='/images/signal-laptop.png'>
-          <p>{{ installComputerName }}</p>
-          <div>
-            <input type='text' id='device-name' spellcheck='false' maxlength='50' />
+        <div class='inner'>
+          <div class='step-body'>
+            <p>{{ installLinkingWithNumber }}</p>
+            <h2 class='number'></h2>
+            <img id='signal-computer' src='/images/signal-laptop.png'>
+            <p>{{ installComputerName }}</p>
+            <div>
+              <input type='text' id='device-name' spellcheck='false' maxlength='50' />
+            </div>
           </div>
           <div class='nav'>
             <div>
               <input type='submit' class='button' id='sync' value='{{ installFinalButton }}' />
             </div>
           </div>
+        </div>
       </form>
 
       <div id='step5' class='step'>
-        <img id='signal-icon' src='/images/icon_250.png'/>
-        <div class='progress-dialog'>
-          <p class='status'></p>
-          <div class='bar-container'><div class='bar progress-bar'></div></div>
-        </div>
-        <div class='nav'>
+        <div class='inner'>
+          <div class='step-body'>
+            <img id='signal-icon' src='/images/icon_250.png'/>
+            <div class='progress-dialog'>
+              <p class='status'></p>
+              <div class='bar-container'><div class='bar progress-bar'></div></div>
+            </div>
+          </div>
+          <div class='nav'>
+          </div>
         </div>
       </div>
 
       <div id='stepTooManyDevices' class='step'>
-        <div class='error-dialog clearfix'>
-          <div class='panel'>{{ installTooManyDevices }}</div>
+        <div class='inner error-dialog clearfix'>
+          <div class='panel step-body'>{{ installTooManyDevices }}</div>
           <div class='nav'>
             <button class='ok step3'>{{ ok }}</button>
           </div>

--- a/options.html
+++ b/options.html
@@ -13,10 +13,10 @@
         <div class='inner'>
           <div class='step-body'>
             <img id='signal-icon' src='/images/icon_250.png'/>
-          </div>
-          <div class='nav'>
             <h1>{{ installWelcome }}</h1>
             <p>{{ installTagline }}</p>
+          </div>
+          <div class='nav'>
             <div> <a class='button step2'>{{ installGetStartedButton }}</a> </div>
             <span class='dot step1 selected'></span>
             <span class='dot step2'></span>

--- a/stylesheets/options.css
+++ b/stylesheets/options.css
@@ -869,13 +869,29 @@ input, button, select, textarea {
   line-height: inherit; }
 
 #install {
-  display: none; }
+  display: none;
+  height: 100%; }
+  @media screen and (max-height: 665px) {
+    #install {
+      height: 666px; } }
 
 .main {
-  padding: 70px 0 10em; }
+  padding: 70px 0 50px; }
 
 .step {
-  display: none; }
+  display: none;
+  height: 100%; }
+
+.inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  height: 100%; }
+  .inner .step-body {
+    margin-top: auto;
+    width: 100%;
+    max-width: 600px; }
 
 #signal-computer,
 #signal-phone {
@@ -907,9 +923,8 @@ a {
 
 .nav {
   width: 100%;
-  position: fixed;
   bottom: 50px;
-  margin-top: 2em;
+  margin-top: auto;
   padding: 0 20px; }
   .nav .button {
     margin-bottom: 3em; }
@@ -942,9 +957,6 @@ h1 {
   font-size: 30pt;
   font-weight: normal;
   padding-bottom: 10px; }
-
-#signal-icon {
-  margin-top: 20px; }
 
 h3.step {
   margin-top: 0;
@@ -1077,6 +1089,7 @@ ul.country-list {
 .progress-dialog {
   text-align: center;
   padding: 1em;
+  width: 100%;
   max-width: 600px;
   margin: auto; }
   .progress-dialog .status {

--- a/stylesheets/options.scss
+++ b/stylesheets/options.scss
@@ -41,12 +41,32 @@ input, button, select, textarea {
 
 #install {
   display: none;
+  height: 100%;
+
+  // 666px is the minimum window height in chromium.js
+  @media screen and (max-height: 665px) {
+    height: 666px;
+  }
 }
 .main {
-  padding: 70px 0 10em;
+  padding: 70px 0 50px;
 }
 .step {
   display: none;
+  height: 100%;
+}
+.inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  height: 100%;
+
+  .step-body {
+    margin-top: auto;
+    width: 100%;
+    max-width: 600px;
+  }
 }
 
 #signal-computer,
@@ -84,9 +104,8 @@ a {
 
 .nav {
   width: 100%;
-  position: fixed;
   bottom: 50px;
-  margin-top: 2em;
+  margin-top: auto;
   padding: 0 20px;
 
   .button {
@@ -131,10 +150,6 @@ h1 {
   font-size: 30pt;
   font-weight: normal;
   padding-bottom: 10px;
-}
-
-#signal-icon {
-  margin-top: 20px;
 }
 
 h3.step {
@@ -287,6 +302,7 @@ ul.country-list {
 .progress-dialog {
   text-align: center;
   padding: 1em;
+  width: 100%;
   max-width: 600px;
   margin: auto;
 


### PR DESCRIPTION
https://github.com/WhisperSystems/Signal-Desktop/issues/1059

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * macOS Sierra, Google Chrome 56.0.2924.87 (64-bit)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

#### Demo

Responsiveness
![image](http://g.recordit.co/iqe2sm9G2Y.gif)

Short window height
![image](http://g.recordit.co/AiBR25LU8z.gif)

#### Notes

Handles the edge case where images in the Install steps can obscure the text below them at certain window dimensions. 

In most cases, it's not possible to replicate this behavior due to minimum dimension settings in `chromium.js`. However, some window managers (such as i3) can ignore those settings, producing this bug.

This fix introduces a flexible, responsive layout to the Install steps, with the goal of keeping the action buttons in a consistent position while adapting the rest of the content to the remaining available space. The result is a clean, usable screen at any window size.

In the rare instance that a window's dimensions are less than that of the minimums set in `chromium.js`, scrollbars will appear to keep the smallest acceptable layout intact.

#### Potential side effects:

- Each `.step` element contains an`.inner` flexbox wrapper, which arranges its children in a column. The layout works best when each `flex-item` is an element that wraps the content inside of it. I believe I accounted for all the possibilities on the Install screen, but any future `.step` items might want to keep that pattern in mind.

#### Test Methods

- I removed the window restrictions by commenting [these lines](https://github.com/jonlong/Signal-Desktop/blob/responsive-install-screen/js/chromium.js#L178-L179) out of my local build.
- I tested by manually showing and hiding each `.step` element in `options.html`, and resizing the window using both the cursor and a window manager.

TODO:

- [x] Test Install process using local builds of the iOS app

Resolves #1059
