### PR TITLE
Show last seen indicator for key change and verification notifications

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -261,7 +261,6 @@
         var message = new Whisper.Message({
             conversationId  : this.id,
             type            : 'verified-change',
-            // why is sent_at set to this.get('timestamp?')
             sent_at         : this.get('timestamp'),
             received_at     : timestamp,
             verifiedChanged : id,
@@ -555,7 +554,7 @@
                 return Boolean(m.sender);
             });
             unreadMessages = unreadMessages.filter(function(m) {
-                return Boolean(m.get('sender'));
+                return Boolean(m.isIncoming());
             });
 
             var unreadCount = unreadMessages.length - read.length;

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -247,7 +247,8 @@
             type           : 'keychange',
             sent_at        : this.get('timestamp'),
             received_at    : timestamp,
-            key_changed    : id
+            key_changed    : id,
+            unread         : 1
         });
         message.save().then(this.trigger.bind(this,'newmessage', message));
     },
@@ -265,7 +266,8 @@
             received_at     : timestamp,
             verifiedChanged : id,
             verified        : verified,
-            local           : options.local
+            local           : options.local,
+            unread          : 1
         });
         message.save().then(this.trigger.bind(this,'newmessage', message));
 
@@ -547,6 +549,14 @@
                     timestamp : m.get('sent_at')
                 };
             }.bind(this));
+
+            // Some messages we're marking read are local notifications with no sender
+            read = _.filter(read, function(m) {
+                return Boolean(m.sender);
+            });
+            unreadMessages = unreadMessages.filter(function(m) {
+                return Boolean(m.get('sender'));
+            });
 
             var unreadCount = unreadMessages.length - read.length;
             this.save({ unreadCount: unreadCount });

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -546,11 +546,8 @@
 
         getLoadedUnreadCount: function() {
             return this.models.reduce(function(total, model) {
-                var count = model.get('unread');
-                if (count === undefined) {
-                    count = 0;
-                }
-                return total + count;
+                var unread = model.get('unread') && model.isIncoming();
+                return total + (unread ? 1 : 0);
             }, 0);
         },
 


### PR DESCRIPTION
This is a relatively simple change - we now give key change and verification change notifications an `unread = 1` property when we save them.

It does have an interesting downstream effect: a conversation's unread count doesn't always reflect what is in the database, since we don't increment `unreadCount` when adding one of these notifications. A couple code changes were required to allow for this.

The trickiest case was this scenario, which we handle properly:
- Alice gets a direct message from Bob, pushing the badge number to 1 on desktop
- Alice was exploring the verify safety number feature with Bob in a group, and went back and forth a couple times. Three notifications show up in the group on desktop.
- On her phone, Alice navigates to the conversation with Bob, and sees four things under the last seen indicator - the new message, then the three verification changes.
- When desktop receives the read sync message from the phone, the badge number for her conversation with Bob should go away (to zero). The temptation is to let it go to three, since there are three unread notifications.