### PR TITLE
Fix for missing hourglass on incoming messages, reduce callbacks

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -508,6 +508,9 @@
         isExpiring: function() {
             return this.get('expireTimer') && this.get('expirationStartTimestamp');
         },
+        isExpired: function() {
+            return this.msTilExpire() <= 0;
+        },
         msTilExpire: function() {
               if (!this.isExpiring()) {
                 return Infinity;

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -27,10 +27,6 @@
     });
     var TimerView = Whisper.View.extend({
         templateName: 'hourglass',
-        className: 'timer',
-        initialize: function() {
-            this.update();
-        },
         update: function() {
             if (this.timeout) {
               clearTimeout(this.timeout);

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -210,8 +210,9 @@
         },
         renderExpiring: function() {
             if (!this.timerView) {
-              this.timerView = new TimerView({ model: this.model, el: this.$('.timer') });
+              this.timerView = new TimerView({ model: this.model });
             }
+            this.timerView.setElement(this.$('.timer'));
             this.timerView.update();
         },
         render: function() {

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -36,6 +36,9 @@
               clearTimeout(this.timeout);
               this.timeout = null;
             }
+            if (this.model.isExpired()) {
+                return this;
+            }
             if (this.model.isExpiring()) {
                 this.render();
                 var totalTime = this.model.get('expireTimer') * 1000;

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -41,8 +41,8 @@
                 var remainingTime = this.model.msTilExpire();
                 var elapsed = (totalTime - remainingTime) / totalTime;
                 this.$('.sand').css('transform', 'translateY(' + elapsed*100 + '%)');
-                this.timeout = setTimeout(this.update.bind(this), totalTime / 100);
                 this.$el.css('display', 'inline-block');
+                this.timeout = setTimeout(this.update.bind(this), Math.max(totalTime / 100, 500));
             }
             return this;
         }


### PR DESCRIPTION
While investigating #1138, I discovered and fixed a couple things.

First, because we re-render messages more often now, we were missing hourglass icons on incoming messages. The `TimerView`'s `el` was not attached to the new DOM as generated by `MessageView` re-renders.

Also: For short-expiring messages, we would schedule a huge number of `setTimeout` callbacks. This introduces a `Math.max()` call so we don't update the hourglass more often than 500ms. We also ensure that we don't continue to update after the message is expired.

Lastly, we remove a couple unused bits of code:
  - initialize doesn't need to call update because `MessageView.renderExpiring()` calls it immediately
  - we don't need the className because that's already present on the `el` it attaches to, part of the `MessageView`'s template.