### PR TITLE
Make Jumbomoji normal size when in the conversation preview

### DIFF
--- a/components/emojijs/demo/emoji.css
+++ b/components/emojijs/demo/emoji.css
@@ -61,3 +61,21 @@ img.emoji.jumbo {
 	width: 2em;
 	height: 2em;
 }
+
+// we need these, or we'll make conversation items too big in the left-nav
+.conversations img.emoji.small {
+	width: 1em;
+	height: 1em;
+}
+.conversations img.emoji.medium {
+	width: 1em;
+	height: 1em;
+}
+.conversations img.emoji.large {
+	width: 1em;
+	height: 1em;
+}
+.conversations img.emoji.jumbo {
+	width: 1em;
+	height: 1em;
+}

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -722,6 +722,22 @@ img.emoji.jumbo {
   width: 2em;
   height: 2em; }
 
+.conversations img.emoji.small {
+  width: 1em;
+  height: 1em; }
+
+.conversations img.emoji.medium {
+  width: 1em;
+  height: 1em; }
+
+.conversations img.emoji.large {
+  width: 1em;
+  height: 1em; }
+
+.conversations img.emoji.jumbo {
+  width: 1	em;
+  height: 1em; }
+
 .settings.modal {
   padding: 50px; }
   .settings.modal .content {


### PR DESCRIPTION
Fixes #1265

Small CSS change to keep the left-nav item size consistent.