### PR TITLE
Conversation.sendMessage: Don't set unreadCount to zero

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -165,7 +165,6 @@
             message.save();
 
             this.save({
-                unreadCount : 0,
                 active_at   : now,
                 timestamp   : now,
                 lastMessage : message.getNotificationText()

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -217,7 +217,8 @@
         },
         updateUnread: function() {
             this.resetLastSeenIndicator();
-            this.markRead();
+            // Waiting for scrolling caused by resetLastSeenIndicator to settle down
+            setTimeout(this.markRead.bind(this), 1);
         },
 
         onOpened: function() {
@@ -418,7 +419,7 @@
 
         onClick: function(e) {
             this.closeMenu(e);
-            this.markRead(e);
+            this.markRead();
         },
 
         findNewestVisibleUnread: function() {
@@ -468,8 +469,15 @@
             }
         },
 
-        markRead: function(e) {
-            var unread = this.findNewestVisibleUnread();
+        markRead: function() {
+            var unread;
+
+            if (this.view.atBottom()) {
+                unread = this.model.messageCollection.last();
+            } else {
+                unread = this.findNewestVisibleUnread();
+            }
+
             if (unread) {
                 this.model.markRead(unread.get('received_at'));
             }


### PR DESCRIPTION
It's no longer guaranteed to be true that you've read all messages when you send a message. If you're scrolled up in a conversation, you may not have read all messages. Setting the `unreadCount` to zero is not good - it prevents the user from marking any of their existing messages as unread until something else happens, like receiving a read receipt or new message.

Also: `ConversationView.markRead()` now marks all messages as read when at bottom. To handle the same 'not quite at the bottom' case that our 30px buffer gives us for scrolling, we use the same `atBottom()` method to determine whether we should mark everything unread. Saves the effort and potential missed messages (due to partial pixels, etc.) of searching for visible messages.