### PR TITLE
Bullet-proof _setVerified and handleDataMessage against rejections

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -128,7 +128,9 @@
         var keychange;
         return promise.then(function(updatedKey) {
             keychange = updatedKey;
-            return this.save({verified: verified});
+            return new Promise(function(resolve) {
+                return this.save({verified: verified}).always(resolve);
+            }.bind(this));
         }.bind(this)).then(function() {
             // Three situations result in a verification notice in the conversation:
             //   1) The message came from an explicit verification in another client (not


### PR DESCRIPTION
Bullet-proofs `_setVerified` and `handleDataMessage` against rejections and the weird behavior we get from `$.Deferred`.

`handleDataMessage` is especially important to get right, because anything that causes us to fail to call `resolve()` will wedge the conversation. Nothing can go out or come in for that conversation until the app is restarted.