### PR TITLE
Failed audio note

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -156,7 +156,7 @@
         });
         var error;
         if ((error = c.validateNumber())) {
-          console.log(error);
+          console.log(error.stack);
           return;
         }
 

--- a/js/debugLog.js
+++ b/js/debugLog.js
@@ -71,7 +71,7 @@
         };
 
         window.onerror = function(message, script, line, col, error) {
-            console.log(error);
+            console.log(error.stack);
         };
     }
 })();

--- a/js/views/recorder_view.js
+++ b/js/views/recorder_view.js
@@ -34,7 +34,9 @@
             if (this.interval) {
               clearInterval(this.interval);
             }
-            this.source.disconnect();
+            if (this.source) {
+              this.source.disconnect();
+            }
             if (this.context) {
               this.context.close().then(function() {
                   console.log('audio context closed');
@@ -64,11 +66,12 @@
             navigator.webkitGetUserMedia({ audio: true }, function(stream) {
                 this.source = this.context.createMediaStreamSource(stream);
                 this.source.connect(this.input);
-            }.bind(this), this.onError);
+            }.bind(this), this.onError.bind(this));
             this.recorder.startRecording();
         },
         onError: function(error) {
             console.log(error);
+            this.close();
         }
     });
 })();

--- a/js/views/recorder_view.js
+++ b/js/views/recorder_view.js
@@ -70,7 +70,7 @@
             this.recorder.startRecording();
         },
         onError: function(error) {
-            console.log(error);
+            console.log(error.stack);
             this.close();
         }
     });


### PR DESCRIPTION
Fixes #1266.

First, we remove recorder UI when we fail to 'getUserMedia'.

Second, we print `error.stack` instead of just `error` for `console.log()` which will give us more data.