### PR TITLE
Do not use output of libphonenumber for anything but displaying

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -109,7 +109,7 @@
             var regionCode = storage.get('regionCode');
             var number = libphonenumber.util.parseNumber(this.id, regionCode);
             if (number.isValidNumber) {
-                this.set({ id: number.e164 });
+                this.set({ id: this.id });
             } else {
                 return number.error || "Invalid phone number";
             }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * OpenBSD 6.1, Chromium 58.0.3029
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

There are some tricky phone numbers that do not get properly parsed by `libphonenumber`, i.e. E164 != real number.
 * When user tries to send a message to such a number, they send it to a wrong (most likely unregistred) number.
 * When a message from such a number is received, it totally borks conversations (pretty undefined behavior), requests to servers for device keys and so on.
The user are unable to open these messages, new broken conversation is created for each message, some things get stuck, `libtextsecure.js` eventually kills entire app due to invalid arguments in key rotation and other crazy things I can't recall.

![screenshot from 2017-05-24 20-42-13](https://cloud.githubusercontent.com/assets/19829265/26425436/467cba4e-40c4-11e7-8737-c206394134f0.png)


While there is a bug in `libphonenumber` itself I think we should not trust its output anyway - phone numbers are made by too many different humans and there are exceptions (bugs) to come.  So this PR only fixes Signal borking on magic message receive; displaying correctly formatted numbers and initiating talks to such fancy numbers should be fixed by fixing `libphonenumber` upstream.