### PR TITLE
Update message history on read receipt

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -66,9 +66,12 @@
             this.messageCollection.get(message.id).fetch();
         }
 
-        return this.getUnread().then(function(unreadMessages) {
-            this.save({unreadCount: unreadMessages.length});
-        }.bind(this));
+        // We mark as read everything older than this message - to clean up old stuff
+        //   still marked unread in the database. If the user generally doesn't read in
+        //   the desktop app, so the desktop app only gets read receipts, we can very
+        //   easily end up with messages never marked as read (our previous early read
+        //   receipt handling, read receipts never sent because app was offline)
+        return this.markRead(message.get('received_at'));
     },
 
     getUnread: function() {

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -306,42 +306,38 @@
         options = options || {};
         _.defaults(options, {sendReadReceipts: true});
 
-        if (this.get('unreadCount') > 0) {
-            var conversationId = this.id;
-            Whisper.Notifications.remove(Whisper.Notifications.where({
-                conversationId: conversationId
-            }));
+        var conversationId = this.id;
+        Whisper.Notifications.remove(Whisper.Notifications.where({
+            conversationId: conversationId
+        }));
 
-            this.getUnread().then(function(unreadMessages) {
-                var oldUnread = unreadMessages.filter(function(message) {
-                    return message.get('received_at') <= newestUnreadDate;
-                });
+        this.getUnread().then(function(unreadMessages) {
+            var oldUnread = unreadMessages.filter(function(message) {
+                return message.get('received_at') <= newestUnreadDate;
+            });
 
-                var read = _.map(oldUnread, function(m) {
-                    if (this.messageCollection.get(m.id)) {
-                        m = this.messageCollection.get(m.id);
-                    } else {
-                        console.log('Marked a message as read in the database, but ' +
-                                    'it was not in messageCollection.');
-                    }
-                    m.markRead();
-                    return {
-                        sender    : m.get('source'),
-                        timestamp : m.get('sent_at')
-                    };
-                }.bind(this));
-
-                if (read.length > 0) {
-                    var unreadCount = unreadMessages.length - read.length;
-                    this.save({ unreadCount: unreadCount });
-
-                    if (options.sendReadReceipts) {
-                        console.log('Sending', read.length, 'read receipts');
-                        textsecure.messaging.syncReadMessages(read);
-                    }
+            var read = _.map(oldUnread, function(m) {
+                if (this.messageCollection.get(m.id)) {
+                    m = this.messageCollection.get(m.id);
+                } else {
+                    console.log('Marked a message as read in the database, but ' +
+                                'it was not in messageCollection.');
                 }
+                m.markRead();
+                return {
+                    sender    : m.get('source'),
+                    timestamp : m.get('sent_at')
+                };
             }.bind(this));
-        }
+
+            var unreadCount = unreadMessages.length - read.length;
+            this.save({ unreadCount: unreadCount });
+
+            if (read.length && options.sendReadReceipts) {
+                console.log('Sending', read.length, 'read receipts');
+                textsecure.messaging.syncReadMessages(read);
+            }
+        }.bind(this));
     },
 
     fetchMessages: function() {

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -311,7 +311,7 @@
             conversationId: conversationId
         }));
 
-        this.getUnread().then(function(unreadMessages) {
+        return this.getUnread().then(function(unreadMessages) {
             var oldUnread = unreadMessages.filter(function(message) {
                 return message.get('received_at') <= newestUnreadDate;
             });

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -457,6 +457,10 @@
                             }
                             if (readReceipt || message.isExpirationTimerUpdate()) {
                                 message.unset('unread');
+                                // This is primarily to allow the conversation to mark all older messages as
+                                //   read, as is done when we receive a read receipt for a message we already
+                                //   know about.
+                                Whisper.ReadReceipts.notifyConversation(message);
                             } else {
                                 conversation.set('unreadCount', conversation.get('unreadCount') + 1);
                             }

--- a/js/read_receipts.js
+++ b/js/read_receipts.js
@@ -29,19 +29,21 @@
                 if (message) {
                     this.remove(receipt);
                     message.markRead(receipt.get('read_at')).then(function() {
-                        var conversation = ConversationController.get({
-                            id: message.get('conversationId')
-                        });
-
-                        if (conversation) {
-                            // notify frontend listeners
-                            conversation.onReadMessage(message);
-                        }
-                    });
+                        this.notifyConversation(message);
+                    }.bind(this));
                 } else {
                     console.log('No message for read receipt');
                 }
             }.bind(this));
-        }
+        },
+        notifyConversation: function(message) {
+            var conversation = ConversationController.get({
+                id: message.get('conversationId')
+            });
+
+            if (conversation) {
+                conversation.onReadMessage(message);
+            }
+        },
     }))();
 })();


### PR DESCRIPTION
On read receipt, we:

1. We mark as read everything older than this message - to clean up old stuff still marked unread in the database. If the user generally doesn't read in the desktop app, so the desktop app only gets read receipts, we can very easily end up with messages never marked as read (our previous early read receipt handling, read receipts never sent because app was offline).

2. We queue the job because we often get a whole lot of read receipts at once, and their markRead calls could very easily overlap given the async pull from DB.

3. We also disable read receipts for any message marked read due to a read receipt. That's a notification explosion we don't need.

4. We no longer restrict `Conversation.markUnread()` to situations where its `unreadCount` property is above zero. This is to help us in situations where we get wedged, like we did in #1228 

5. When we get an out-of-order read receipt, we also mark as read all earlier messages.