### PR TITLE
30px at bottom of conversation considered 'at the bottom'

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -291,14 +291,14 @@
 
                 unreadEl.insertBefore(this.$('#' + oldestUnread.get('id')));
 
-                if (this.view.bottomOffset === 0 || options.scroll) {
+                if (this.view.atBottom() || options.scroll) {
                     var position = unreadEl[0].scrollIntoView(true);
                 }
 
                 // scrollIntoView is an async operation, but we have no way to listen for
                 // completion of the resultant scroll.
                 setTimeout(function() {
-                    if (this.view.bottomOffset > 0) {
+                    if (!this.view.atBottom()) {
                         this.addScrollDownButtonWithCount(unreadCount);
                     }
                 }.bind(this), 1);

--- a/js/views/message_list_view.js
+++ b/js/views/message_list_view.js
@@ -33,7 +33,7 @@
             this.outerHeight = this.$el.outerHeight();
             this.scrollPosition = this.$el.scrollTop() + this.outerHeight;
             this.scrollHeight = this.el.scrollHeight;
-            this.bottomOffset = this.scrollHeight - this.$el.scrollTop() - this.outerHeight;
+            this.bottomOffset = this.scrollHeight - this.scrollPosition;
         },
         resetScrollPosition: function() {
             this.$el.scrollTop(this.scrollPosition - this.$el.outerHeight());

--- a/js/views/message_list_view.js
+++ b/js/views/message_list_view.js
@@ -24,7 +24,7 @@
             }
         },
         atBottom: function() {
-            return this.bottomOffset < 20;
+            return this.bottomOffset < 30;
         },
         measureScrollPosition: function() {
             if (this.el.scrollHeight === 0) { // hidden

--- a/js/views/message_list_view.js
+++ b/js/views/message_list_view.js
@@ -17,11 +17,14 @@
             if (this.$el.scrollTop() === 0) {
                 this.$el.trigger('loadMore');
             }
-            if (this.bottomOffset === 0) {
+            if (this.atBottom()) {
                 this.$el.trigger('atBottom');
             } else if (this.bottomOffset > this.outerHeight) {
                 this.$el.trigger('farFromBottom');
             }
+        },
+        atBottom: function() {
+            return this.bottomOffset < 20;
         },
         measureScrollPosition: function() {
             if (this.el.scrollHeight === 0) { // hidden
@@ -30,18 +33,13 @@
             this.outerHeight = this.$el.outerHeight();
             this.scrollPosition = this.$el.scrollTop() + this.outerHeight;
             this.scrollHeight = this.el.scrollHeight;
-            this.shouldStickToBottom = this.scrollPosition === this.scrollHeight;
-            if (this.shouldStickToBottom) {
-                this.bottomOffset = 0;
-            } else {
-                this.bottomOffset = this.scrollHeight - this.$el.scrollTop() - this.outerHeight;
-            }
+            this.bottomOffset = this.scrollHeight - this.$el.scrollTop() - this.outerHeight;
         },
         resetScrollPosition: function() {
             this.$el.scrollTop(this.scrollPosition - this.$el.outerHeight());
         },
         scrollToBottomIfNeeded: function() {
-            if (this.bottomOffset === 0) {
+            if (this.atBottom()) {
                 this.scrollToBottom();
             }
         },
@@ -63,7 +61,8 @@
 
             var index = this.collection.indexOf(model);
             this.measureScrollPosition();
-            if (model.get('unread') && this.bottomOffset > 0) {
+
+            if (model.get('unread') && !this.atBottom()) {
                 this.$el.trigger('newOffscreenMessage');
             }
 


### PR DESCRIPTION
A bit of cleanup in our 'is the conversation at the bottom?' code, as well as a little bit of wiggle room. We consider the 30px of space at the bottom of the conversation to be 'at the bottom' so users who are 'close enough' at the bottom of the conversation won't get marooned in history.