### PR TITLE
Visual tweaks: Fix last seen font, padding at top of conversation

### DIFF
--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -717,10 +717,9 @@ li.entry .error-icon-container {
   }
 
   .text {
-    font-family: "Helvetica Neue";
     font-size: 12px;
     text-transform: uppercase;
-    letter-spacing: .045em;
+    letter-spacing: .06em;
     background-color: white;
     border-radius: 1.5em;
     padding: 10px 21px 9px 21px;

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -51,7 +51,7 @@
         height: 100%;
         width: 100%;
         margin: 0;
-        padding: 0;
+        padding: 10px 0 0 0;
         overflow-y: overlay;
       }
     }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1517,10 +1517,9 @@ li.entry .error-icon-container {
     border-bottom: 1px solid rgba(0, 0, 0, 0.055);
     background-color: rgba(0, 0, 0, 0.05); }
   .message-list .last-seen-indicator-view .text {
-    font-family: "Helvetica Neue";
     font-size: 12px;
     text-transform: uppercase;
-    letter-spacing: .045em;
+    letter-spacing: .06em;
     background-color: white;
     border-radius: 1.5em;
     padding: 10px 21px 9px 21px; }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1000,7 +1000,7 @@ input.search {
         height: 100%;
         width: 100%;
         margin: 0;
-        padding: 0;
+        padding: 10px 0 0 0;
         overflow-y: overlay; }
 
 .discussion-container {


### PR DESCRIPTION
On Linux, where Helvetica Neue is not installed, we fall back to Times New Roman for the Last Seen Indicator. Removed - we didn't need Helvetica Neue anyway.

The oldest message in a conversation was 0px from the top of the window. Now has proper padding.