### PR TITLE
UI modifications to match Android, handle UNVERIFIED syncs, and more!

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -37,7 +37,7 @@
     "globalstrict"  : false,
     "iterator"      : false,
     "lastsemic"     : false,
-    "laxbreak"      : false,
+    "laxbreak"      : true,
     "laxcomma"      : false,
     "loopfunc"      : false,
     "multistr"      : false,

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -171,7 +171,7 @@
       "message": "Mark as verified"
     },
     "unverify": {
-      "message": "Clear verification"
+      "message": "Mark as not verified"
     },
     "isVerified": {
       "message": "You have verified your safety number with $name$.",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -475,6 +475,10 @@
         "message": "Message not sent.",
         "description": "Informational label, appears on messages that failed to send"
     },
+    "someRecipientsFailed": {
+        "message": "Some recipients failed",
+        "description": "Informational label, for messages where some recipients succeeded, others failed"
+    },
     "showMore": {
         "message": "Details",
         "description": "Displays the details of a key change"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,6 +3,10 @@
       "message": "Me",
       "description": "The label for yourself when shown in a group member list"
     },
+    "view": {
+      "message": "View",
+      "description": "Used as a label on a button allowing user to see more information"
+    },
     "youLeftTheGroup": {
       "message": "You left the group",
       "description": "Displayed when a user can't send a message because they have left the group"
@@ -105,9 +109,15 @@
         }
       }
     },
