### PR TITLE
Fix dark theme button hover color

### DIFF
--- a/stylesheets/android-dark.scss
+++ b/stylesheets/android-dark.scss
@@ -242,4 +242,10 @@ $text-dark: #CCCCCC;
       }
     }
   }
+  .choose-file button:hover {
+    background-color: $grey-dark;
+  }
+  .capture-audio button:hover {
+    background-color: $grey-dark;
+  }
 }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -2178,5 +2178,9 @@ li.entry .error-icon-container {
         background-color: white; }
       .android-dark .discussion-container .scroll-down-button-view button.new-messages:hover {
         background-color: #1472bd; }
+  .android-dark .choose-file button:hover {
+    background-color: #333333; }
+  .android-dark .capture-audio button:hover {
+    background-color: #333333; }
 
 /*# sourceMappingURL=manifest.css.map */


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Debian 9, Chrome 59.0.3071.109 64-bit
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

Fixes the "choose file" and "capture audio" button colors to match the rest of the Android dark theme.
