### PR TITLE
Mark groups left on synced "You left the group"

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -366,6 +366,7 @@
                             }
                             else if (dataMessage.group.type === textsecure.protobuf.GroupContext.Type.QUIT) {
                                 if (source == textsecure.storage.user.getNumber()) {
+                                    attributes.left = true;
                                     group_update = { left: "You" };
                                 } else {
                                     group_update = { left: source };


### PR DESCRIPTION
When leaving a group on mobile, we sync the group quit message to desktop, but
we weren't marking the conversation left.