### PR TITLE
Delete individual message

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -296,6 +296,15 @@
     "messageDetail": {
         "message": "Message Detail"
     },
+    "delete": {
+      "message": "Delete"
+    },
+    "deleteWarning": {
+      "message": "Are you sure? Clicking 'delete' will permanently remove this message from this device."
+    },
+    "deleteMessage": {
+      "message": "Delete this message"
+    },
     "from": {
         "message": "From",
         "description": "Label for the sender of a message"

--- a/background.html
+++ b/background.html
@@ -325,6 +325,9 @@
         <div class='contacts'>
         </div>
       </div>
+      <div class='delete-container'>
+        <button class='delete grey'>{{ deleteLabel }}</button>
+      </div>
     </div>
   </script>
   <script type='text/x-tmpl-mustache' id='identity-key-send-error'>

--- a/js/views/confirmation_dialog_view.js
+++ b/js/views/confirmation_dialog_view.js
@@ -10,6 +10,7 @@
         templateName: 'confirmation-dialog',
         initialize: function(options) {
             this.message = options.message;
+            this.hideCancel = options.hideCancel;
 
             this.resolve = options.resolve;
             this.okText = options.okText || i18n('ok');
@@ -27,18 +28,22 @@
         render_attributes: function() {
             return {
                 message: this.message,
-                showCancel: Boolean(this.reject),
+                showCancel: !this.hideCancel,
                 cancel: this.cancelText,
                 ok: this.okText
             };
         },
         ok: function() {
             this.remove();
-            this.resolve();
+            if (this.resolve) {
+                this.resolve();
+            }
         },
         cancel: function() {
             this.remove();
-            this.reject();
+            if (this.reject) {
+                this.reject();
+            }
         },
         onKeyup: function(event) {
             if (event.key === 'Escape' || event.key === 'Esc') {

--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -96,11 +96,11 @@
             var dialog = new Whisper.ConfirmationDialogView({
                 message: i18n('deleteWarning'),
                 okText: i18n('delete'),
+                hideCancel: true,
                 resolve: function() {
                     this.model.destroy();
                     this.resetPanel();
-                }.bind(this),
-                reject: function() {}
+                }.bind(this)
             });
 
             this.$el.prepend(dialog.el);

--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -89,6 +89,23 @@
 
             this.listenTo(this.model, 'change', this.render);
         },
+        events: {
+            'click button.delete': 'onDelete'
+        },
+        onDelete: function() {
+            var dialog = new Whisper.ConfirmationDialogView({
+                message: i18n('deleteWarning'),
+                okText: i18n('delete'),
+                resolve: function() {
+                    this.model.destroy();
+                    this.resetPanel();
+                }.bind(this),
+                reject: function() {}
+            });
+
+            this.$el.prepend(dialog.el);
+            dialog.focusCancel();
+        },
         getContact: function(number) {
             var c = ConversationController.get(number);
             return {
@@ -128,6 +145,7 @@
                 sent            : i18n('sent'),
                 received        : i18n('received'),
                 errorLabel      : i18n('error'),
+                deleteLabel     : i18n('deleteMessage'),
                 retryDescription: i18n('retryDescription')
             }));
             this.view.$el.prependTo(this.$('.message-container'));

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -245,6 +245,15 @@
     color: $grey_d;
     border: solid 1px #ccc;
   }
+
+  .delete-container {
+    text-align: center;
+
+    button.delete {
+      background-color: red;
+      color: white;
+    }
+  }
 }
 .message-list {
   .error-icon {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1186,6 +1186,11 @@ input.search {
     float: right;
     color: #454545;
     border: solid 1px #ccc; }
+  .message-detail .delete-container {
+    text-align: center; }
+    .message-detail .delete-container button.delete {
+      background-color: red;
+      color: white; }
 
 .message-list .error-icon {
   cursor: pointer; }


### PR DESCRIPTION
A big red 'Delete these message' button at the bottom of the message detail pane, with a confirmation dialog to be sure.

I did notice a bit of weirdness with the confirmation dialogs we have right now - when one is active, you can tab around to all focus-able controls and interact with them normally. You can send messages with the dialog showing. Not ideal, but not blocking.