### PR TITLE
Fix: attachments rendered multiple times

### DIFF
--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -134,7 +134,7 @@
             return this.model.fileName;
         }
         if (this.isAudio() || this.isVideo()) {
-            return i18n('mediaMssage');
+            return i18n('mediaMessage');
         }
 
         return i18n('unnamedFile');

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -261,10 +261,13 @@
             this.$('.avatar').replaceWith(avatarView.render().$('.avatar'));
         },
         loadAttachments: function() {
-            if (this.loadedAttachments) {
+            this.loadedAttachments = this.loadedAttachments || [];
+
+            // Messages can go from no attachments to some attachments (via key approval),
+            //   but they can't go from some attachments to a different set of them.
+            if (this.loadedAttachments.length) {
                 return;
             }
-            this.loadedAttachments = [];
 
             this.model.get('attachments').forEach(function(attachment) {
                 var view = new Whisper.AttachmentView({

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -261,6 +261,11 @@
             this.$('.avatar').replaceWith(avatarView.render().$('.avatar'));
         },
         loadAttachments: function() {
+            if (this.loadedAttachments) {
+                return;
+            }
+            this.loadedAttachments = [];
+
             this.model.get('attachments').forEach(function(attachment) {
                 var view = new Whisper.AttachmentView({
                   model: attachment,
@@ -274,6 +279,7 @@
                     }
                 });
                 view.render();
+                this.loadedAttachments.push(view);
             }.bind(this));
         }
     });


### PR DESCRIPTION
Fixes #1213, introduced by recent changes to re-fetch data from IndexedDB.

This change makes `MessageView.render()` idempotent. Our previous technique for loading attachments resulted in a new `AttachmentView` added for every call to `render()`. We now only add attachments the first time. This okay because messages are immutable, therefore attachments don't change.

Also: A quick fix of a typo in an i18n message.