### PR TITLE
File attachment styles, gray background for message detail screen

### DIFF
--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -104,6 +104,8 @@
 }
 
 .message-detail {
+  background-color: #eee;
+
   .key-conflict-dialogue {
     border-radius: $border-radius;
     margin: 20px 0;
@@ -139,7 +141,6 @@
   }
 
   .message-container {
-    background: white;
     padding: 20px 0;
 
     .sender {

--- a/stylesheets/_ios.scss
+++ b/stylesheets/_ios.scss
@@ -84,7 +84,7 @@ $ios-border-color: rgba(0,0,0,0.1);
   }
 
 
-  .message-list .attachments .bubbled {
+  .attachments .bubbled {
     border-radius: 15px;
     margin-bottom: 0.25em;
 
@@ -110,7 +110,7 @@ $ios-border-color: rgba(0,0,0,0.1);
       height: 11px;
       right: -6px;
       bottom: -3px;
-      background: white;
+      background: #eee;
     }
   }
 
@@ -156,7 +156,7 @@ $ios-border-color: rgba(0,0,0,0.1);
     }
   }
 
-  .message-list .incoming .bubbled {
+  .incoming .bubbled {
     background-color: white;
     color: black;
     float: left;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1616,28 +1616,28 @@ li.entry .error-icon-container {
 .ios .error-message.content,
 .ios .control .content {
   padding: 10px; }
-.ios .message-list .attachments .bubbled {
+.ios .attachments .bubbled {
   border-radius: 15px;
   margin-bottom: 0.25em;
   padding: 10px;
   position: relative; }
-  .ios .message-list .attachments .bubbled:before, .ios .message-list .attachments .bubbled:after {
+  .ios .attachments .bubbled:before, .ios .attachments .bubbled:after {
     content: '';
     display: block;
     border-radius: 20px;
     position: absolute;
     width: 10px; }
-  .ios .message-list .attachments .bubbled:before {
+  .ios .attachments .bubbled:before {
     right: -1px;
     bottom: -3px;
     height: 10px;
     border-radius: 20px;
     background: #2090ea; }
-  .ios .message-list .attachments .bubbled:after {
+  .ios .attachments .bubbled:after {
     height: 11px;
     right: -6px;
     bottom: -3px;
-    background: white; }
+    background: #eee; }
 .ios .bubble .content {
   margin-bottom: 5px; }
   .ios .bubble .content .body {
@@ -1668,14 +1668,14 @@ li.entry .error-icon-container {
   background-color: white; }
 .ios .bubble .meta {
   clear: both; }
-.ios .message-list .incoming .bubbled {
+.ios .incoming .bubbled {
   background-color: white;
   color: black;
   float: left; }
-  .ios .message-list .incoming .bubbled:before {
+  .ios .incoming .bubbled:before {
     left: -1px;
     background-color: white; }
-  .ios .message-list .incoming .bubbled:after {
+  .ios .incoming .bubbled:after {
     left: -6px; }
 .ios .incoming .content {
   background-color: white;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1037,70 +1037,72 @@ input.search {
     display: inline-block;
     max-width: 100%; }
 
-.message-detail .key-conflict-dialogue {
-  border-radius: 5px;
-  margin: 20px 0; }
-  .message-detail .key-conflict-dialogue .header {
-    border-radius: 5px 5px 0 0;
-    background: #F3F3A7;
-    margin: 0;
-    padding: 10px 20px; }
-  .message-detail .key-conflict-dialogue .content {
-    padding: 20px;
-    border: 2px solid #F3F3A7; }
-  .message-detail .key-conflict-dialogue button.resolve {
-    outline: none;
-    border: none;
+.message-detail {
+  background-color: #eee; }
+  .message-detail .key-conflict-dialogue {
     border-radius: 5px;
-    color: white;
-    font-weight: bold;
-    line-height: 36px;
-    padding: 0 20px;
+    margin: 20px 0; }
+    .message-detail .key-conflict-dialogue .header {
+      border-radius: 5px 5px 0 0;
+      background: #F3F3A7;
+      margin: 0;
+      padding: 10px 20px; }
+    .message-detail .key-conflict-dialogue .content {
+      padding: 20px;
+      border: 2px solid #F3F3A7; }
+    .message-detail .key-conflict-dialogue button.resolve {
+      outline: none;
+      border: none;
+      border-radius: 5px;
+      color: white;
+      font-weight: bold;
+      line-height: 36px;
+      padding: 0 20px;
+      float: right;
+      background: #2090ea;
+      margin-left: 20px; }
+    .message-detail .key-conflict-dialogue .hideKeys, .message-detail .key-conflict-dialogue .showKeys {
+      float: right;
+      line-height: 36px; }
+  .message-detail .message-container {
+    background: white;
+    padding: 20px 0; }
+    .message-detail .message-container .sender {
+      display: none; }
+  .message-detail .info {
+    padding: 1em; }
+    .message-detail .info .label {
+      font-weight: bold;
+      padding-right: 1em;
+      vertical-align: top; }
+    .message-detail .info button {
+      border: none;
+      border-radius: 5px;
+      color: white;
+      padding: 0.5em;
+      font-weight: bold; }
+      .message-detail .info button span {
+        vertical-align: middle; }
+  .message-detail .contacts .contact-detail {
+    padding: 0 36px;
+    margin-bottom: 5px; }
+    .message-detail .contacts .contact-detail .error-icon-container {
+      float: right; }
+    .message-detail .contacts .contact-detail .error-message {
+      margin: 6px 0 0;
+      font-size: 0.92857em;
+      font-weight: bold;
+      color: red; }
+  .message-detail h3 {
+    font-size: 1em;
+    padding: 5px; }
+  .message-detail button.conflict {
     float: right;
-    background: #2090ea;
-    margin-left: 20px; }
-  .message-detail .key-conflict-dialogue .hideKeys, .message-detail .key-conflict-dialogue .showKeys {
+    background: #d00; }
+  .message-detail button.cancel {
     float: right;
-    line-height: 36px; }
-.message-detail .message-container {
-  background: white;
-  padding: 20px 0; }
-  .message-detail .message-container .sender {
-    display: none; }
-.message-detail .info {
-  padding: 1em; }
-  .message-detail .info .label {
-    font-weight: bold;
-    padding-right: 1em;
-    vertical-align: top; }
-  .message-detail .info button {
-    border: none;
-    border-radius: 5px;
-    color: white;
-    padding: 0.5em;
-    font-weight: bold; }
-    .message-detail .info button span {
-      vertical-align: middle; }
-.message-detail .contacts .contact-detail {
-  padding: 0 36px;
-  margin-bottom: 5px; }
-  .message-detail .contacts .contact-detail .error-icon-container {
-    float: right; }
-  .message-detail .contacts .contact-detail .error-message {
-    margin: 6px 0 0;
-    font-size: 0.92857em;
-    font-weight: bold;
-    color: red; }
-.message-detail h3 {
-  font-size: 1em;
-  padding: 5px; }
-.message-detail button.conflict {
-  float: right;
-  background: #d00; }
-.message-detail button.cancel {
-  float: right;
-  color: #454545;
-  border: solid 1px #ccc; }
+    color: #454545;
+    border: solid 1px #ccc; }
 
 .message-list .error-icon {
   cursor: pointer; }


### PR DESCRIPTION
First, this fixes file attachment styles in iOS theme. They weren't fully updated when we moved to the gray conversation background color, resulting in little gray blobs instead of nice little chat bubble tails. Also, in the message detail screen, they didn't have nice styling - removed some too-specific CSS rules.

Second, this makes the background color of the message detail screen gray, so that you can see outgoing messages in Android theme, incoming messages in iOS theme. White on white was too hard to see.