### PR TITLE
Add conventional changelog for tracking releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+<a name="0.41.2"></a>
+# [0.41.2](https://github.com/WhisperSystems/Signal-Desktop/compare/v0.41.2...v0.41.1) (2017-06-26)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "signal-desktop",
   "repository": "https://github.com/WhisperSystems/Signal-Desktop.git",
-  "version": "0.0.0",
+  "version": "0.41.2",
   "devDependencies": {
     "bower": "^1.3.12",
     "grunt": "^0.4.5",
@@ -16,10 +16,12 @@
     "grunt-gitinfo": "^0.1.7",
     "grunt-jscs": "^1.1.0",
     "grunt-preen": "^1.0.0",
-    "grunt-saucelabs": "^8.3.3"
+    "grunt-saucelabs": "^8.3.3",
+    "standard-version": "^4.2.0"
   },
   "scripts": {
     "test": "grunt test",
-    "lint": "grunt jshint"
+    "lint": "grunt jshint",
+    "release": "standard-version && git push --follow-tags origin master"
   }
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
 * Amiga OS 3.1, Chrom{e,ium} Z.Y
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

Did some research into conventional changelog after talking with @scottnonnenberg , and got this initial commit to lay the foundation for having a consistent changelog format.

I had to massage the initial commit somewhat as we aren't starting from v0.0.0, but rather v0.41.2. I also didn't include any actual changes in this initial commit as the commits don't really follow the commit message outlines here:

https://github.com/conventional-changelog/standard-version

It's worth discussing - since the commit messages will need to follow a bit of semantics, is it worth updating the default checklist that all new pull requests see?