### PR TITLE
Fix: Don't scroll to last seen indicator on focus

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -116,7 +116,7 @@
 
             var onFocus = function() {
                 if (this.$el.css('display') !== 'none') {
-                    this.updateUnread();
+                    this.updateUnread({scroll: false});
                 }
             }.bind(this);
             this.window.addEventListener('focus', onFocus);
@@ -206,8 +206,8 @@
             this.$('.bottom-bar form').addClass('active');
         },
 
-        updateUnread: function() {
-            this.updateLastSeenIndicator();
+        updateUnread: function(options) {
+            this.updateLastSeenIndicator(options);
             this.model.markRead();
         },
 

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -278,14 +278,14 @@
             options = options || {};
             _.defaults(options, {scroll: true});
 
-            this.removeLastSeenIndicator({force: true});
-
             var oldestUnread = this.model.messageCollection.find(function(model) {
                 return model.get('unread');
             });
             var unreadCount = this.model.get('unreadCount');
 
             if (oldestUnread && unreadCount > 0) {
+                this.removeLastSeenIndicator({force: true});
+
                 this.lastSeenIndicator = new Whisper.LastSeenIndicatorView({count: unreadCount});
                 var unreadEl = this.lastSeenIndicator.render().$el;
 
@@ -302,6 +302,9 @@
                         this.addScrollDownButtonWithCount(unreadCount);
                     }
                 }.bind(this), 1);
+            }
+            else {
+                this.removeLastSeenIndicator({force: false});
             }
         },
 


### PR DESCRIPTION
Sadly a [recent commit](https://github.com/WhisperSystems/Signal-Desktop/commit/9de384f3b8816631dc7ab1843187b55cfb860f68) regressed the "don't scroll on focus" work I merged earlier today. This fixes that. The [new behaviors described in that pull request](https://github.com/WhisperSystems/Signal-Desktop/pull/1197) now truly apply. :0)

Bonus: We don't get rid of the last seen indicator quite as aggressively.