### PR TITLE
Bulletproofing: inProgressFetch promise flow

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -636,7 +636,9 @@
     },
 
     fetchMessages: function() {
-        if (!this.id) { return false; }
+        if (!this.id) {
+            return Promise.reject('This conversation has no id!');
+        }
         return this.messageCollection.fetchConversation(this.id, null, this.get('unreadCount'));
     },
 

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -624,7 +624,7 @@
                     // SELECT messages WHERE conversationId = this.id ORDER
                     // received_at DESC
                 };
-                this.fetch(options).then(resolve);
+                this.fetch(options).always(resolve);
             }.bind(this)).then(function() {
                 if (unreadCount > 0) {
                     if (unreadCount <= startingLoadedUnread) {
@@ -637,6 +637,7 @@
                         return;
                     }
 
+                    console.log('fetchConversation: doing another fetch to get all unread');
                     return this.fetchConversation(conversationId, limit, unreadCount);
                 }
             }.bind(this));

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -474,8 +474,10 @@
                     });
                     this.inProgressFetch = null;
                 }.bind(this));
+            }.bind(this)).catch(function(error) {
+                console.log('fetchMessages error:', error && error.stack ? error.stack : error);
+                this.inProgressFetch = null;
             }.bind(this));
-            // TODO catch?
 
             return this.inProgressFetch;
         },


### PR DESCRIPTION
Got a bug report that the badge, with an unread count, persisted despite switching back and forth between other conversations.

This change makes a number of small tweaks to ensure that our `inProgressFetch` promise in `ConversationView` is resolved, so `markRead()` can be called in `onOpened().`