### PR TITLE
search: adjust overlay clear icon

### DIFF
--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -134,11 +134,11 @@ input.search {
     background-size: $search-x-size;
 
     &.ltr {
-      background-position : right $search-padding-right center;
+      background-position : right $search-padding-right + 3px center;
     }
 
     &.rtl {
-      background-position : left $search-padding-left center;
+      background-position : left $search-padding-left + 3px center;
     }
   }
 

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -832,9 +832,9 @@ input.search {
     background-repeat: no-repeat;
     background-size: 16px; }
     input.search.active.ltr {
-      background-position: right 10px center; }
+      background-position: right 13px center; }
     input.search.active.rtl {
-      background-position: left 65px center; }
+      background-position: left 68px center; }
   input.search::-webkit-search-cancel-button {
     -webkit-appearance: none;
     display: block;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Linux, Chromium 58.0.3029.81
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description

In PR #1114, a second overlay clear icon has been introduced. This is misaligned on (at least) Linux (#1136).

Somebody needs to test this on MacOS - the committer of PR #1114 used a Mac, so maybe it is only broken on Linux?