### PR TITLE
Update the scroll position when 'fetch more messages' is complete

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -156,7 +156,7 @@
             'focus .send-message': 'focusBottomBar',
             'change .file-input': 'toggleMicrophone',
             'blur .send-message': 'unfocusBottomBar',
-            'loadMore .message-list': 'fetchMessages',
+            'loadMore .message-list': 'loadMoreMessages',
             'newOffscreenMessage .message-list': 'addScrollDownButtonWithCount',
             'atBottom .message-list': 'hideScrollDownButton',
             'farFromBottom .message-list': 'addScrollDownButton',
@@ -310,6 +310,27 @@
 
         focusMessageField: function() {
             this.$messageField.focus();
+        },
+
+        loadMoreMessages: function() {
+            if (this.inProgressFetch) {
+                return;
+            }
+
+            this.view.measureScrollPosition();
+            var startingHeight = this.view.scrollHeight;
+
+            this.fetchMessages().then(function() {
+                // We delay this work to let scrolling/layout settle down first
+                setTimeout(function() {
+                    this.view.measureScrollPosition();
+                    var endingHeight = this.view.scrollHeight;
+                    var delta = endingHeight - startingHeight;
+
+                    var newScrollPosition = this.view.scrollPosition + delta - this.view.
+                    this.view.$el.scrollTop(newScrollPosition);
+                }.bind(this), 1);
+            }.bind(this));
         },
 
         fetchMessages: function() {


### PR DESCRIPTION
With the recent changes to scrolling behavior, the 'load more messages' scenario was left behind. This work attempts to keep the scroll position exactly where it was when you initially made the scroll request. There's a little bit of flashing I'd like to get rid of at some point, but it does faithfully maintain the scroll position based on my testing.
