### PR TITLE
Legacy message cleanup

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38691,8 +38691,6 @@ function OutgoingMessage(server, timestamp, numbers, message, callback) {
     this.numbers = numbers;
     this.message = message; // ContentMessage proto
     this.callback = callback;
-    this.legacy = (message instanceof textsecure.protobuf.DataMessage);
-
 
     this.numbersCompleted = 0;
     this.errors = [];

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38798,20 +38798,27 @@ OutgoingMessage.prototype = {
         return messagePartCount * 160;
     },
 
+    getPlaintext: function() {
+        if (!this.plaintext) {
+            var messageBuffer = this.message.toArrayBuffer();
+            this.plaintext = new Uint8Array(
+                this.getPaddedMessageLength(messageBuffer.byteLength + 1) - 1
+            );
+            this.plaintext.set(new Uint8Array(messageBuffer));
+            this.plaintext[messageBuffer.byteLength] = 0x80;
+        }
+        return this.plaintext;
+    },
+
     doSendMessage: function(number, deviceIds, recurse) {
         var ciphers = {};
-        var plaintext = this.message.toArrayBuffer();
-        var paddedPlaintext = new Uint8Array(
-            this.getPaddedMessageLength(plaintext.byteLength + 1) - 1
-        );
-        paddedPlaintext.set(new Uint8Array(plaintext));
-        paddedPlaintext[plaintext.byteLength] = 0x80;
+        var plaintext = this.getPlaintext();
 
         return Promise.all(deviceIds.map(function(deviceId) {
             var address = new libsignal.SignalProtocolAddress(number, deviceId);
-            var sessionCipher =  new libsignal.SessionCipher(textsecure.storage.protocol, address);
+            var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address);
             ciphers[address.getDeviceId()] = sessionCipher;
-            return sessionCipher.encrypt(paddedPlaintext).then(function(ciphertext) {
+            return sessionCipher.encrypt(plaintext).then(function(ciphertext) {
                 return {
                     type                      : ciphertext.type,
                     destinationDeviceId       : address.getDeviceId(),

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -12,8 +12,6 @@ function OutgoingMessage(server, timestamp, numbers, message, callback) {
     this.numbers = numbers;
     this.message = message; // ContentMessage proto
     this.callback = callback;
-    this.legacy = (message instanceof textsecure.protobuf.DataMessage);
-
 
     this.numbersCompleted = 0;
     this.errors = [];

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -132,7 +132,14 @@ OutgoingMessage.prototype = {
             var address = new libsignal.SignalProtocolAddress(number, deviceId);
             var sessionCipher =  new libsignal.SessionCipher(textsecure.storage.protocol, address);
             ciphers[address.getDeviceId()] = sessionCipher;
-            return this.encryptToDevice(address, paddedPlaintext, sessionCipher);
+            return sessionCipher.encrypt(paddedPlaintext).then(function(ciphertext) {
+                return {
+                    type                      : ciphertext.type,
+                    destinationDeviceId       : address.getDeviceId(),
+                    destinationRegistrationId : ciphertext.registrationId,
+                    content                   : btoa(ciphertext.body)
+                };
+            });
         }.bind(this))).then(function(jsonData) {
             return this.transmitMessage(number, jsonData, this.timestamp).then(function() {
                 this.successfulNumbers[this.successfulNumbers.length] = number;
@@ -164,25 +171,6 @@ OutgoingMessage.prototype = {
                 this.registerError(number, "Failed to create or send message", error);
             }
         }.bind(this));
-    },
-
-    encryptToDevice: function(address, plaintext, sessionCipher) {
-        return sessionCipher.encrypt(plaintext).then(function(ciphertext) {
-            return this.toJSON(address, ciphertext);
-        }.bind(this));
-    },
-
-    toJSON: function(address, encryptedMsg) {
-        var json = {
-            type                      : encryptedMsg.type,
-            destinationDeviceId       : address.getDeviceId(),
-            destinationRegistrationId : encryptedMsg.registrationId
-        };
-
-        var content = btoa(encryptedMsg.body);
-        json.content = content;
-
-        return json;
     },
 
     getStaleDeviceIdsForNumber: function(number) {


### PR DESCRIPTION
A bit of cleanup on the heels of e8548879db405d9bcd78b82a456ad8d655592c0f.

* Simplify some code
* Remove an unused property

While I was there I also noticed we were creating a new padded plaintext buffer for each recipient, which is unnecessary since the plaintext message is the same for everybody.