### PR TITLE
Use setElement to ensure that re-parented AttachmentViews listen for events

### DIFF
--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -272,6 +272,7 @@
 
                 this.trigger('beforeChangeHeight');
                 this.$('.attachments').append(view.el);
+                view.setElement(view.el);
                 this.trigger('afterChangeHeight');
             }
         },


### PR DESCRIPTION
Fixes #1242.

With the reliable repro provided in #1242, I was able to very clearly see that it was a problem of missing event handlers when we moved the `AttachmentView`'s `el` from one parent to another. I thought I had reproduced this issue before, but apparently not when I thought I did, or not when it counted. There y'are!