### PR TITLE
Fix race condition: Pull from database after add to conversation

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -303,6 +303,9 @@
                 var read = unreadMessages.map(function(m) {
                     if (this.messageCollection.get(m.id)) {
                         m = this.messageCollection.get(m.id);
+                    } else {
+                        console.log('Marked a message as read in the database, but ' +
+                                    'it was not in messageCollection.');
                     }
                     m.markRead();
                     return {


### PR DESCRIPTION
Occasionally you can see the last seen indicator in a totally inappropriate place. Say, for example, with the number 1 in it, but five messages up. Or higher. And it will continue to do that until you restart the app.

This is because we had a race condition. We would mark the message as unread in the database, but it wouldn't be in our message collection. So it would sit there, unread, until restart. These changes catch that, sync state with the database, and start all the timers that are supposed to start when a message is unread. This might fix some of the problems we have with disappearing messages not disappearing.

Along with the fix, this change adds some console logs to help us determine whether this ever happens to people in the wild.

Tested this with a script that sent message every couple seconds, then I went crazy: flipping focus back and forth, sending messages, etc. I actually did get it to happen. Here's the log:

```
data message from REDACTED
Marked a message as read in the database, but it was not in messageCollection.
Sending 1 read receipts
Caught race condition on new message read state! Manually starting timers.
clear attention
```