### PR TITLE
Replace Backbone.fetch with our own; overwrite local data with db data

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -541,6 +541,7 @@
             if (typeof unreadCount !== 'number') {
                 unreadCount = 0;
             }
+            var startingLoadedUnread = this.getLoadedUnreadCount();
             return new Promise(function(resolve) {
                 var upper;
                 if (this.length === 0) {
@@ -563,6 +564,10 @@
                 this.fetch(options).then(resolve);
             }.bind(this)).then(function() {
                 var loadedUnread = this.getLoadedUnreadCount();
+                if (startingLoadedUnread === loadedUnread) {
+                    // that fetch didn't get us any more unread. stop fetching more.
+                    return;
+                }
                 if (loadedUnread < unreadCount) {
                     return this.fetchConversation(conversationId, limit, unreadCount);
                 }

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -48,6 +48,7 @@
         // overriding this to allow for this.unset('unread'), save to db, then fetch()
         // to propagate. We don't want the unset key in the db so our unread index stays
         // small.
+        // jscs:disable
         fetch: function(options) {
             options = options ? _.clone(options) : {};
             if (options.parse === void 0) options.parse = true;
@@ -66,6 +67,7 @@
             };
             return this.sync('read', this, options);
         },
+        // jscs:enable
         getDescription: function() {
             if (this.isGroupUpdate()) {
                 var group_update = this.get('group_update');

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -564,7 +564,11 @@
             if (typeof unreadCount !== 'number') {
                 unreadCount = 0;
             }
-            var startingLoadedUnread = this.getLoadedUnreadCount();
+
+            var startingLoadedUnread = 0;
+            if (unreadCount > 0) {
+                startingLoadedUnread = this.getLoadedUnreadCount();
+            }
             return new Promise(function(resolve) {
                 var upper;
                 if (this.length === 0) {
@@ -586,12 +590,17 @@
                 };
                 this.fetch(options).then(resolve);
             }.bind(this)).then(function() {
-                var loadedUnread = this.getLoadedUnreadCount();
-                if (startingLoadedUnread === loadedUnread) {
-                    // that fetch didn't get us any more unread. stop fetching more.
-                    return;
-                }
-                if (loadedUnread < unreadCount) {
+                if (unreadCount > 0) {
+                    if (unreadCount <= startingLoadedUnread) {
+                        return;
+                    }
+
+                    var loadedUnread = this.getLoadedUnreadCount();
+                    if (startingLoadedUnread === loadedUnread) {
+                        // that fetch didn't get us any more unread. stop fetching more.
+                        return;
+                    }
+
                     return this.fetchConversation(conversationId, limit, unreadCount);
                 }
             }.bind(this));


### PR DESCRIPTION
Resolves situation with read receipts not setting messages as read if conversation is already loaded. Why? The default `fetch()` call does pull the latest information from the database, but it doesn't eliminate keys which have been removed - it only overwrites the current attributes with the pulled attributes. Our version drops all local data in favor of database data.

Also, a bonus to ensure that our conversation fetches don't result in infinite loops.