### PR TITLE
loadMoreMessages: Fix broken reference to this.view.outerHeight

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -332,7 +332,7 @@
                     var endingHeight = this.view.scrollHeight;
                     var delta = endingHeight - startingHeight;
 
-                    var newScrollPosition = this.view.scrollPosition + delta - this.view.
+                    var newScrollPosition = this.view.scrollPosition + delta - this.view.outerHeight;
                     this.view.$el.scrollTop(newScrollPosition);
                 }.bind(this), 1);
             }.bind(this));


### PR DESCRIPTION
Sadly, some sort of slip in the editor caused a key bit of code to be left out of https://github.com/WhisperSystems/Signal-Desktop/pull/1222. Sadly, linting didn't find it because it ended in `.`, and it skated under the review radar. :0/

