### PR TITLE
Add support for opening the inbox via a keyboard shortcut - fixes #1134.

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -335,5 +335,10 @@
         }
     });
 
+    chrome.commands.onCommand.addListener(function(command) {
+        if (command === 'show_signal') {
+            openInbox();
+        }
+    });
 
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -30,5 +30,15 @@
       "background": {
           "page": "background.html"
       }
+    },
+
+    "commands": {
+      "show_signal": {
+        "suggested_key": {
+          "default": "Alt+S"
+        },
+        "description": "Show the Signal inbox."
+      }
     }
+
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Arch Linux - Chrome Version 58.0.3029.81 (64-bit)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them
----------------------------------------
This change adds support for opening the inbox via a user-defined shortcut (defaulting to Alt+S, if available) and fixes #1134.
