### PR TITLE
Fix duplicate x icon (cancel) on active search field

### DIFF
--- a/stylesheets/_index.scss
+++ b/stylesheets/_index.scss
@@ -147,8 +147,6 @@ input.search {
     display: block;
     width: $search-x-size;
     height: $search-x-size;
-    background: url('/images/x.svg') no-repeat center;
-    background-size: cover;
   }
 
   &::-webkit-search-cancel-button:hover {

--- a/stylesheets/android-dark.scss
+++ b/stylesheets/android-dark.scss
@@ -112,10 +112,6 @@ $text-dark: #CCCCCC;
     background-color: $grey-dark_l3;
     border-color: $grey-dark_l2;
     @include invert-text-color;
-    &::-webkit-search-cancel-button {
-      background: url('/images/x_white.svg') no-repeat center;
-      background-size: cover;
-    }
     &.active.ltr, &.active.rtl {
       background-image: url('/images/x_white.svg');
     }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -855,9 +855,7 @@ input.search {
     -webkit-appearance: none;
     display: block;
     width: 16px;
-    height: 16px;
-    background: url("/images/x.svg") no-repeat center;
-    background-size: cover; }
+    height: 16px; }
   input.search::-webkit-search-cancel-button:hover {
     cursor: pointer; }
 
@@ -2004,9 +2002,6 @@ li.entry .error-icon-container {
     .android-dark .search::selection {
       background: white;
       color: #454545; }
-    .android-dark .search::-webkit-search-cancel-button {
-      background: url("/images/x_white.svg") no-repeat center;
-      background-size: cover; }
     .android-dark .search.active.ltr, .android-dark .search.active.rtl {
       background-image: url("/images/x_white.svg"); }
   .android-dark .bubble {


### PR DESCRIPTION
// FREEBIE

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * OpenBSD amd64, Chromium 58.0.3029
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

Two layered X icons  are displayed. This PR is to fix #1136.
![screenshot from 2017-05-20 16-30-36](https://cloud.githubusercontent.com/assets/19829265/26277616/a8c1ab80-3d7a-11e7-9202-7e088c6e1386.png)
![screenshot from 2017-05-20 16-31-00](https://cloud.githubusercontent.com/assets/19829265/26277617/a8db8a96-3d7a-11e7-867b-d42218f5c566.png)
![screenshot from 2017-05-20 16-31-36](https://cloud.githubusercontent.com/assets/19829265/26277618/a8ec39c2-3d7a-11e7-9eb3-ab61c2599809.png)





### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->
