### PR TITLE
Update TextSecure Staging URL instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,9 +39,11 @@ mobile, **you must build a mobile client that targets the staging server**
 ## Linking
 
 
-0. Build Signal for Android or iOS from source, and change its `TEXTSECURE_URL` to point
-   at `textsecure-service-staging.whispersystems.org`. This task is 1% search and
-   replace, 99% setting up your build environment. Instructions are available for both
+0. Build Signal for Android or iOS from source, and point its TextSecure service URL to `textsecure-service-staging.whispersystems.org`:
+  - **on Android:** Replace the `SIGNAL_URL` value in [build.gradle](https://github.com/WhisperSystems/Signal-Android/blob/master/build.gradle)
+  - **on iOS:** Replace the `textSecureServerURL` value in `TSConstants.h`(located in the SignalServiceKit pod)
+  
+    This task is 1% search and replace, 99% setting up your build environment. Instructions are available for both
    the [Android](https://github.com/WhisperSystems/Signal-Android/blob/master/BUILDING.md)
    and [iOS](https://github.com/WhisperSystems/Signal-iOS/blob/master/BUILDING.md) projects.
 1. Upon installing the extension you will be presented with a qr code.


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

Small change to clarify where the TextSecure server URL should be updated to the staging value in local builds. 

Ran into this one when building a local version of the iOS app for testing desktop linking in #1097. 

It looks like the Android variable has been updated from `TEXTSECURE_URL` to `SIGNAL_URL` (https://github.com/WhisperSystems/Signal-Android/commit/ae40715526aa0fbad583783be63115bb46b1c2c8#diff-c197962302397baf3a4cc36463dce5eaR179) and the iOS counterpart is named `textSecureServerURL`.

### Question 

Should the `textSecureWebSocketAPI` value on iOS be updated as well in this case? FWIW I didn't see a counterpart to that in the Android repo.

FREEBIE