### PR TITLE
Remove default Alt+S shortcut for showing the app

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,9 +34,6 @@
 
     "commands": {
       "show_signal": {
-        "suggested_key": {
-          "default": "Alt+S"
-        },
         "description": "Show the Signal inbox."
       }
     }


### PR DESCRIPTION
Verified via a new profile that the Alt+S shortcut isn't put in place on new installs, but I suspect that it won't fix the situation for users who have already installed older builds.

Fixes #1259. And those still commenting in #1134 will want to know about this.