### PR TITLE
Disable menu item text capitalization in iOS theme

### DIFF
--- a/stylesheets/_ios.scss
+++ b/stylesheets/_ios.scss
@@ -64,10 +64,6 @@ $ios-border-color: rgba(0,0,0,0.1);
     }
     .avatar { display: none; }
   }
-  .settings h3,
-  .menu-list li {
-    text-transform: capitalize;
-  }
   .bottom-bar {
     padding: 15px;
     min-height: 30px;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -735,7 +735,7 @@ img.emoji.jumbo {
   height: 1em; }
 
 .conversations img.emoji.jumbo {
-  width: 1	em;
+  width: 1em;
   height: 1em; }
 
 .settings.modal {
@@ -1620,9 +1620,6 @@ li.entry .error-icon-container {
     line-height: 64px; }
   .ios .conversation-header .avatar {
     display: none; }
-.ios .settings h3,
-.ios .menu-list li {
-  text-transform: capitalize; }
 .ios .bottom-bar {
   padding: 15px;
   min-height: 30px;


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Debian 9, Chrome 59.0.3071.109 64-bit
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description

Disables the menu text capitalization in the iOS theme. It's grammatically incorrect and isn't present in Android theme(s).