### PR TITLE
Fix: Show attachment views; they trigger update synchronously

### DIFF
--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -208,7 +208,7 @@
         this.update();
     },
     renderFileView: function() {
-        this.view = new FileView({
+        this.fileView = new FileView({
           model: {
             mediaType: this.mediaType(),
             fileName: this.displayName(),
@@ -217,8 +217,8 @@
           }
         });
 
-        this.view.$el.appendTo(this.$el.empty());
-        this.view.render();
+        this.fileView.$el.appendTo(this.$el.empty());
+        this.fileView.render();
         return this;
     },
     update: function() {

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -294,13 +294,14 @@
                   model: attachment,
                   timestamp: this.model.get('sent_at')
                 });
-                view.render();
                 this.loadedAttachments.push(view);
 
                 this.listenTo(view, 'update', function() {
                     view.updated = true;
                     this.appendAttachmentView(view);
                 });
+
+                view.render();
             }.bind(this));
         }
     });


### PR DESCRIPTION
Fixes #1260. Recent changes to attachment handling made it so we only listened for the `update` event after `render()`, but file views, having no async load to do, immediately trigger the `update` event during `render()`.

Also: noticed that we overwrite `this.view` (initially `FileView`, later a video or audio player), so gave the `FileView` its own member variable.