-    "retryDescription": {
-      "message": "You can retry sending this message to each of the failed recipients with these buttons:",
-      "description": "Shows on the message details view when it's a message error which can be retried."
+    "identityKeyErrorOnSend": {
+      "message": "Your safety number with $name$ has changed. This could either mean that someone is trying to intercept your communication or that $name$ has simply reinstalled Signal. You may wish to verify your saftey number with this contact.",
+      "description": "Shown when user clicks on a failed recipient in the message detail view after an identity key change",
+      "placeholders": {
+        "name": {
+          "content": "$1",
+          "example": "Bob"
+        }
+      }
     },
     "sendAnyway": {
       "message": "Send Anyway",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -34,7 +34,7 @@
       }
     },
     "youMarkedAsVerified": {
-      "message": "You marked $name$ as verified.",
+      "message": "You marked your safety number with $name$ as verified.",
       "description": "Shown in the conversation history when the user marks a contact as verified.",
       "placeholders": {
         "name": {
@@ -44,7 +44,7 @@
       }
     },
     "youMarkedAsNotVerified": {
-      "message": "You marked $name$ as not verified.",
+      "message": "You marked your safety number with $name$ as unverified.",
       "description": "Shown in the conversation history when the user marks a contact as not verified, whether on the safety number screen or by dismissing a banner or dialog.",
       "placeholders": {
         "name": {
@@ -54,7 +54,7 @@
       }
     },
     "youMarkedAsVerifiedOtherDevice": {
-      "message": "You marked $name$ as verified on another device.",
+      "message": "You marked your safety number with $name$ as verified from another device.",
       "description": "Shown in the conversation history when we discover that the user marked a contact as verified on another device.",
       "placeholders": {
         "name": {
@@ -64,7 +64,7 @@
       }
     },
     "youMarkedAsNotVerifiedOtherDevice": {
-      "message": "You marked $name$ as not verified on anther device.",
+      "message": "You marked your safety number with $name$ as not verified from another device.",
       "description": "Shown in the conversation history when we discover that the user marked a contact as not verified on another device.",
       "placeholders": {
         "name": {
@@ -158,10 +158,13 @@
       "description": "Label for a button to accept a new safety number"
     },
     "verify": {
-      "message": "Verify"
+      "message": "Mark as verified"
+    },
+    "unverify": {
+      "message": "Clear verification"
     },
     "isVerified": {
-      "message": "$name$ is verified.",
+      "message": "You have verified your safety number with $name$.",
       "description": "Summary state shown at top of the safety number screen if user has verified contact.",
       "placeholders": {
         "name": {
@@ -171,7 +174,7 @@
       }
     },
     "isNotVerified": {
-      "message": "$name$ is not verified.",
+      "message": "You have not verified your safety number with $name$.",
       "description": "Summary state shown at top of the safety number screen if user has not verified contact.",
       "placeholders": {
         "name": {
@@ -305,9 +308,6 @@
     },
     "showSafetyNumber": {
       "message": "Show safety number"
-    },
-    "markAsNotVerified": {
-      "message": "Mark as not verified"
     },
     "verifyHelp": {
       "message": "If you wish to verify the security of your end-to-end encryption with $name$, compare the numbers above with the numbers on their device.",

--- a/background.html
+++ b/background.html
@@ -337,15 +337,6 @@
   </script>
   <script type='text/x-tmpl-mustache' id='key-verification'>
     <div class='container'>
-      <div class='summary'>
-        {{ #isVerified }}
-          <span class='icon verified'></span>
-        {{ /isVerified }}
-        {{ ^isVerified }}
-          <span class='icon shield'></span>
-        {{ /isVerified }}
-        {{ verifiedStatus }}
-      </div>
       {{ ^has_their_key }}
         <div class='placeholder'>{{ their_key_unknown }}</div>
       {{ /has_their_key }}
@@ -358,6 +349,15 @@
       {{ /has_their_key }}
       {{ verifyHelp }}
       <p> {{> link_to_support }} </p>
+      <div class='summary'>
+        {{ #isVerified }}
+          <span class='icon verified'></span>
+        {{ /isVerified }}
+        {{ ^isVerified }}
+          <span class='icon shield'></span>
+        {{ /isVerified }}
+        {{ verifiedStatus }}
+      </div>
       <div class='verify'>
         <button class='verify grey'>
           {{ verifyButton }}

--- a/background.html
+++ b/background.html
@@ -191,6 +191,9 @@
     {{ messageNotSent }}
     <span href='#' class='retry'>{{ resend }}</span>
   </script>
+  <script type='text/x-tmpl-mustache' id='some-failed'>
+    {{ someFailed }}
+  </script>
   <script type='text/x-tmpl-mustache' id='keychange'>
       <span class='content' dir='auto'><span class='shield icon'></span> {{ content }}</span>
   </script>

--- a/background.html
+++ b/background.html
@@ -297,14 +297,6 @@
   <script type='text/x-tmpl-mustache' id='message-detail'>
     <div class='container'>
       <div class='message-container'></div>
-      {{ #allowRetry }}
-        <div class='retries'>
-          <div>{{ retryDescription }}</div>
-          {{ #retryTargets }}
-            <button class='retry gray' data-number='{{ number }}'>{{ title }}</button>
-          {{ /retryTargets }}
-        </div>
-      {{ /allowRetry }}
       <div class='info'>
         <table>
           {{ #errors }}
@@ -327,6 +319,20 @@
         </table>
         <div class='contacts'>
         </div>
+      </div>
+    </div>
+  </script>
+  <script type='text/x-tmpl-mustache' id='identity-key-send-error'>
+    <div class='container'>
+      <div class='explanation'>
+        {{ errorExplanation }}
+      </div>
+      <div class='safety-number'>
+        <button class='show-safety-number grey'>{{ showSafetyNumber }}</button>
+      </div>
+      <div class='actions'>
+        <button class='send-anyway grey'>{{ sendAnyway }}</button>
+        <button class='cancel grey'>{{ cancel }}</button>
       </div>
     </div>
   </script>
@@ -415,7 +421,15 @@
         <div class='contact-details'>
           {{ #errors }}
               <div class='error-icon-container'>
-                <span class='error-icon'></span>
+                {{ #showErrorButton }}
+                  <button class='error'>
+                    <span class='icon error'></span>
+                    {{ errorButtonLabel }}
+                  </button>
+                {{ /showErrorButton }}
+                {{ ^showErrorButton }}
+                  <span class='error-icon'></span>
+                {{ /showErrorButton }}
               </div>
           {{ /errors }}
           <span class='name' dir='auto'>{{ name }}</span>
@@ -680,8 +694,9 @@
   <script type='text/javascript' src='js/views/confirmation_dialog_view.js'></script>
   <script type='text/javascript' src='js/views/identicon_svg_view.js'></script>
   <script type='text/javascript' src='js/views/settings_view.js'></script>
-  <script type="text/javascript" src="js/views/install_view.js"></script>
-  <script type="text/javascript" src="js/views/banner_view.js"></script>
+  <script type='text/javascript' src='js/views/install_view.js'></script>
+  <script type='text/javascript' src='js/views/banner_view.js'></script>
+  <script type='text/javascript' src='js/views/identity_key_send_error_view.js'></script>
 
   <script type='text/javascript' src='js/wall_clock_listener.js'></script>
   <script type='text/javascript' src='js/rotate_signed_prekey_listener.js'></script>

--- a/js/background.js
+++ b/js/background.js
@@ -315,10 +315,16 @@
             return;
         }
 
+        var options = {
+            viaSyncMessage: true,
+            viaContactSync: ev.viaContactSync,
+            key: key
+        };
+
         if (state === 'DEFAULT') {
-            contact.setVerifiedDefault({viaSyncMessage: true, key: key});
+            contact.setVerifiedDefault(options);
         } else if (state === 'VERIFIED') {
-            contact.setVerified({viaSyncMessage: true, key: key});
+            contact.setVerified(options);
         }
     }
 

--- a/js/background.js
+++ b/js/background.js
@@ -321,10 +321,12 @@
             key: key
         };
 
-        if (state === 'DEFAULT') {
-            contact.setVerifiedDefault(options);
-        } else if (state === 'VERIFIED') {
+        if (state === 'VERIFIED') {
             contact.setVerified(options);
+        } else if (state === 'DEFAULT') {
+            contact.setVerifiedDefault(options);
+        } else {
+            contact.setUnverified(options);
         }
     }
 

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38493,13 +38493,17 @@ MessageReceiver.prototype.extend({
             throw new Error('Got empty SyncMessage');
         }
     },
-    handleVerified: function(verified) {
+    handleVerified: function(verified, options) {
+        options = options || {};
+        _.defaults(options, {viaContactSync: false});
+
         var ev = new Event('verified');
         ev.verified = {
             state: verified.state,
             destination: verified.destination,
             identityKey: verified.identityKey.toArrayBuffer()
         };
+        ev.viaContactSync = options.viaContactSync;
         this.dispatchEvent(ev);
     },
     handleRead: function(read, timestamp) {
@@ -38526,7 +38530,7 @@ MessageReceiver.prototype.extend({
                 eventTarget.dispatchEvent(ev);
 
                 if (contactDetails.verified) {
-                    this.handleVerified(contactDetails.verified);
+                    this.handleVerified(contactDetails.verified, {viaContactSync: true});
                 }
 
                 contactDetails = contactBuffer.next();

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -142,8 +142,7 @@
                 || (beginningVerified !== verified && verified !== UNVERIFIED)
                 || (keychange && verified === VERIFIED)) {
 
-                var local = !options.viaSyncMessage && !options.viaContactSync;
-                this.addVerifiedChange(this.id, verified === VERIFIED, {local: local});
+                this.addVerifiedChange(this.id, verified === VERIFIED, {local: !options.viaSyncMessage});
             }
             if (!options.viaSyncMessage) {
                 return this.sendVerifySyncMessage(this.id, verified);
@@ -302,7 +301,7 @@
         if (this.isPrivate()) {
             var groups = ConversationController.getAllGroupsInvolvingId(id);
             _.forEach(groups, function(group) {
-                group.addVerifiedChange(id, verified);
+                group.addVerifiedChange(id, verified, options);
             });
         }
     },

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -122,7 +122,7 @@
         }.bind(this));
     },
     sendVerifySyncMessage: function(number, state) {
-        textsecure.storage.protocol.loadIdentityKey(number).then(function(key) {
+        return textsecure.storage.protocol.loadIdentityKey(number).then(function(key) {
             return textsecure.messaging.syncVerification(number, state, key);
         });
     },

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -202,6 +202,14 @@
             }.bind(this)));
         }
     },
+    setTrusted: function() {
+        if (!this.isPrivate()) {
+            throw new Error('You cannot set a group conversation as trusted. ' +
+                            'You must set individual contacts as trusted.');
+        }
+
+        return textsecure.storage.protocol.setApproval(this.id, true);
+    },
     isUntrusted: function() {
         if (this.isPrivate()) {
             return textsecure.storage.protocol.isUntrusted(this.id);

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -202,7 +202,7 @@
             }.bind(this)));
         }
     },
-    setTrusted: function() {
+    setApproved: function() {
         if (!this.isPrivate()) {
             throw new Error('You cannot set a group conversation as trusted. ' +
                             'You must set individual contacts as trusted.');

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -249,6 +249,25 @@
             }.bind(this));
         },
 
+        someRecipientsFailed: function() {
+            var c = this.getConversation();
+            if (c.isPrivate()) {
+                return false;
+            }
+
+            var recipients = c.contactCollection.length - 1;
+            var errors = this.get('errors');
+            if (!errors) {
+                return false;
+            }
+
+            if (errors.length > 0 && recipients > 0 && errors.length < recipients) {
+                return true;
+            }
+
+            return false;
+        },
+
         sendSyncMessage: function() {
             this.syncPromise = this.syncPromise || Promise.resolve();
             this.syncPromise = this.syncPromise.then(function() {

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -331,10 +331,10 @@
                     var promises = [];
                     while (sessions.length > 0) {
                         promises.push(new Promise(function(res) {
-                            sessions.pop().destroy().then(res);
+                            sessions.pop().destroy().then(res, res);
                         }));
                     }
-                    Promise.all(promises).then(resolve);
+                    Promise.all(promises).then(resolve, resolve);
                 });
             });
         },
@@ -472,7 +472,7 @@
                             this.archiveSiblingSessions(identifier).then(function() {
                                 resolve(true);
                             }, reject);
-                        }.bind(this));
+                        }.bind(this), reject);
                     } else if (this.isNonBlockingApprovalRequired(identityRecord)) {
                         console.log("Setting approval status...");
                         identityRecord.save({
@@ -547,7 +547,7 @@
                             identityRecord.save({
                             }).then(function() {
                                 resolve();
-                            });
+                            }, reject);
                         } else {
                             reject(identityRecord.validationError);
                         }

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -625,9 +625,12 @@
                             timestamp           : Date.now(),
                             nonblockingApproval : true
                         }).then(function() {
-                            if (!isPresent || !isEqual) {
+                            if (isPresent && !isEqual) {
                                 this.trigger('keychange', identifier);
-                                return this.archiveAllSessions(identifier).then(resolve, reject);
+                                return this.archiveAllSessions(identifier).then(function() {
+                                    // true signifies that we overwrote a previous key with a new one
+                                    return resolve(true);
+                                }, reject);
                             }
 
                             return resolve();

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -325,16 +325,16 @@
             if (number === null || number === undefined) {
                 throw new Error("Tried to remove sessions for undefined/null number");
             }
-            return new Promise(function(resolve) {
+            return new Promise(function(resolve, reject) {
                 var sessions = new SessionCollection();
                 sessions.fetchSessionsForNumber(number).always(function() {
                     var promises = [];
                     while (sessions.length > 0) {
-                        promises.push(new Promise(function(res) {
-                            sessions.pop().destroy().then(res, res);
+                        promises.push(new Promise(function(res, rej) {
+                            sessions.pop().destroy().then(res, rej);
                         }));
                     }
-                    Promise.all(promises).then(resolve, resolve);
+                    Promise.all(promises).then(resolve, reject);
                 });
             });
         },

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -638,6 +638,9 @@
 
         listenBack: function(view) {
             this.panels = this.panels || [];
+            if (this.panels.length > 0) {
+                this.panels[0].$el.hide();
+            }
             this.panels.unshift(view);
 
             if (this.panels.length === 1) {
@@ -649,6 +652,9 @@
         },
         resetPanel: function() {
             var view = this.panels.shift();
+            if (this.panels.length > 0) {
+                this.panels[0].$el.show();
+            }
             view.remove();
 
             if (this.panels.length === 0) {

--- a/js/views/identity_key_send_error_view.js
+++ b/js/views/identity_key_send_error_view.js
@@ -1,0 +1,51 @@
+/*
+ * vim: ts=4:sw=4:expandtab
+ */
+(function () {
+    'use strict';
+    window.Whisper = window.Whisper || {};
+
+    Whisper.IdentityKeySendErrorPanelView = Whisper.View.extend({
+        className: 'identity-key-send-error panel',
+        templateName: 'identity-key-send-error',
+        initialize: function(options) {
+            this.listenBack = options.listenBack;
+            this.resetPanel = options.resetPanel;
+
+            this.wasUnverified = this.model.isUnverified();
+            this.listenTo(this.model, 'change', this.render);
+        },
+        events: {
+            'click .show-safety-number': 'showSafetyNumber',
+            'click .send-anyway': 'sendAnyway',
+            'click .cancel': 'cancel'
+        },
+        showSafetyNumber: function() {
+            var view = new Whisper.KeyVerificationPanelView({
+                model: this.model
+            });
+            this.listenBack(view);
+        },
+        sendAnyway: function() {
+            this.resetPanel();
+            this.trigger('send-anyway');
+        },
+        cancel: function() {
+            this.resetPanel();
+        },
+        render_attributes: function() {
+            var send = i18n('sendAnyway');
+            if (this.wasUnverified && !this.model.isUnverified()) {
+                send = i18n('resend');
+            }
+
+            var errorExplanation = i18n('identityKeyErrorOnSend', this.model.getTitle(), this.model.getTitle());
+            return {
+                errorExplanation : errorExplanation,
+                showSafetyNumber : i18n('showSafetyNumber'),
+                sendAnyway       : send,
+                cancel           : i18n('cancel')
+            };
+        }
+    });
+})();

--- a/js/views/key_verification_view.js
+++ b/js/views/key_verification_view.js
@@ -75,7 +75,7 @@
             var name = this.model.getTitle();
             var yourSafetyNumberWith = i18n('yourSafetyNumberWith', name);
             var isVerified = this.model.isVerified();
-            var verifyButton = isVerified ? i18n('markAsNotVerified') : i18n('verify');
+            var verifyButton = isVerified ? i18n('unverify') : i18n('verify');
             var verifiedStatus = isVerified ? i18n('isVerified', name) : i18n('isNotVerified', name);
 
             return {

--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -52,7 +52,7 @@
                 return this.model.isUntrusted();
             }.bind(this)).then(function(untrusted) {
                 if (untrusted) {
-                    return this.model.setTrusted();
+                    return this.model.setApproved();
                 }
             }.bind(this)).then(function() {
                 this.message.resend(this.outgoingKeyError.number);

--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -38,9 +38,10 @@
                 this.listenTo(view, 'send-anyway', this.onSendAnyway);
 
                 view.render();
+
                 this.listenBack(view);
+                view.$('.cancel').focus();
             }
-            // TODO: is there anything we might want to do here? Pop a confirmation dialog? Ideally it would always have error-specific help.
         },
         forceSend: function() {
             this.model.updateVerified().then(function() {

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -25,6 +25,14 @@
             resend: i18n('resend')
         }
     });
+    var SomeFailedView = Whisper.View.extend({
+        tagName: 'span',
+        className: 'some-failed',
+        templateName: 'some-failed',
+        render_attributes: {
+            someFailed: i18n('someRecipientsFailed')
+        }
+    });
     var TimerView = Whisper.View.extend({
         templateName: 'hourglass',
         update: function() {
@@ -172,6 +180,7 @@
             'click .error-icon': 'select',
             'click .timestamp': 'select',
             'click .status': 'select',
+            'click .some-failed': 'select',
             'click .error-message': 'select'
         },
         retryMessage: function() {
@@ -240,6 +249,10 @@
             this.$('.meta .hasRetry').remove();
             if (this.model.hasNetworkError()) {
                 this.$('.meta').prepend(new NetworkErrorView().render().el);
+            }
+            this.$('.meta .some-failed').remove();
+            if (this.model.someRecipientsFailed()) {
+                this.$('.meta').prepend(new SomeFailedView().render().el);
             }
         },
         renderControl: function() {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -284,13 +284,17 @@ MessageReceiver.prototype.extend({
             throw new Error('Got empty SyncMessage');
         }
     },
-    handleVerified: function(verified) {
+    handleVerified: function(verified, options) {
+        options = options || {};
+        _.defaults(options, {viaContactSync: false});
+
         var ev = new Event('verified');
         ev.verified = {
             state: verified.state,
             destination: verified.destination,
             identityKey: verified.identityKey.toArrayBuffer()
         };
+        ev.viaContactSync = options.viaContactSync;
         this.dispatchEvent(ev);
     },
     handleRead: function(read, timestamp) {
@@ -317,7 +321,7 @@ MessageReceiver.prototype.extend({
                 eventTarget.dispatchEvent(ev);
 
                 if (contactDetails.verified) {
-                    this.handleVerified(contactDetails.verified);
+                    this.handleVerified(contactDetails.verified, {viaContactSync: true});
                 }
 
                 contactDetails = contactBuffer.next();

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -406,11 +406,17 @@ li.entry .error-icon-container {
       cursor: pointer;
     }
 
+    .some-failed {
+      float: left;
+      margin-left: 6px;
+      margin-right: 6px;
+    }
+
     .hasRetry, .timestamp, .status, .timer {
       float: left;
     }
 
-    .timestamp, .status {
+    .timestamp, .status, .some-failed {
       cursor: pointer;
       opacity: 0.5;
 

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -39,7 +39,7 @@
 
     .container {
       padding-top: 20px;
-      max-width: 950px;
+      max-width: 750px;
       margin: 0 auto;
       padding: 20px;
     }
@@ -77,10 +77,6 @@
 }
 
 .key-verification {
-  .container {
-    max-width: 750px;
-  }
-
   label {
     display: block;
     margin: 10px 0;
@@ -150,6 +146,24 @@
   }
 }
 
+.identity-key-send-error {
+  button {
+    margin-top: 0px;
+    margin-bottom: 0px;
+  }
+  .explanation {
+    margin-top: 20px;
+  }
+  .safety-number {
+    margin-top: 30px;
+    text-align: center;
+  }
+  .actions {
+    margin-top: 30px;
+    text-align: center;
+  }
+}
+
 .message-detail {
   background-color: #eee;
 
@@ -196,6 +210,20 @@
 
     .error-icon-container {
       float: right;
+    }
+
+    button.error {
+      background-color: red;
+      color: white;
+
+      span.icon.error {
+        display: inline-block;
+        width: 1.25em;
+        height: 1.25em;
+        position: relative;
+        vertical-align: middle;
+        @include color-svg('/images/warning.svg', white);
+      }
     }
 
     .error-message {

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -77,15 +77,14 @@
 }
 
 .key-verification {
+  .container {
+    max-width: 750px;
+  }
+
   label {
     display: block;
     margin: 10px 0;
     font-size: $font-size-small;
-  }
-
-  .summary {
-    margin: 10px 0;
-    text-align: center;
   }
 
   .icon {
@@ -135,6 +134,11 @@
     }
   }
 
+  .summary {
+    margin: 30px 0 10px;
+    text-align: center;
+  }
+
   div.verify {
     text-align: center;
   }
@@ -142,9 +146,8 @@
     border-radius: 5px;
     font-weight: bold;
     padding: 10px;
+    margin: 0;
   }
-
-
 }
 
 .message-detail {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1041,7 +1041,7 @@ input.search {
     overflow-y: scroll; }
     .conversation .panel .container {
       padding-top: 20px;
-      max-width: 950px;
+      max-width: 750px;
       margin: 0 auto;
       padding: 20px; }
   .conversation .main.panel {
@@ -1067,8 +1067,6 @@ input.search {
 .discussion-container {
   background-color: #eee; }
 
-.key-verification .container {
-  max-width: 750px; }
 .key-verification label {
   display: block;
   margin: 10px 0;
@@ -1123,6 +1121,18 @@ input.search {
   padding: 10px;
   margin: 0; }
 
+.identity-key-send-error button {
+  margin-top: 0px;
+  margin-bottom: 0px; }
+.identity-key-send-error .explanation {
+  margin-top: 20px; }
+.identity-key-send-error .safety-number {
+  margin-top: 30px;
+  text-align: center; }
+.identity-key-send-error .actions {
+  margin-top: 30px;
+  text-align: center; }
+
 .message-detail {
   background-color: #eee; }
   .message-detail .message-container {
@@ -1152,6 +1162,18 @@ input.search {
     margin-bottom: 5px; }
     .message-detail .contacts .contact-detail .error-icon-container {
       float: right; }
+    .message-detail .contacts .contact-detail button.error {
+      background-color: red;
+      color: white; }
+      .message-detail .contacts .contact-detail button.error span.icon.error {
+        display: inline-block;
+        width: 1.25em;
+        height: 1.25em;
+        position: relative;
+        vertical-align: middle;
+        -webkit-mask: url("/images/warning.svg") no-repeat center;
+        -webkit-mask-size: 100%;
+        background-color: white; }
     .message-detail .contacts .contact-detail .error-message {
       margin: 6px 0 0;
       font-size: 0.92857em;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1067,13 +1067,12 @@ input.search {
 .discussion-container {
   background-color: #eee; }
 
+.key-verification .container {
+  max-width: 750px; }
 .key-verification label {
   display: block;
   margin: 10px 0;
   font-size: 0.92857em; }
-.key-verification .summary {
-  margin: 10px 0;
-  text-align: center; }
 .key-verification .icon {
   height: 1.25em;
   width: 1.25em;
@@ -1113,12 +1112,16 @@ input.search {
   .key-verification .qr img {
     display: inline-block;
     max-width: 100%; }
+.key-verification .summary {
+  margin: 30px 0 10px;
+  text-align: center; }
 .key-verification div.verify {
   text-align: center; }
 .key-verification button.verify {
   border-radius: 5px;
   font-weight: bold;
-  padding: 10px; }
+  padding: 10px;
+  margin: 0; }
 
 .message-detail {
   background-color: #eee; }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1316,20 +1316,27 @@ li.entry .error-icon-container {
     .message-list .meta .retry {
       text-decoration: underline;
       cursor: pointer; }
+    .message-container .meta .some-failed,
+    .message-list .meta .some-failed {
+      float: left;
+      margin-left: 6px;
+      margin-right: 6px; }
     .message-container .meta .hasRetry, .message-container .meta .timestamp, .message-container .meta .status, .message-container .meta .timer,
     .message-list .meta .hasRetry,
     .message-list .meta .timestamp,
     .message-list .meta .status,
     .message-list .meta .timer {
       float: left; }
-    .message-container .meta .timestamp, .message-container .meta .status,
+    .message-container .meta .timestamp, .message-container .meta .status, .message-container .meta .some-failed,
     .message-list .meta .timestamp,
-    .message-list .meta .status {
+    .message-list .meta .status,
+    .message-list .meta .some-failed {
       cursor: pointer;
       opacity: 0.5; }
-      .message-container .meta .timestamp:hover, .message-container .meta .status:hover,
+      .message-container .meta .timestamp:hover, .message-container .meta .status:hover, .message-container .meta .some-failed:hover,
       .message-list .meta .timestamp:hover,
-      .message-list .meta .status:hover {
+      .message-list .meta .status:hover,
+      .message-list .meta .some-failed:hover {
         opacity: 1.0; }
   .message-container .status,
   .message-list .status {

--- a/test/index.html
+++ b/test/index.html
@@ -316,6 +316,20 @@
       </div>
     </div>
   </script>
+  <script type='text/x-tmpl-mustache' id='identity-key-send-error'>
+    <div class='container'>
+      <div class='explanation'>
+        {{ errorExplanation }}
+      </div>
+      <div class='safety-number'>
+        <button class='show-safety-number grey'>{{ showSafetyNumber }}</button>
+      </div>
+      <div class='actions'>
+        <button class='send-anyway grey'>{{ sendAnyway }}</button>
+        <button class='cancel grey'>{{ cancel }}</button>
+      </div>
+    </div>
+  </script>
   <script type='text/x-tmpl-mustache' id='group-member-list'>
     <div class='container'>
       {{ #summary }} <div class='summary'>{{ summary }}</div>{{ /summary }}
@@ -588,6 +602,7 @@
   <script type='text/javascript' src='../js/views/last_seen_indicator_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/scroll_down_button_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/banner_view.js' data-cover></script>
+  <script type="text/javascript" src='../js/views/identity_key_send_error_view.js' data-cover></script>
 
   <script type="text/javascript" src="views/whisper_view_test.js"></script>
   <script type="text/javascript" src="views/group_update_view_test.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -546,30 +546,33 @@
     </div>
   </script>
 
-
   <script type="text/javascript" src="../js/components.js"></script>
   <script type="text/javascript" src="test.js"></script>
 
-  <script type='text/javascript' src='../js/registration.js'></script>
-  <script type="text/javascript" src="../js/expire.js"></script>
-  <script type="text/javascript" src="../js/chromium.js"></script>
-  <script type="text/javascript" src="../js/database.js"></script>
-  <script type="text/javascript" src="../js/storage.js"></script>
-  <script type="text/javascript" src="../js/signal_protocol_store.js"></script>
-  <script type="text/javascript" src="../js/libtextsecure.js"></script>
+  <!-- Comment out to turn off code coverage. Useful for getting real callstacks.
+       Don't forget about turning on the mantual test start below! -->
+  <!-- <script type="text/javascript" src="blanket_mocha.js"></script> -->
+
+  <script type='text/javascript' src='../js/registration.js' data-cover></script>
+  <script type="text/javascript" src="../js/expire.js" data-cover></script>
+  <script type="text/javascript" src="../js/chromium.js" data-cover></script>
+  <script type="text/javascript" src="../js/database.js" data-cover></script>
+  <script type="text/javascript" src="../js/storage.js" data-cover></script>
+  <script type="text/javascript" src="../js/signal_protocol_store.js" data-cover></script>
+  <script type="text/javascript" src="../js/libtextsecure.js" data-cover></script>
 
   <script type="text/javascript" src="../js/libphonenumber-util.js"></script>
   <script type="text/javascript" src="../js/models/messages.js" data-cover></script>
   <script type="text/javascript" src="../js/models/conversations.js" data-cover></script>
   <script type="text/javascript" src="../js/models/blockedNumbers.js" data-cover></script>
   <script type="text/javascript" src="../js/conversation_controller.js" data-cover></script>
-  <script type="text/javascript" src="../js/panel_controller.js"></script>
-  <script type='text/javascript' src='../js/emoji_util.js'></script>
-  <script type="text/javascript" src="../js/keychange_listener.js"></script>
-  <script type='text/javascript' src='../js/expiring_messages.js'></script>
-  <script type='text/javascript' src='../js/notifications.js'></script>
+  <script type="text/javascript" src="../js/panel_controller.js" data-cover></script>
+  <script type='text/javascript' src='../js/emoji_util.js' data-cover></script>
+  <script type="text/javascript" src="../js/keychange_listener.js" data-cover></script>
+  <script type='text/javascript' src='../js/expiring_messages.js' data-cover></script>
+  <script type='text/javascript' src='../js/notifications.js' data-cover></script>
 
-  <script type="text/javascript" src="../js/chromium.js"></script>
+  <script type="text/javascript" src="../js/chromium.js" data-cover></script>
 
   <script type='text/javascript' src='../js/views/whisper_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/debug_log_view.js' data-cover></script>
@@ -626,10 +629,7 @@
   <script type="text/javascript" src="fixtures.js"></script>
   <script type="text/javascript" src="fixtures_test.js"></script>
 
-  <!-- Comment out to turn off code coverage. Useful for getting real callstacks. -->
-  <!-- <script type="text/javascript" src="blanket_mocha.js"></script> -->
-
-  <!-- Uncomment to start tests without code coverage enabled -->
+  <!-- Uncomment to start tests without code coverage enabled (don't forget about blanket stuff above) -->
   <script type="text/javascript">
     mocha.run();
   </script>

--- a/test/index.html
+++ b/test/index.html
@@ -323,15 +323,6 @@
   </script>
   <script type='text/x-tmpl-mustache' id='key-verification'>
     <div class='container'>
-      <div class='summary'>
-        {{ #isVerified }}
-          <span class='icon verified'></span>
-        {{ /isVerified }}
-        {{ ^isVerified }}
-          <span class='icon shield'></span>
-        {{ /isVerified }}
-        {{ verifiedStatus }}
-      </div>
       {{ ^has_their_key }}
         <div class='placeholder'>{{ their_key_unknown }}</div>
       {{ /has_their_key }}
@@ -343,6 +334,20 @@
         </div>
       {{ /has_their_key }}
       <p> {{> link_to_support }} </p>
+      <div class='summary'>
+        {{ #isVerified }}
+          <span class='icon verified'></span>
+        {{ /isVerified }}
+        {{ ^isVerified }}
+          <span class='icon shield'></span>
+        {{ /isVerified }}
+        {{ verifiedStatus }}
+      </div>
+      <div class='verify'>
+        <button class='verify grey'>
+          {{ verifyButton }}
+        </button>
+      </div>
     </div>
   </script>
   <!-- index -->

--- a/test/index.html
+++ b/test/index.html
@@ -549,10 +549,6 @@
   <script type="text/javascript" src="../js/components.js"></script>
   <script type="text/javascript" src="test.js"></script>
 
-  <!-- Comment out to turn off code coverage. Useful for getting real callstacks.
-       Don't forget about turning on the mantual test start below! -->
-  <!-- <script type="text/javascript" src="blanket_mocha.js"></script> -->
-
   <script type='text/javascript' src='../js/registration.js' data-cover></script>
   <script type="text/javascript" src="../js/expire.js" data-cover></script>
   <script type="text/javascript" src="../js/chromium.js" data-cover></script>
@@ -629,7 +625,10 @@
   <script type="text/javascript" src="fixtures.js"></script>
   <script type="text/javascript" src="fixtures_test.js"></script>
 
-  <!-- Uncomment to start tests without code coverage enabled (don't forget about blanket stuff above) -->
+  <!-- Comment out to turn off code coverage. Useful for getting real callstacks. -->
+  <!-- <script type="text/javascript" src="blanket_mocha.js"></script> -->
+
+  <!-- Uncomment to start tests without code coverage enabled -->
   <script type="text/javascript">
     mocha.run();
   </script>

--- a/test/keychange_listener_test.js
+++ b/test/keychange_listener_test.js
@@ -1,6 +1,6 @@
 describe('KeyChangeListener', function() {
   var phoneNumberWithKeyChange = '+13016886524';  // nsa
-  var address = new libsignal.SignalProtocolAddress(identifier, 1);
+  var address = new libsignal.SignalProtocolAddress(phoneNumberWithKeyChange, 1);
   var oldKey = libsignal.crypto.getRandomBytes(33);
   var newKey = libsignal.crypto.getRandomBytes(33);
   var store;

--- a/test/storage_test.js
+++ b/test/storage_test.js
@@ -355,7 +355,7 @@ describe("SignalProtocolStore", function() {
       });
     });
   });
-  describe('processVerifiedMessage', function() {
+  describe('processContactSyncVerificationState', function() {
     var record;
     var newIdentity = libsignal.crypto.getRandomBytes(33);
     var keychangeTriggered;
@@ -387,12 +387,12 @@ describe("SignalProtocolStore", function() {
         });
 
         it ('does nothing', function() {
-          return store.processVerifiedMessage(
+          return store.processContactSyncVerificationState(
             identifier, store.VerifiedStatus.DEFAULT, newIdentity
           ).then(fetchRecord).then(function() {
             // fetchRecord resolved so there is a record.
             // Bad.
-            throw new Error("processVerifiedMessage should not save new records");
+            throw new Error("processContactSyncVerificationState should not save new records");
           }, function() {
             assert.strictEqual(keychangeTriggered, 0);
           });
@@ -412,13 +412,13 @@ describe("SignalProtocolStore", function() {
             return wrapDeferred(record.save());
           });
 
-          it ('saves the new identity and marks it DEFAULT', function() {
-            return store.processVerifiedMessage(
+          it ('does not save the new identity (because this is a less secure state)', function() {
+            return store.processContactSyncVerificationState(
               identifier, store.VerifiedStatus.DEFAULT, newIdentity
             ).then(fetchRecord).then(function() {
-              assert.strictEqual(record.get('verified'), store.VerifiedStatus.DEFAULT);
-              assertEqualArrayBuffers(record.get('publicKey'), newIdentity);
-              assert.strictEqual(keychangeTriggered, 1);
+              assert.strictEqual(record.get('verified'), store.VerifiedStatus.VERIFIED);
+              assertEqualArrayBuffers(record.get('publicKey'), testKey.pubKey);
+              assert.strictEqual(keychangeTriggered, 0);
             });
           });
         });
@@ -436,7 +436,7 @@ describe("SignalProtocolStore", function() {
           });
 
           it ('updates the verified status', function() {
-            return store.processVerifiedMessage(
+            return store.processContactSyncVerificationState(
               identifier, store.VerifiedStatus.DEFAULT, testKey.pubKey
             ).then(fetchRecord).then(function() {
               assert.strictEqual(record.get('verified'), store.VerifiedStatus.DEFAULT);
@@ -459,7 +459,7 @@ describe("SignalProtocolStore", function() {
           });
 
           it ('does not hang', function() {
-            return store.processVerifiedMessage(
+            return store.processContactSyncVerificationState(
               identifier, store.VerifiedStatus.DEFAULT, testKey.pubKey
             ).then(fetchRecord).then(function() {
               assert.strictEqual(keychangeTriggered, 0);
@@ -476,7 +476,7 @@ describe("SignalProtocolStore", function() {
         });
 
         it ('saves the new identity and marks it verified', function() {
-          return store.processVerifiedMessage(
+          return store.processContactSyncVerificationState(
             identifier, store.VerifiedStatus.UNVERIFIED, newIdentity
           ).then(fetchRecord).then(function() {
             assert.strictEqual(record.get('verified'), store.VerifiedStatus.UNVERIFIED);
@@ -500,7 +500,7 @@ describe("SignalProtocolStore", function() {
           });
 
           it ('saves the new identity and marks it UNVERIFIED', function() {
-            return store.processVerifiedMessage(
+            return store.processContactSyncVerificationState(
               identifier, store.VerifiedStatus.UNVERIFIED, newIdentity
             ).then(fetchRecord).then(function() {
               assert.strictEqual(record.get('verified'), store.VerifiedStatus.UNVERIFIED);
@@ -523,7 +523,7 @@ describe("SignalProtocolStore", function() {
           });
 
           it ('updates the verified status', function() {
-            return store.processVerifiedMessage(
+            return store.processContactSyncVerificationState(
               identifier, store.VerifiedStatus.UNVERIFIED, testKey.pubKey
             ).then(fetchRecord).then(function() {
               assert.strictEqual(record.get('verified'), store.VerifiedStatus.UNVERIFIED);
@@ -546,7 +546,7 @@ describe("SignalProtocolStore", function() {
           });
 
           it ('does not hang', function() {
-            return store.processVerifiedMessage(
+            return store.processContactSyncVerificationState(
               identifier, store.VerifiedStatus.UNVERIFIED, testKey.pubKey
             ).then(fetchRecord).then(function() {
               assert.strictEqual(keychangeTriggered, 0);
@@ -565,7 +565,7 @@ describe("SignalProtocolStore", function() {
         });
 
         it ('saves the new identity and marks it verified', function() {
-          return store.processVerifiedMessage(
+          return store.processContactSyncVerificationState(
             identifier, store.VerifiedStatus.VERIFIED, newIdentity
           ).then(fetchRecord).then(function() {
             assert.strictEqual(record.get('verified'), store.VerifiedStatus.VERIFIED);
@@ -589,7 +589,7 @@ describe("SignalProtocolStore", function() {
           });
 
           it ('saves the new identity and marks it VERIFIED', function() {
-            return store.processVerifiedMessage(
+            return store.processContactSyncVerificationState(
               identifier, store.VerifiedStatus.VERIFIED, newIdentity
             ).then(fetchRecord).then(function() {
               assert.strictEqual(record.get('verified'), store.VerifiedStatus.VERIFIED);
@@ -612,7 +612,7 @@ describe("SignalProtocolStore", function() {
           });
 
           it ('saves the identity and marks it verified', function() {
-            return store.processVerifiedMessage(
+            return store.processContactSyncVerificationState(
               identifier, store.VerifiedStatus.VERIFIED, testKey.pubKey
             ).then(fetchRecord).then(function() {
               assert.strictEqual(record.get('verified'), store.VerifiedStatus.VERIFIED);
@@ -635,7 +635,7 @@ describe("SignalProtocolStore", function() {
           });
 
           it ('does not hang', function() {
-            return store.processVerifiedMessage(
+            return store.processContactSyncVerificationState(
               identifier, store.VerifiedStatus.VERIFIED, testKey.pubKey
             ).then(fetchRecord).then(function() {
               assert.strictEqual(keychangeTriggered, 0);

--- a/test/storage_test.js
+++ b/test/storage_test.js
@@ -189,8 +189,9 @@ describe("SignalProtocolStore", function() {
           record.save({ firstUse: false }).then(function() { done(); });
         });
         describe('If nonblocking approval is required', function() {
-          var now = Date.now();
+          var now;
           before(function(done) {
+            now = Date.now();
             record.save({ timestamp: now }).then(function() { done(); });
           });
           it('sets non-blocking approval', function(done) {

--- a/test/storage_test.js
+++ b/test/storage_test.js
@@ -442,7 +442,7 @@ describe("SignalProtocolStore", function() {
           ).then(fetchRecord).then(function() {
             assert.strictEqual(record.get('verified'), store.VerifiedStatus.VERIFIED);
             assertEqualArrayBuffers(record.get('publicKey'), newIdentity);
-            assert.strictEqual(keychangeTriggered, 1);
+            assert.strictEqual(keychangeTriggered, 0);
           });
         });
       });


### PR DESCRIPTION
Verification notifications:
- We were showing identity key notifications too often (when we didn't have an identity key before, for example)
- We were showing verification notifications too often (when we got them from contact syncs)
- Because contact sync can send us `UNVERIFIED` keys, a number of changes were needed in the `Conversation` model, our `onVerified` handler, and in `processVerifiedMessage`.

A number of UI updates to match Android: 
- More informative strings which talk about verifying a safety number, and not the contact themselves
- A notification that a group message did not reach all recipients
- When outgoing identity key errors happen (because a getProfile didn't happen beforehand) we have a nicer experience on the message detail screen. A View button like Android, which opens an informative screen, with three options: 'Show Safety Number', 'Send Anyway', and 'Cancel'
- To ensure that the user sees the errors in large groups, the contacts with errors are sorted to the top. Otherwise it's alphabetical.

Miscellaneous:
- Our 'send anyway' button in the confirmation dialog didn't properly break through the five-second warning period after a key change; fixed.
- Fix code coverage instrumentation so that we get coverage for protocol layer (startup takes longer)
- Fix a few errors in tests, both under code coverage and generally
- Turned on the `laxbreak` jshint rule, because leading `||` and `&&` makes complex `if` subclauses easier to read.