### PR TITLE
i18n now supports duplicate replacements, out-of-order strings

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -8,19 +8,33 @@
     var messages = window.config.localeMessages;
     var locale = window.config.locale;
 
-    window.i18n = function (message, substitutions) {
-      if (!messages[message]) {
+    window.i18n = function (key, values) {
+      var data = messages[key];
+      if (!data) {
         return;
       }
-      var s = messages[message].message;
-      if (substitutions instanceof Array) {
-        substitutions.forEach(function(sub) {
-          s = s.replace(/\$.+?\$/, sub);
-        });
-      } else if (substitutions) {
-        s = s.replace(/\$.+?\$/, substitutions);
+
+      var message = data.message;
+      var placeholders = data.placeholders;
+      if (!values || !placeholders) {
+        return message;
       }
-      return s;
+
+      if (!(values instanceof Array)) {
+        values = [values];
+      }
+
+      var names = Object.keys(placeholders);
+      for (var i = 0, max = names.length; i < max; i += 1) {
+        var name = names[i];
+        var value = values[i]
+
+        var r = new RegExp('\\$' + name + '\\$', 'g');
+
+        message = message.replace(r, value);
+      }
+
+      return message;
     };
 
     i18n.getLocale = function() {

--- a/test/i18n_test.js
+++ b/test/i18n_test.js
@@ -14,6 +14,10 @@ describe('i18n', function() {
       const actual = i18n('verifyContact', ['<strong>', '</strong>']);
       assert.equal(actual, 'You may wish to <strong> verify </strong> your safety number with this contact.');
     });
+    it('handles duplicates of the same substitution', function() {
+      const actual = i18n('changedSinceVerified', 'Someone');
+      assert.equal(actual, 'Your safety number with Someone has changed since you last verified. This could mean that someone is trying to intercept your communication or that Someone has simply reinstalled Signal.');
+    });
   });
 
   describe('getLocale', function() {


### PR DESCRIPTION
Our previous implementation had two problems:

- Multiple instances of the same $name$ would be replaced with two different values from the provided set of values.
- Re-ordering of replacement values in other languages would cause problems, since we previous did a linear search for $<anything>$ and replaced that with the corresponding array index in the values array.