### PR TITLE
Fix being re-added to a group you previously left

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -386,6 +386,10 @@
                                 if (difference.length > 0) {
                                     group_update.joined = difference;
                                 }
+                                if (conversation.get('left')) {
+                                  console.log('re-added to a left group');
+                                  attributes.left = false;
+                                }
                             }
                             else if (dataMessage.group.type === textsecure.protobuf.GroupContext.Type.QUIT) {
                                 if (source == textsecure.storage.user.getNumber()) {


### PR DESCRIPTION
Negate the flag marking the group as left. Fixes #1207.

This bug was introduced by the combination of app-level left group blocking in cfe0c77 and a fix to left-group state tracking in 80bfe18.