### PR TITLE
Ensure that we never show last seen indicator if count is zero

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -269,9 +269,9 @@
             var oldestUnread = this.model.messageCollection.find(function(model) {
                 return model.get('unread');
             });
+            var unreadCount = this.model.get('unreadCount');
 
-            if (oldestUnread) {
-                var unreadCount = this.model.get('unreadCount');
+            if (oldestUnread && unreadCount > 0) {
                 this.lastSeenIndicator = new Whisper.LastSeenIndicatorView({count: unreadCount});
                 var unreadEl = this.lastSeenIndicator.render().$el;
 


### PR DESCRIPTION
When we get read receipts, a conversation's in-memory messages can get out of date with the database. This means that we'll have messages with `unread = 1` in the collection, but the overall conversation `unreadCount` is zero. For now, we won't show the last seen indicator in this case. In the future, we'll want to prevent these kind of out-of-sync errors.