### PR TITLE
Conversation view blocks sending to left groups

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,4 +1,8 @@
 {
+    "youLeftTheGroup": {
+      "message": "You left the group",
+      "description": "Displayed when a user can't send a message because they have left the group"
+    },
     "debugLogExplanation": {
       "message": "This log will be posted publicly online for contributors to view. You may examine and edit it before submitting."
     },

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -15,6 +15,11 @@
             return { toastMessage: i18n('unblockToSend') };
         }
     });
+    Whisper.LeftGroupToast = Whisper.ToastView.extend({
+        render_attributes: function() {
+            return { toastMessage: i18n('youLeftTheGroup') };
+        }
+    });
 
     var MenuView = Whisper.View.extend({
         toggleMenu: function() {
@@ -343,12 +348,15 @@
             var toast;
             if (extension.expired()) {
                 toast = new Whisper.ExpiredToast();
-                toast.$el.insertAfter(this.$el);
-                toast.render();
-                return;
             }
             if (this.model.isPrivate() && storage.isBlocked(this.model.id)) {
                 toast = new Whisper.BlockedToast();
+            }
+            if (!this.model.isPrivate() && this.model.get('left')) {
+                toast = new Whisper.LeftGroupToast();
+            }
+
+            if (toast) {
                 toast.$el.insertAfter(this.$el);
                 toast.render();
                 return;


### PR DESCRIPTION
Block sending to left groups in the same way we block sending when the contact is on our block list or the client is too far out of date.

Before:
<img width="503" alt="screen shot 2017-05-12 at 4 03 22 pm" src="https://cloud.githubusercontent.com/assets/1039940/26019829/6fbd15a2-372d-11e7-996d-0c74c9558c01.png">

After:
<img width="537" alt="screen shot 2017-05-12 at 4 04 25 pm" src="https://cloud.githubusercontent.com/assets/1039940/26019821/637b0308-372d-11e7-8bbe-a91ea0e8bc51.png">