### PR TITLE
Scrolling and last seen indicator UX tweaks

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -116,7 +116,7 @@
 
             var onFocus = function() {
                 if (this.$el.css('display') !== 'none') {
-                    this.markRead();
+                    this.updateUnread();
                 }
             }.bind(this);
             this.window.addEventListener('focus', onFocus);

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -251,8 +251,11 @@
             }
         },
 
-        removeLastSeenIndicator: function() {
-            if (this.lastSeenIndicator) {
+        removeLastSeenIndicator: function(options) {
+            options = options || {};
+            _.defaults(options, {force: false});
+
+            if (this.lastSeenIndicator && (options.force || this.lastSeenIndicator.isOldEnough())) {
                 this.lastSeenIndicator.remove();
                 this.lastSeenIndicator = null;
             }
@@ -275,7 +278,7 @@
             options = options || {};
             _.defaults(options, {scroll: true});
 
-            this.removeLastSeenIndicator();
+            this.removeLastSeenIndicator({force: true});
 
             var oldestUnread = this.model.messageCollection.find(function(model) {
                 return model.get('unread');
@@ -340,6 +343,12 @@
         addMessage: function(message) {
             this.model.messageCollection.add(message, {merge: true});
             message.setToExpire();
+
+            // if the last seen indicator is old enough, it will go away.
+            // if it isn't, we want to make sure it's up to date
+            if (this.lastSeenIndicator) {
+                this.lastSeenIndicator.increment(1);
+            }
 
             if (!this.isHidden() && !window.isFocused()) {
                 this.updateLastSeenIndicator({scroll: false});

--- a/js/views/last_seen_indicator_view.js
+++ b/js/views/last_seen_indicator_view.js
@@ -5,12 +5,27 @@
     'use strict';
     window.Whisper = window.Whisper || {};
 
+    var FIVE_SECONDS = 5 * 1000;
+
     Whisper.LastSeenIndicatorView = Whisper.View.extend({
         className: 'last-seen-indicator-view',
         templateName: 'last-seen-indicator-view',
         initialize: function(options) {
           options = options || {};
           this.count = options.count || 0;
+          this.start = Date.now();
+        },
+
+        isOldEnough: function() {
+          var now = Date.now();
+          if (now - this.start > FIVE_SECONDS) {
+            return true;
+          }
+        },
+
+        increment: function(count) {
+            this.count += count;
+            this.render();
         },
 
         render_attributes: function() {

--- a/test/manual.txt
+++ b/test/manual.txt
@@ -10,24 +10,27 @@ Conversation view:
     - Receive messages to conversation out of focus, and the last seen indicator should move up the screen with each new message. When the number of new messages can no longer fit on the screen, the last seen indicator should stay at the top of the screen, and new messages will appear below. The scroll down button will turn blue to indicate new messages out of view.
     - Switch back to Signal app, and the last seen indicator and scroll down button should stay where they are
     - Click the scroll down button to go to the bottom of the window, and it should disappear
-    - Send a message, then scroll up. The last seen indicator should be gone.
+    - Send a message, then scroll up. The last seen indicator should be gone.  Note: if it has been less than five seconds since the last seen indicator was shown, then it will stay despite your sent message.
 
     - Switch to a different conversation, then receive messages on original conversation
     - Switch back to original conversation, and the last seen indicator should be visible
-    - Receive another message on that conversation while it has focus, and the last seen indicator should disappear
+    - Receive another message on that conversation while it has focus, and the last seen indicator should disappear. Note: if it has been less than five seconds since the last seen indicator was shown, then it will stay despite the new message.
 
     - Switch to a different conversation, then receive messages on original conversation
     - Switch back to original conversation, and the last seen indicator should be visible
     - Switch away from conversation and back. The last seen indicator should be gone.
+
+    - Scroll up on a conversation then switch to another application, keeping the conversation visible. Receive new messages. Switch back to application. The scroll down button should be blue, and the conversation scroll location should stay where it was.
 
     - ADVANCED: Set fetch limit to a low number, like 3 (in models/messages.js, fetchConversation function). Load the application, and don't select the conversation. Receive more than four new messages in that conversation. Select the conversation. The last seen indicator should reflect the total number of new messages and all of them should be visible.
 
   Scrolling:
     - If scrolled to bottom of a conversation, should stay there when a new message comes in
     - If scrolled to the middle of a conversation, should stay there when a new message comes in
-    - When you've scrolled up an entire screen's worth, a scroll down button in the bottom right should appear
+    - When you've scrolled up an entire screen's worth, a scroll down button in the bottom right should appear.
 
   Scroll-down button:
     - Clicking it takes you to the bottom of the conversation, makes the button disappear
     - If a new message comes in while it is already showing, it turns blue
-    - If a new message comes in while not at the bottom of the converstation (but button is not already showing), it should appear, already blue
+    - If a new message comes in while not at the bottom of the conversation (but button is not already showing), it should appear, already blue.
+    - If you've scrolled up higher than the last seen indicator, then clicking the scroll down button should take you to the last seen indicator. Once there, clicking the button will take you to the bottom of the conversation, at which point the button will disappear.

--- a/test/views/last_seen_indicator_view_test.js
+++ b/test/views/last_seen_indicator_view_test.js
@@ -9,4 +9,11 @@ describe('LastSeenIndicatorView', function() {
         assert.equal(view.count, 10);
     });
 
+    it('increments count', function() {
+        var view = new Whisper.LastSeenIndicatorView({count: 4});
+        assert.equal(view.count, 4);
+        view.increment(3);
+        assert.equal(view.count, 7);
+    });
+
 });


### PR DESCRIPTION
A couple changes to last seen indicator/scrolling:

- If you've scrolled up in a conversation and switch to another window (leaving the conversation active but the window loses focus), we will preserve your scroll location even if new messages come in. This is different from leaving the conversation within the app and coming back, which will force you to see the last seen indicator.
- If you're above the last seen indicator, the first click of the scroll down button will take you to the last seen indicator, with the oldest new messages. Once you're there, a second click will take you to the bottom of the conversation, with the very newest messages.
- Today the last seen indicator is dismissed when new messages arrive, to ensure that it doesn't stick around for a long time in an active conversation. But it may disappear too quickly in that same active conversation. A five-second time limit has been added to ensure that it doesn't disappear if you receive or send a message during that window.
