### PR TITLE
Bring file attachments on-theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/curve25519_compiled.js
 stylesheets/*.css.map
 dist
 .tx
+.DS_Store

--- a/background.html
+++ b/background.html
@@ -152,8 +152,11 @@
         <a class='x close' alt='remove attachment' href='#'></a>
   </script>
   <script type='text/x-tmpl-mustache' id='file-view'>
-    <span class='icon'></span>
-    <span class='fileName' alt='{{ fileName }}' title='{{ altText }}'>{{ fileName }}</a>
+    <div class='icon'></div>
+    <div class='text'>
+      <div class='fileName' alt='{{ fileName }}' title='{{ altText }}'>{{ fileName }}</div>
+      <div class='fileSize'>{{ fileSize }}</div>
+    </div>
   </script>
   <script type='text/x-tmpl-mustache' id='hasRetry'>
     {{ messageNotSent }}

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,8 @@
     "emojidata": "https://github.com/iamcal/emoji-data.git",
     "autosize": "~3.0.6",
     "webaudiorecorder": "https://github.com/higuma/web-audio-recorder-js.git",
-    "mp3lameencoder": "https://github.com/higuma/mp3-lame-encoder-js.git"
+    "mp3lameencoder": "https://github.com/higuma/mp3-lame-encoder-js.git",
+    "filesize": "https://github.com/avoidwork/filesize.js.git"
   },
   "devDependencies": {
     "mocha": "~2.0.1",
@@ -99,6 +100,9 @@
     ],
     "mp3lameencoder": [
       "lib/Mp3LameEncoder.js"
+    ],
+    "filesize": [
+      "lib/filesize.js"
     ]
   },
   "concat": {
@@ -119,7 +123,8 @@
       "blueimp-load-image",
       "blueimp-canvas-to-blob",
       "emojijs",
-      "autosize"
+      "autosize",
+      "filesize"
     ],
     "libtextsecure": [
       "long",

--- a/components/filesize/lib/filesize.js
+++ b/components/filesize/lib/filesize.js
@@ -1,0 +1,167 @@
+"use strict";
+
+/**
+ * filesize
+ *
+ * @copyright 2017 Jason Mulligan <jason.mulligan@avoidwork.com>
+ * @license BSD-3-Clause
+ * @version 3.5.9
+ */
+(function (global) {
+	var b = /^(b|B)$/,
+	    symbol = {
+		iec: {
+			bits: ["b", "Kib", "Mib", "Gib", "Tib", "Pib", "Eib", "Zib", "Yib"],
+			bytes: ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
+		},
+		jedec: {
+			bits: ["b", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"],
+			bytes: ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+		}
+	},
+	    fullform = {
+		iec: ["", "kibi", "mebi", "gibi", "tebi", "pebi", "exbi", "zebi", "yobi"],
+		jedec: ["", "kilo", "mega", "giga", "tera", "peta", "exa", "zetta", "yotta"]
+	};
+
+	/**
+  * filesize
+  *
+  * @method filesize
+  * @param  {Mixed}   arg        String, Int or Float to transform
+  * @param  {Object}  descriptor [Optional] Flags
+  * @return {String}             Readable file size String
+  */
+	function filesize(arg) {
+		var descriptor = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+		var result = [],
+		    val = 0,
+		    e = void 0,
+		    base = void 0,
+		    bits = void 0,
+		    ceil = void 0,
+		    full = void 0,
+		    fullforms = void 0,
+		    neg = void 0,
+		    num = void 0,
+		    output = void 0,
+		    round = void 0,
+		    unix = void 0,
+		    spacer = void 0,
+		    standard = void 0,
+		    symbols = void 0;
+
+		if (isNaN(arg)) {
+			throw new Error("Invalid arguments");
+		}
+
+		bits = descriptor.bits === true;
+		unix = descriptor.unix === true;
+		base = descriptor.base || 2;
+		round = descriptor.round !== undefined ? descriptor.round : unix ? 1 : 2;
+		spacer = descriptor.spacer !== undefined ? descriptor.spacer : unix ? "" : " ";
+		symbols = descriptor.symbols || descriptor.suffixes || {};
+		standard = base === 2 ? descriptor.standard || "jedec" : "jedec";
+		output = descriptor.output || "string";
+		full = descriptor.fullform === true;
+		fullforms = descriptor.fullforms instanceof Array ? descriptor.fullforms : [];
+		e = descriptor.exponent !== undefined ? descriptor.exponent : -1;
+		num = Number(arg);
+		neg = num < 0;
+		ceil = base > 2 ? 1000 : 1024;
+
+		// Flipping a negative number to determine the size
+		if (neg) {
+			num = -num;
+		}
+
+		// Determining the exponent
+		if (e === -1 || isNaN(e)) {
+			e = Math.floor(Math.log(num) / Math.log(ceil));
+
+			if (e < 0) {
+				e = 0;
+			}
+		}
+
+		// Exceeding supported length, time to reduce & multiply
+		if (e > 8) {
+			e = 8;
+		}
+
+		// Zero is now a special case because bytes divide by 1
+		if (num === 0) {
+			result[0] = 0;
+			result[1] = unix ? "" : symbol[standard][bits ? "bits" : "bytes"][e];
+		} else {
+			val = num / (base === 2 ? Math.pow(2, e * 10) : Math.pow(1000, e));
+
+			if (bits) {
+				val = val * 8;
+
+				if (val >= ceil && e < 8) {
+					val = val / ceil;
+					e++;
+				}
+			}
+
+			result[0] = Number(val.toFixed(e > 0 ? round : 0));
+			result[1] = base === 10 && e === 1 ? bits ? "kb" : "kB" : symbol[standard][bits ? "bits" : "bytes"][e];
+
+			if (unix) {
+				result[1] = standard === "jedec" ? result[1].charAt(0) : e > 0 ? result[1].replace(/B$/, "") : result[1];
+
+				if (b.test(result[1])) {
+					result[0] = Math.floor(result[0]);
+					result[1] = "";
+				}
+			}
+		}
+
+		// Decorating a 'diff'
+		if (neg) {
+			result[0] = -result[0];
+		}
+
+		// Applying custom symbol
+		result[1] = symbols[result[1]] || result[1];
+
+		// Returning Array, Object, or String (default)
+		if (output === "array") {
+			return result;
+		}
+
+		if (output === "exponent") {
+			return e;
+		}
+
+		if (output === "object") {
+			return { value: result[0], suffix: result[1], symbol: result[1] };
+		}
+
+		if (full) {
+			result[1] = fullforms[e] ? fullforms[e] : fullform[standard][e] + (bits ? "bit" : "byte") + (result[0] === 1 ? "" : "s");
+		}
+
+		return result.join(spacer);
+	}
+
+	// Partial application for functional programming
+	filesize.partial = function (opt) {
+		return function (arg) {
+			return filesize(arg, opt);
+		};
+	};
+
+	// CommonJS, AMD, script tag
+	if (typeof exports !== "undefined") {
+		module.exports = filesize;
+	} else if (typeof define === "function" && define.amd) {
+		define(function () {
+			return filesize;
+		});
+	} else {
+		global.filesize = filesize;
+	}
+})(typeof window !== "undefined" ? window : global);

--- a/js/components.js
+++ b/js/components.js
@@ -39227,6 +39227,174 @@ JSON.stringify(result);
 
 	module.exports = autosize;
 });
