### PR TITLE
Fix Spellcheck on Windows and Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
       "images/**",
       "fonts/*",
       "node_modules/**",
+      "!node_modules/spellchecker/vendor/hunspell/**/*",
       "!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme,test,__tests__,tests,powered-test,example,examples,*.d.ts}",
       "!**/node_modules/.bin",
       "!**/node_modules/*/build/**",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
       "bundleVersion": "1"
     },
     "win": {
+      "asarUnpack": "node_modules/spellchecker/vendor/hunspell_dictionaries",
       "artifactName": "${productName}-Setup_${version}.${ext}",
       "icon": "build/icons/win/icon.ico",
       "publish": {
@@ -93,6 +94,7 @@
       ]
     },
     "linux": {
+      "asarUnpack": "node_modules/spellchecker/vendor/hunspell_dictionaries",
       "target": [
         "deb",
         "zip"

--- a/preload.js
+++ b/preload.js
@@ -46,17 +46,7 @@
   }
   resetSelection();
 
-  // Reset the selection when clicking around, before the spell-checker runs and the context menu shows.
-  window.addEventListener('mousedown', resetSelection);
-
-  // The spell-checker runs when the user clicks on text and before the 'contextmenu' event fires.
-  // Thus, we may retrieve spell-checking suggestions to put in the menu just before it shows.
-  webFrame.setSpellCheckProvider(
-    'en-US',
-    // Not sure what this parameter (`autoCorrectWord`) does: https://github.com/atom/electron/issues/4371
-    // The documentation for `webFrame.setSpellCheckProvider` passes `true` so we do too.
-    true,
-    new SpellCheckProvider('en-US').on('misspelling', function(suggestions) {
+  window.spellChecker = new SpellCheckProvider(window.config.locale).on('misspelling', function(suggestions) {
       // Prime the context menu with spelling suggestions _if_ the user has selected text. Electron
       // may sometimes re-run the spell-check provider for an outdated selection e.g. if the user
       // right-clicks some misspelled text and then an image.
@@ -65,7 +55,21 @@
         // Take the first three suggestions if any.
         selection.spellingSuggestions = suggestions.slice(0, 3);
       }
-    }));
+  });
+
+  // Reset the selection when clicking around, before the spell-checker runs and the context menu shows.
+  window.addEventListener('mousedown', resetSelection);
+
+  // The spell-checker runs when the user clicks on text and before the 'contextmenu' event fires.
+  // Thus, we may retrieve spell-checking suggestions to put in the menu just before it shows.
+
+  webFrame.setSpellCheckProvider(
+    'en-US',
+    // Not sure what this parameter (`autoCorrectWord`) does: https://github.com/atom/electron/issues/4371
+    // The documentation for `webFrame.setSpellCheckProvider` passes `true` so we do too.
+    true,
+    spellChecker
+  );
 
   window.addEventListener('contextmenu', function(e) {
     // Only show the context menu in text editors.

--- a/test/index.html
+++ b/test/index.html
@@ -579,6 +579,7 @@
   <script type="text/javascript" src="keychange_listener_test.js"></script>
   <script type="text/javascript" src="emoji_util_test.js"></script>
   <script type="text/javascript" src="i18n_test.js"></script>
+  <script type="text/javascript" src="spellcheck_test.js"></script>
 
   <script type="text/javascript" src="fixtures.js"></script>
   <script type="text/javascript" src="fixtures_test.js"></script>

--- a/test/spellcheck_test.js
+++ b/test/spellcheck_test.js
@@ -1,0 +1,10 @@
+/*
+ * vim: ts=4:sw=4:expandtab
+ */
+
+describe('spellChecker', function() {
+  it('should work', function() {
+    assert(window.spellChecker.spellCheck('correct'));
+    assert(!window.spellChecker.spellCheck('fhqwgads'));
+  });
+});


### PR DESCRIPTION
I initially thought this was a native module issue, but it turns out to be an asar issue, wherein the spellcheck module can't read dictionary files from an asar. While I was here I added a minimal test for spellchecking and also slimmed down our asar size by excluding ~1MB (uncompressed) of hunspell source code.