### PR TITLE
replace webkit-search-cancel-button pseudo-element with a button.

### DIFF
--- a/background.html
+++ b/background.html
@@ -22,6 +22,7 @@
           <div class='tool-bar clearfix'>
             <input type='search' class='search' placeholder='{{ searchForPeopleOrGroups }}' dir='auto'>
             <span class='search-icon'></span>
+            <button class='clear-search'></span>
           </div>
         </div>
         <div class='content'>

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -105,6 +105,7 @@
             this.listenTo(this.searchView, 'hide', function() {
                 this.searchView.$el.hide();
                 this.inboxListView.$el.show();
+                this.$('.clear-search').hide();
             });
             this.listenTo(this.searchView, 'show', function() {
                 this.searchView.$el.show();
@@ -144,7 +145,8 @@
             'select .gutter .conversation-list-item': 'openConversation',
             'input input.search': 'filterContacts',
             'click .restart-signal': 'reloadBackgroundPage',
-            'show .lightbox': 'showLightbox'
+            'show .lightbox': 'showLightbox',
+            'click .clear-search' : 'resetTypeahead',
         },
         focusConversation: function(e) {
             if (e && this.$(e.target).closest('.placeholder').length) {
@@ -170,8 +172,10 @@
         filterContacts: function(e) {
             this.searchView.filterContacts(e);
             var input = this.$('input.search');
+            var closeButton = this.$('.clear-search');
             if (input.val().length > 0) {
                 input.addClass('active');
+                closeButton.show();
                 var textDir = window.getComputedStyle(input[0]).direction;
                 if (textDir === 'ltr') {
                     input.removeClass('rtl').addClass('ltr');
@@ -180,6 +184,7 @@
                 }
             } else {
                 input.removeClass('active');
+                closeButton.hide();
             }
         },
         openConversation: function(e, conversation) {
@@ -190,6 +195,9 @@
         },
         toggleMenu: function() {
             this.$('.global-menu .menu-list').toggle();
+        },
+        resetTypeahead: function() {
+            this.searchView.reset();
         },
         showDebugLog: function() {
             this.$('.debug-log').remove();

--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -112,6 +112,21 @@
     left: 20px;
     top: 0;
   }
+
+  .clear-search {
+    content: '';
+    display: none;
+    float: right;
+    width: 24px;
+    height: 100%;
+    -webkit-mask: url('/images/x.svg') no-repeat left center;
+    -webkit-mask-size: 100%;
+    position: absolute;
+    right: 20px;
+    top: 0;
+    cursor: pointer;
+  }
+
 }
 
 input.search {
@@ -129,31 +144,12 @@ input.search {
 
   &.active {
     outline: solid 1px $blue;
-    background-image: url('/images/x.svg');
-    background-repeat: no-repeat;
-    background-size: $search-x-size;
-
-    &.ltr {
-      background-position : right $search-padding-right center;
-    }
-
-    &.rtl {
-      background-position : left $search-padding-left center;
-    }
   }
 
   &::-webkit-search-cancel-button {
-    -webkit-appearance: none;
-    display: block;
-    width: $search-x-size;
-    height: $search-x-size;
-    background: url('/images/x.svg') no-repeat center;
-    background-size: cover;
+    -webkit-appearance: none !important;
   }
 
-  &::-webkit-search-cancel-button:hover {
-    cursor: pointer;
-  }
 }
 
 .last-timestamp {

--- a/stylesheets/_ios.scss
+++ b/stylesheets/_ios.scss
@@ -35,6 +35,11 @@ $ios-border-color: rgba(0,0,0,0.1);
   .tool-bar {
     float: left;
     padding: 15px;
+
+    .clear-search {
+        background-color: #000;
+    }
+
   }
   input[type=text]:active,
   input[type=text]:focus,
@@ -52,9 +57,6 @@ $ios-border-color: rgba(0,0,0,0.1);
     padding-left: $search-padding-left-ios;
     line-height: 34px;
     background-color: #dddddd;
-    &.active.rtl {
-      background-position : left $search-padding-left-ios center;
-    }
   }
   .conversation-header {
     background-color: $grey_l;

--- a/stylesheets/android-dark.scss
+++ b/stylesheets/android-dark.scss
@@ -112,13 +112,6 @@ $text-dark: #CCCCCC;
     background-color: $grey-dark_l3;
     border-color: $grey-dark_l2;
     @include invert-text-color;
-    &::-webkit-search-cancel-button {
-      background: url('/images/x_white.svg') no-repeat center;
-      background-size: cover;
-    }
-    &.active.ltr, &.active.rtl {
-      background-image: url('/images/x_white.svg');
-    }
   }
   .bubble {
     padding: 9px 12px;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -813,6 +813,18 @@ img.emoji {
     position: absolute;
     left: 20px;
     top: 0; }
+  .tool-bar .clear-search {
+    content: '';
+    display: none;
+    float: right;
+    width: 24px;
+    height: 100%;
+    -webkit-mask: url("/images/x.svg") no-repeat left center;
+    -webkit-mask-size: 100%;
+    position: absolute;
+    right: 20px;
+    top: 0;
+    cursor: pointer; }
 
 input.search {
   border: none;
@@ -827,23 +839,9 @@ input.search {
   font-size: inherit;
   position: relative; }
   input.search.active {
-    outline: solid 1px #2090ea;
-    background-image: url("/images/x.svg");
-    background-repeat: no-repeat;
-    background-size: 16px; }
-    input.search.active.ltr {
-      background-position: right 10px center; }
-    input.search.active.rtl {
-      background-position: left 65px center; }
+    outline: solid 1px #2090ea; }
   input.search::-webkit-search-cancel-button {
-    -webkit-appearance: none;
-    display: block;
-    width: 16px;
-    height: 16px;
-    background: url("/images/x.svg") no-repeat center;
-    background-size: cover; }
-  input.search::-webkit-search-cancel-button:hover {
-    cursor: pointer; }
+    -webkit-appearance: none !important; }
 
 .last-timestamp {
   font-size: smaller;
@@ -1487,6 +1485,8 @@ li.entry .error-icon-container {
 .ios .tool-bar {
   float: left;
   padding: 15px; }
+  .ios .tool-bar .clear-search {
+    background-color: #000; }
 .ios input[type=text]:active,
 .ios input[type=text]:focus,
 .ios input[type=search]:active,
@@ -1502,8 +1502,6 @@ li.entry .error-icon-container {
   padding-left: 30px;
   line-height: 34px;
   background-color: #dddddd; }
-  .ios input.search.active.rtl {
-    background-position: left 30px center; }
 .ios .conversation-header {
   background-color: #f3f3f3;
   color: #454545;
@@ -1881,11 +1879,6 @@ li.entry .error-icon-container {
     .android-dark .search::selection {
       background: white;
       color: #454545; }
-    .android-dark .search::-webkit-search-cancel-button {
-      background: url("/images/x_white.svg") no-repeat center;
-      background-size: cover; }
-    .android-dark .search.active.ltr, .android-dark .search.active.rtl {
-      background-image: url("/images/x_white.svg"); }
   .android-dark .bubble {
     padding: 9px 12px;
     border-radius: 5px;


### PR DESCRIPTION
Fixes issue of breakign alignment on the pseudo-element and background-image on conversation search box
//FREEBIE

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 *  macOS 10.12.4, Chromium 60.0.3089.0 (Developer Build) (64-bit)
 * macOS 10.12.4, , Chrome 58.0.3029.96 (64-bit)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
This is an attempt at fixing the same bug #1136  that another recent pull request, #1140, addressed. I did some research and the input field uses a psuedo-element '::-webkit-search-cancel-button' which is "non-standard and is not on a standards track. Do not use it on production sites facing the Web: it will not work for every user" ([mozilla developers reference](https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-search-cancel-button)). I don't think there is a safe way to know where the psuedo-element will be on the screen across different browsers, OSes, and versions. So, trying to line it up with a background-image seems futile! as does maintaining it going forward. In this pull request, I replaced it with a button. I'm definitely a first-time contributor and v new to backbone, so any feedback would be appreciated. 

Another possible simpler solution, which is less complicated, would just be to revert PR #1114, and suffer a ~ little ~ ui niceness.