+"use strict";
+
+/**
+ * filesize
+ *
+ * @copyright 2017 Jason Mulligan <jason.mulligan@avoidwork.com>
+ * @license BSD-3-Clause
+ * @version 3.5.9
+ */
+(function (global) {
+	var b = /^(b|B)$/,
+	    symbol = {
+		iec: {
+			bits: ["b", "Kib", "Mib", "Gib", "Tib", "Pib", "Eib", "Zib", "Yib"],
+			bytes: ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
+		},
+		jedec: {
+			bits: ["b", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"],
+			bytes: ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+		}
+	},
+	    fullform = {
+		iec: ["", "kibi", "mebi", "gibi", "tebi", "pebi", "exbi", "zebi", "yobi"],
+		jedec: ["", "kilo", "mega", "giga", "tera", "peta", "exa", "zetta", "yotta"]
+	};
+
+	/**
+  * filesize
+  *
+  * @method filesize
+  * @param  {Mixed}   arg        String, Int or Float to transform
+  * @param  {Object}  descriptor [Optional] Flags
+  * @return {String}             Readable file size String
+  */
+	function filesize(arg) {
+		var descriptor = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+		var result = [],
+		    val = 0,
+		    e = void 0,
+		    base = void 0,
+		    bits = void 0,
+		    ceil = void 0,
+		    full = void 0,
+		    fullforms = void 0,
+		    neg = void 0,
+		    num = void 0,
+		    output = void 0,
+		    round = void 0,
+		    unix = void 0,
+		    spacer = void 0,
+		    standard = void 0,
+		    symbols = void 0;
+
+		if (isNaN(arg)) {
+			throw new Error("Invalid arguments");
+		}
+
+		bits = descriptor.bits === true;
+		unix = descriptor.unix === true;
+		base = descriptor.base || 2;
+		round = descriptor.round !== undefined ? descriptor.round : unix ? 1 : 2;
+		spacer = descriptor.spacer !== undefined ? descriptor.spacer : unix ? "" : " ";
+		symbols = descriptor.symbols || descriptor.suffixes || {};
+		standard = base === 2 ? descriptor.standard || "jedec" : "jedec";
+		output = descriptor.output || "string";
+		full = descriptor.fullform === true;
+		fullforms = descriptor.fullforms instanceof Array ? descriptor.fullforms : [];
+		e = descriptor.exponent !== undefined ? descriptor.exponent : -1;
+		num = Number(arg);
+		neg = num < 0;
+		ceil = base > 2 ? 1000 : 1024;
+
+		// Flipping a negative number to determine the size
+		if (neg) {
+			num = -num;
+		}
+
+		// Determining the exponent
+		if (e === -1 || isNaN(e)) {
+			e = Math.floor(Math.log(num) / Math.log(ceil));
+
+			if (e < 0) {
+				e = 0;
+			}
+		}
+
+		// Exceeding supported length, time to reduce & multiply
+		if (e > 8) {
+			e = 8;
+		}
+
+		// Zero is now a special case because bytes divide by 1
+		if (num === 0) {
+			result[0] = 0;
+			result[1] = unix ? "" : symbol[standard][bits ? "bits" : "bytes"][e];
+		} else {
+			val = num / (base === 2 ? Math.pow(2, e * 10) : Math.pow(1000, e));
+
+			if (bits) {
+				val = val * 8;
+
+				if (val >= ceil && e < 8) {
+					val = val / ceil;
+					e++;
+				}
+			}
+
+			result[0] = Number(val.toFixed(e > 0 ? round : 0));
+			result[1] = base === 10 && e === 1 ? bits ? "kb" : "kB" : symbol[standard][bits ? "bits" : "bytes"][e];
+
+			if (unix) {
+				result[1] = standard === "jedec" ? result[1].charAt(0) : e > 0 ? result[1].replace(/B$/, "") : result[1];
+
+				if (b.test(result[1])) {
+					result[0] = Math.floor(result[0]);
+					result[1] = "";
+				}
+			}
+		}
+
+		// Decorating a 'diff'
+		if (neg) {
+			result[0] = -result[0];
+		}
+
+		// Applying custom symbol
+		result[1] = symbols[result[1]] || result[1];
+
+		// Returning Array, Object, or String (default)
+		if (output === "array") {
+			return result;
+		}
+
+		if (output === "exponent") {
+			return e;
+		}
+
+		if (output === "object") {
+			return { value: result[0], suffix: result[1], symbol: result[1] };
+		}
+
+		if (full) {
+			result[1] = fullforms[e] ? fullforms[e] : fullform[standard][e] + (bits ? "bit" : "byte") + (result[0] === 1 ? "" : "s");
+		}
+
+		return result.join(spacer);
+	}
+
+	// Partial application for functional programming
+	filesize.partial = function (opt) {
+		return function (arg) {
+			return filesize(arg, opt);
+		};
+	};
+
+	// CommonJS, AMD, script tag
+	if (typeof exports !== "undefined") {
+		module.exports = filesize;
+	} else if (typeof define === "function" && define.amd) {
+		define(function () {
+			return filesize;
+		});
+	} else {
+		global.filesize = filesize;
+	}
+})(typeof window !== "undefined" ? window : global);
+
 (function(window) {
   // internal: same as jQuery.extend(true, args...)
   var extend = function() {

--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -9,10 +9,7 @@
       className: 'fileView',
       templateName: 'file-view',
       render_attributes: function() {
-        return {
-            fileName : this.model.fileName,
-            altText  : i18n('unsupportedAttachment')
-        };
+        return this.model;
       }
   });
 
@@ -163,7 +160,14 @@
         this.renderFileView();
     },
     renderFileView: function() {
-        this.view = new FileView({model: {fileName: this.suggestedName()}});
+        this.view = new FileView({
+          model: {
+            fileName: this.suggestedName(),
+            fileSize: window.filesize(this.model.size),
+            altText: i18n('unsupportedAttachment')
+          }
+        });
+
         this.view.$el.appendTo(this.$el.empty());
         this.view.render();
         this.update();

--- a/stylesheets/_android.scss
+++ b/stylesheets/_android.scss
@@ -37,6 +37,10 @@
     @include hourglass(#fff);
   }
 
+  .attachments .fileView {
+    margin-bottom: 0.5em;
+  }
+
   .incoming .bubble {
     .sender, .content, .body, .meta, a {
       @include invert-text-color;

--- a/stylesheets/_android.scss
+++ b/stylesheets/_android.scss
@@ -37,12 +37,8 @@
     @include hourglass(#fff);
   }
 
-  .attachments .fileView {
-    margin-bottom: 0.5em;
-  }
-
   .incoming .bubble {
-    .sender, .content, .body, .meta, a {
+    .sender, .content, .body, .meta, a, .fileView {
       @include invert-text-color;
     }
     .attachments, .content {
@@ -51,6 +47,11 @@
       }
     }
   }
+
+  .incoming .bubble .fileView .icon::before {
+    @include color-svg('/images/file.svg', white);
+  }
+
   button.clock {
     @include header-icon-white('/images/clock.svg');
   }

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -491,6 +491,7 @@ li.entry .error-icon-container {
       }
 
       .icon {
+        margin-left: -0.5em;
         display: inline-block;
         vertical-align: middle;
         &:before {

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -466,21 +466,30 @@ li.entry .error-icon-container {
     }
 
     .fileView {
+      display: flex;
+      align-items: center;
+
       position: relative;
       padding: 5px;
       padding-right: 10px;
+
       background-color: #fafafa;
       border: 1px solid $grey_l2;
       border-radius: $border-radius;
       cursor: pointer;
       color: $grey_d;
 
-      .icon, .fileName {
+      .fileName {
+        font-weight: bold;
+        margin-bottom: 0.25em;
+      }
+
+      .icon, .text {
         opacity: 0.75;
       }
 
       &:hover {
-        .icon, .fileName {
+        .icon, .text {
           opacity: 1.0;
         }
       }
@@ -491,8 +500,8 @@ li.entry .error-icon-container {
         &:before {
           content: '';
           display: inline-block;
-          width: $button-height;
-          height: $button-height;
+          width: $button-height * 2;
+          height: $button-height * 2;
           @include color-svg('/images/file.svg', black);
         }
       }

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -473,11 +473,7 @@ li.entry .error-icon-container {
       padding: 5px;
       padding-right: 10px;
 
-      background-color: #fafafa;
-      border: 1px solid $grey_l2;
-      border-radius: $border-radius;
       cursor: pointer;
-      color: $grey_d;
 
       .fileName {
         font-weight: bold;

--- a/stylesheets/_ios.scss
+++ b/stylesheets/_ios.scss
@@ -85,6 +85,37 @@ $ios-border-color: rgba(0,0,0,0.1);
   .control .content {
     padding: 10px;
   }
+
+
+  .message-list .attachments .fileView {
+    border-radius: 15px;
+    margin-bottom: 0.25em;
+
+    padding: 10px;
+    position: relative;
+
+    &:before, &:after {
+      content: '';
+      display: block;
+      border-radius: 20px;
+      position: absolute;
+      width: 10px;
+    }
+    &:before {
+      right: -1px;
+      bottom: -3px;
+      height: 10px;
+      border-radius: 20px;
+      background: $blue;
+    }
+    &:after {
+      height: 11px;
+      right: -6px;
+      bottom: -3px;
+      background: white;
+    }
+  }
+
   .bubble {
     .content {
       margin-bottom: 5px;
@@ -126,6 +157,21 @@ $ios-border-color: rgba(0,0,0,0.1);
       clear: both;
     }
   }
+
+  .message-list .incoming .attachment .fileView {
+    background-color: #e6e5ea;
+    color: black;
+    float: left;
+
+    &:before {
+      left: -1px;
+      background-color: #e6e5ea;
+    }
+    &:after {
+      left: -6px;
+    }
+  }
+
   .incoming .content {
     background-color: #e6e5ea;
     color: black;
@@ -141,7 +187,7 @@ $ios-border-color: rgba(0,0,0,0.1);
     }
   }
   .outgoing {
-    .content {
+    .content, .attachments .fileView {
       background-color: $blue;
       &, .body, a {
         @include invert-text-color;
@@ -149,6 +195,11 @@ $ios-border-color: rgba(0,0,0,0.1);
       float: right;
     }
   }
+
+  .outgoing .attachments .fileView .icon::before {
+    @include color-svg('/images/file.svg', white);
+  }
+
   .attachment {
     a {
       border-radius: 15px;

--- a/stylesheets/android-dark.scss
+++ b/stylesheets/android-dark.scss
@@ -138,6 +138,10 @@ $text-dark: #CCCCCC;
     @include hourglass(#fff);
   }
 
+  .attachments .fileView {
+    margin-bottom: 0.5em;
+  }
+
   .incoming .bubble {
     .sender, .content, .body, .meta, a {
       @include invert-text-color;

--- a/stylesheets/android-dark.scss
+++ b/stylesheets/android-dark.scss
@@ -138,20 +138,25 @@ $text-dark: #CCCCCC;
     @include hourglass(#fff);
   }
 
-  .attachments .fileView {
-    margin-bottom: 0.5em;
-  }
-
   .incoming .bubble {
-    .sender, .content, .body, .meta, a {
+    .sender, .content, .body, .meta, a, .fileView {
       @include invert-text-color;
     }
-    .attachments, .content {
+    .content {
       a {
         color: $grey_l;
       }
     }
   }
+
+  .incoming .bubble .fileView .icon::before {
+    @include color-svg('/images/file.svg', white);
+  }
+
+  .outgoing .bubble .fileView .icon::before {
+    @include color-svg('/images/file.svg', #CCCCCC);
+  }
+
   button.clock {
     @include header-icon-white('/images/clock.svg');
   }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1335,6 +1335,7 @@ li.entry .error-icon-container {
       opacity: 1.0; }
     .message-container .attachments .fileView .icon,
     .message-list .attachments .fileView .icon {
+      margin-left: -0.5em;
       display: inline-block;
       vertical-align: middle; }
       .message-container .attachments .fileView .icon:before,

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1703,6 +1703,8 @@ li.entry .error-icon-container {
     -webkit-mask: url("/images/hourglass_empty.svg") no-repeat center;
     -webkit-mask-size: 100%;
     background-color: #fff; }
+.android .attachments .fileView {
+  margin-bottom: 0.5em; }
 .android .incoming .bubble .sender, .android .incoming .bubble .content, .android .incoming .bubble .body, .android .incoming .bubble .meta, .android .incoming .bubble a {
   color: white; }
   .android .incoming .bubble .sender::selection, .android .incoming .bubble .content::selection, .android .incoming .bubble .body::selection, .android .incoming .bubble .meta::selection, .android .incoming .bubble a::selection {
@@ -1947,6 +1949,8 @@ li.entry .error-icon-container {
       -webkit-mask: url("/images/hourglass_empty.svg") no-repeat center;
       -webkit-mask-size: 100%;
       background-color: #fff; }
+  .android-dark .attachments .fileView {
+    margin-bottom: 0.5em; }
   .android-dark .incoming .bubble .sender, .android-dark .incoming .bubble .content, .android-dark .incoming .bubble .body, .android-dark .incoming .bubble .meta, .android-dark .incoming .bubble a {
     color: white; }
     .android-dark .incoming .bubble .sender::selection, .android-dark .incoming .bubble .content::selection, .android-dark .incoming .bubble .body::selection, .android-dark .incoming .bubble .meta::selection, .android-dark .incoming .bubble a::selection {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1735,15 +1735,17 @@ li.entry .error-icon-container {
     -webkit-mask: url("/images/hourglass_empty.svg") no-repeat center;
     -webkit-mask-size: 100%;
     background-color: #fff; }
-.android .attachments .fileView {
-  margin-bottom: 0.5em; }
-.android .incoming .bubble .sender, .android .incoming .bubble .content, .android .incoming .bubble .body, .android .incoming .bubble .meta, .android .incoming .bubble a {
+.android .incoming .bubble .sender, .android .incoming .bubble .content, .android .incoming .bubble .body, .android .incoming .bubble .meta, .android .incoming .bubble a, .android .incoming .bubble .fileView {
   color: white; }
-  .android .incoming .bubble .sender::selection, .android .incoming .bubble .content::selection, .android .incoming .bubble .body::selection, .android .incoming .bubble .meta::selection, .android .incoming .bubble a::selection {
+  .android .incoming .bubble .sender::selection, .android .incoming .bubble .content::selection, .android .incoming .bubble .body::selection, .android .incoming .bubble .meta::selection, .android .incoming .bubble a::selection, .android .incoming .bubble .fileView::selection {
     background: white;
     color: #454545; }
 .android .incoming .bubble .attachments a, .android .incoming .bubble .content a {
   color: #f3f3f3; }
+.android .incoming .bubble .fileView .icon::before {
+  -webkit-mask: url("/images/file.svg") no-repeat center;
+  -webkit-mask-size: 100%;
+  background-color: white; }
 .android button.clock {
   -webkit-mask: url("/images/clock.svg") no-repeat center;
   -webkit-mask-size: 100%;
@@ -1981,15 +1983,21 @@ li.entry .error-icon-container {
       -webkit-mask: url("/images/hourglass_empty.svg") no-repeat center;
       -webkit-mask-size: 100%;
       background-color: #fff; }
-  .android-dark .attachments .fileView {
-    margin-bottom: 0.5em; }
-  .android-dark .incoming .bubble .sender, .android-dark .incoming .bubble .content, .android-dark .incoming .bubble .body, .android-dark .incoming .bubble .meta, .android-dark .incoming .bubble a {
+  .android-dark .incoming .bubble .sender, .android-dark .incoming .bubble .content, .android-dark .incoming .bubble .body, .android-dark .incoming .bubble .meta, .android-dark .incoming .bubble a, .android-dark .incoming .bubble .fileView {
     color: white; }
-    .android-dark .incoming .bubble .sender::selection, .android-dark .incoming .bubble .content::selection, .android-dark .incoming .bubble .body::selection, .android-dark .incoming .bubble .meta::selection, .android-dark .incoming .bubble a::selection {
+    .android-dark .incoming .bubble .sender::selection, .android-dark .incoming .bubble .content::selection, .android-dark .incoming .bubble .body::selection, .android-dark .incoming .bubble .meta::selection, .android-dark .incoming .bubble a::selection, .android-dark .incoming .bubble .fileView::selection {
       background: white;
       color: #454545; }
-  .android-dark .incoming .bubble .attachments a, .android-dark .incoming .bubble .content a {
+  .android-dark .incoming .bubble .content a {
     color: #f3f3f3; }
+  .android-dark .incoming .bubble .fileView .icon::before {
+    -webkit-mask: url("/images/file.svg") no-repeat center;
+    -webkit-mask-size: 100%;
+    background-color: white; }
+  .android-dark .outgoing .bubble .fileView .icon::before {
+    -webkit-mask: url("/images/file.svg") no-repeat center;
+    -webkit-mask-size: 100%;
+    background-color: #CCCCCC; }
   .android-dark button.clock {
     -webkit-mask: url("/images/clock.svg") no-repeat center;
     -webkit-mask-size: 100%;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1320,11 +1320,7 @@ li.entry .error-icon-container {
     position: relative;
     padding: 5px;
     padding-right: 10px;
-    background-color: #fafafa;
-    border: 1px solid #d9d9d9;
-    border-radius: 5px;
-    cursor: pointer;
-    color: #454545; }
+    cursor: pointer; }
     .message-container .attachments .fileView .fileName,
     .message-list .attachments .fileView .fileName {
       font-weight: bold;
@@ -1532,6 +1528,28 @@ li.entry .error-icon-container {
 .ios .error-message.content,
 .ios .control .content {
   padding: 10px; }
+.ios .message-list .attachments .fileView {
+  border-radius: 15px;
+  margin-bottom: 0.25em;
+  padding: 10px;
+  position: relative; }
+  .ios .message-list .attachments .fileView:before, .ios .message-list .attachments .fileView:after {
+    content: '';
+    display: block;
+    border-radius: 20px;
+    position: absolute;
+    width: 10px; }
+  .ios .message-list .attachments .fileView:before {
+    right: -1px;
+    bottom: -3px;
+    height: 10px;
+    border-radius: 20px;
+    background: #2090ea; }
+  .ios .message-list .attachments .fileView:after {
+    height: 11px;
+    right: -6px;
+    bottom: -3px;
+    background: white; }
 .ios .bubble .content {
   margin-bottom: 5px; }
   .ios .bubble .content .body {
@@ -1562,6 +1580,15 @@ li.entry .error-icon-container {
   border: 1px solid rgba(0, 0, 0, 0.1); }
 .ios .bubble .meta {
   clear: both; }
+.ios .message-list .incoming .attachment .fileView {
+  background-color: #e6e5ea;
+  color: black;
+  float: left; }
+  .ios .message-list .incoming .attachment .fileView:before {
+    left: -1px;
+    background-color: #e6e5ea; }
+  .ios .message-list .incoming .attachment .fileView:after {
+    left: -6px; }
 .ios .incoming .content {
   background-color: #e6e5ea;
   color: black;
@@ -1571,14 +1598,18 @@ li.entry .error-icon-container {
     background-color: #e6e5ea; }
   .ios .incoming .content .body:after {
     left: -6px; }
-.ios .outgoing .content {
+.ios .outgoing .content, .ios .outgoing .attachments .fileView {
   background-color: #2090ea;
   float: right; }
-  .ios .outgoing .content, .ios .outgoing .content .body, .ios .outgoing .content a {
+  .ios .outgoing .content, .ios .outgoing .content .body, .ios .outgoing .content a, .ios .outgoing .attachments .fileView, .ios .outgoing .attachments .fileView .body, .ios .outgoing .attachments .fileView a {
     color: white; }
-    .ios .outgoing .content::selection, .ios .outgoing .content .body::selection, .ios .outgoing .content a::selection {
+    .ios .outgoing .content::selection, .ios .outgoing .content .body::selection, .ios .outgoing .content a::selection, .ios .outgoing .attachments .fileView::selection, .ios .outgoing .attachments .fileView .body::selection, .ios .outgoing .attachments .fileView a::selection {
       background: white;
       color: #454545; }
+.ios .outgoing .attachments .fileView .icon::before {
+  -webkit-mask: url("/images/file.svg") no-repeat center;
+  -webkit-mask-size: 100%;
+  background-color: white; }
 .ios .attachment {
   margin-bottom: 1px; }
   .ios .attachment a {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1315,6 +1315,8 @@ li.entry .error-icon-container {
     cursor: pointer; }
   .message-container .attachments .fileView,
   .message-list .attachments .fileView {
+    display: flex;
+    align-items: center;
     position: relative;
     padding: 5px;
     padding-right: 10px;
@@ -1323,13 +1325,17 @@ li.entry .error-icon-container {
     border-radius: 5px;
     cursor: pointer;
     color: #454545; }
-    .message-container .attachments .fileView .icon, .message-container .attachments .fileView .fileName,
-    .message-list .attachments .fileView .icon,
+    .message-container .attachments .fileView .fileName,
     .message-list .attachments .fileView .fileName {
+      font-weight: bold;
+      margin-bottom: 0.25em; }
+    .message-container .attachments .fileView .icon, .message-container .attachments .fileView .text,
+    .message-list .attachments .fileView .icon,
+    .message-list .attachments .fileView .text {
       opacity: 0.75; }
-    .message-container .attachments .fileView:hover .icon, .message-container .attachments .fileView:hover .fileName,
+    .message-container .attachments .fileView:hover .icon, .message-container .attachments .fileView:hover .text,
     .message-list .attachments .fileView:hover .icon,
-    .message-list .attachments .fileView:hover .fileName {
+    .message-list .attachments .fileView:hover .text {
       opacity: 1.0; }
     .message-container .attachments .fileView .icon,
     .message-list .attachments .fileView .icon {
@@ -1339,8 +1345,8 @@ li.entry .error-icon-container {
       .message-list .attachments .fileView .icon:before {
         content: '';
         display: inline-block;
-        width: 24px;
-        height: 24px;
+        width: 48px;
+        height: 48px;
         -webkit-mask: url("/images/file.svg") no-repeat center;
         -webkit-mask-size: 100%;
         background-color: black; }

--- a/test/index.html
+++ b/test/index.html
@@ -503,8 +503,11 @@
     {{/action }}
   </script>
   <script type='text/x-tmpl-mustache' id='file-view'>
-    <span class='paperclip icon'></span>
-    <span class='fileName' alt='{{ fileName }}' title='{{ altText }}'>{{ fileName }}</a>
+    <div class='icon'></div>
+    <div class='text'>
+      <div class='fileName' alt='{{ fileName }}' title='{{ altText }}'>{{ fileName }}</div>
+      <div class='fileSize'>{{ fileSize }}</div>
+    </div>
   </script>
 
 

--- a/test/views/attachment_view_test.js
+++ b/test/views/attachment_view_test.js
@@ -2,14 +2,29 @@ describe('AttachmentView', function() {
 
   describe('with arbitrary files', function() {
       it('should render a file view', function() {
-        var attachment = { contentType: 'arbitrary/content' };
+        var attachment = {
+          contentType: 'unused',
+          size: 1232
+        };
         var view = new Whisper.AttachmentView({model: attachment}).render();
         assert.match(view.el.innerHTML, /fileView/);
       });
       it('should display the filename if present', function() {
-        var attachment = { contentType: 'arbitrary/content', fileName: 'foo.txt' };
+        var attachment = {
+          fileName: 'foo.txt',
+          contentType: 'unused',
+          size: 1232,
+        };
         var view = new Whisper.AttachmentView({model: attachment}).render();
         assert.match(view.el.innerHTML, /foo.txt/);
+      });
+      it('should render a file size', function() {
+        var attachment = {
+          size: 1232,
+          contentType: 'unused'
+        };
+        var view = new Whisper.AttachmentView({model: attachment}).render();
+        assert.match(view.el.innerHTML, /1.2 KB/);
       });
   });
   it('should render an image for images', function() {


### PR DESCRIPTION
- [X] My contribution is fully baked and ready to be merged as is
- [X] My changes are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [X] I have tested my contribution on these platforms: OSX, Chrome 58.0.3029.96
- [X] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [X] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

## Description
Fixes #1150. See below screenshots. Existing transparency and hover behavior was maintained, which means that any text included in the message will be a slightly different color until the attachment is hovered over.

### Before 
<img width="445" alt="before - android-dark" src="https://cloud.githubusercontent.com/assets/443005/25873804/bbd4fce0-34c4-11e7-8941-63d97c1f0e7a.png">
<img width="446" alt="before - android" src="https://cloud.githubusercontent.com/assets/443005/25873800/bbc35c74-34c4-11e7-8c01-eb273d2264d7.png">
<img width="446" alt="before - ios" src="https://cloud.githubusercontent.com/assets/443005/25873803/bbd17ea8-34c4-11e7-9162-4f36a4a18f7b.png">

### After
<img width="446" alt="after - android-dark" src="https://cloud.githubusercontent.com/assets/443005/25873801/bbc548b8-34c4-11e7-87be-f91101bb081f.png">
<img width="448" alt="after - android" src="https://cloud.githubusercontent.com/assets/443005/25873802/bbd0e632-34c4-11e7-98c5-b76db60f4d57.png">
<img width="450" alt="after - ios" src="https://cloud.githubusercontent.com/assets/443005/25873799/bbc2dcfe-34c4-11e7-8960-f1445e1a522b.png">






