### PR TITLE
Caching, retry and de-duplication of incoming messages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -198,7 +198,6 @@ module.exports = function(grunt) {
           build: process.env.TRAVIS_JOB_ID,
           browsers: [
             { browserName: 'chrome', version: '41' },
-            { platform: 'linux', browserName: 'firefox', version: '34' }
           ],
           testname: 'TextSecure-Browser Tests',
           'max-duration': 300,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,7 @@ module.exports = function(grunt) {
           'libtextsecure/sync_request.js',
           'libtextsecure/contacts_parser.js',
           'libtextsecure/ProvisioningCipher.js',
+          'libtextsecure/task_with_timeout.js',
         ],
         dest: 'js/libtextsecure.js',
       },

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,6 +47,7 @@ module.exports = function(grunt) {
           'libtextsecure/storage.js',
           'libtextsecure/storage/user.js',
           'libtextsecure/storage/groups.js',
+          'libtextsecure/storage/unprocessed.js',
           'libtextsecure/protobufs.js',
           'libtextsecure/websocket-resources.js',
           'libtextsecure/helpers.js',

--- a/background.html
+++ b/background.html
@@ -651,6 +651,7 @@
   </script>
 
   <script type='text/javascript' src='js/components.js'></script>
+  <script type='text/javascript' src='js/reliable_trigger.js'></script>
   <script type='text/javascript' src='js/database.js'></script>
   <script type='text/javascript' src='js/debugLog.js'></script>
   <script type='text/javascript' src='js/storage.js'></script>

--- a/js/database.js
+++ b/js/database.js
@@ -254,6 +254,26 @@
                   console.log(event);
                 };
             }
+        },
+        {
+            version: "14.0",
+            migrate: function(transaction, next) {
+                console.log('migration 14.0');
+                console.log('Adding unprocessed message store');
+                var unprocessed = transaction.db.createObjectStore('unprocessed');
+                unprocessed.createIndex('received', 'timestamp', { unique: false });
+                next();
+            }
+        },
+        {
+            version: "15.0",
+            migrate: function(transaction, next) {
+                console.log('migration 15.0');
+                console.log('Adding messages index for de-duplication');
+                var messages = transaction.objectStore('messages');
+                messages.createIndex('unique', ['source', 'sourceDevice', 'sent_at'], { unique: true });
+                next();
+            }
         }
     ];
 }());

--- a/js/debugLog.js
+++ b/js/debugLog.js
@@ -40,7 +40,7 @@
         }
     });
 
-    var MAX_MESSAGES = 1000;
+    var MAX_MESSAGES = 3000;
     var PHONE_REGEX = /\+\d{7,12}(\d{3})/g;
     var log = new DebugLog();
     if (window.console) {

--- a/js/delivery_receipts.js
+++ b/js/delivery_receipts.js
@@ -43,7 +43,6 @@
                 });
             }).then(function(message) {
                 if (message) {
-                    this.remove(receipt);
                     var deliveries = message.get('delivered') || 0;
                     message.save({
                         delivered: deliveries + 1
@@ -55,7 +54,9 @@
                         if (conversation) {
                             conversation.trigger('delivered', message);
                         }
-                    });
+
+                        this.remove(receipt);
+                    }.bind(this));
                     // TODO: consider keeping a list of numbers we've
                     // successfully delivered to?
                 }

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38094,7 +38094,8 @@ var TextSecureServer = (function() {
             }.bind(this));
         },
         queueTask: function(task) {
-            return this.pending = this.pending.then(task, task);
+            var taskWithTimeout = textsecure.createTaskWithTimeout(task);
+            return this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
         },
         cleanSignedPreKeys: function() {
             var nextSignedKeyId = textsecure.storage.get('signedKeyId');
@@ -38420,21 +38421,29 @@ MessageReceiver.prototype.extend({
         return textsecure.storage.unprocessed.remove(id);
     },
     queueDecryptedEnvelope: function(envelope, plaintext) {
-        console.log('queueing decrypted envelope', this.getEnvelopeId(envelope));
-        var handleDecryptedEnvelope = this.handleDecryptedEnvelope.bind(this, envelope, plaintext);
-        this.pending = this.pending.then(handleDecryptedEnvelope, handleDecryptedEnvelope);
+        var id = this.getEnvelopeId(envelope);
+        console.log('queueing decrypted envelope', id);
+
+        var task = this.handleDecryptedEnvelope.bind(this, envelope, plaintext);
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task, 'queueEncryptedEnvelope ' + id);
+
+        this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
 
         return this.pending.catch(function(error) {
-            console.log('queueDecryptedEnvelope error:', error && error.stack ? error.stack : error);
+            console.log('queueDecryptedEnvelope error handling envelope', id, ':', error && error.stack ? error.stack : error);
         });
     },
     queueEnvelope: function(envelope) {
-        console.log('queueing envelope', this.getEnvelopeId(envelope));
-        var handleEnvelope = this.handleEnvelope.bind(this, envelope);
-        this.pending = this.pending.then(handleEnvelope, handleEnvelope);
+        var id = this.getEnvelopeId(envelope);
+        console.log('queueing envelope', id);
+
+        var task = this.handleEnvelope.bind(this, envelope);
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task, 'queueEnvelope ' + id);
+
+        this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
 
         return this.pending.catch(function(error) {
-            console.log('queueEnvelope error:', error && error.stack ? error.stack : error);
+            console.log('queueEnvelope error handling envelope', id, ':', error && error.stack ? error.stack : error);
         });
     },
     // Same as handleEnvelope, just without the decryption step. Necessary for handling
@@ -39330,8 +39339,10 @@ MessageSender.prototype = {
     },
 
     queueJobForNumber: function(number, runJob) {
+        var taskWithTimeout = textsecure.createTaskWithTimeout(runJob, 'queueJobForNumber ' + number);
+
         var runPrevious = this.pendingMessages[number] || Promise.resolve();
-        var runCurrent = this.pendingMessages[number] = runPrevious.then(runJob, runJob);
+        var runCurrent = this.pendingMessages[number] = runPrevious.then(taskWithTimeout, taskWithTimeout);
         runCurrent.then(function() {
             if (this.pendingMessages[number] === runCurrent) {
                 delete this.pendingMessages[number];
@@ -39973,5 +39984,71 @@ libsignal.ProvisioningCipher = function() {
     this.getPublicKey = cipher.getPublicKey.bind(cipher);
 };
 
+})();
+
+/*
+ * vim: ts=4:sw=4:expandtab
+ */
+(function () {
+    window.textsecure = window.textsecure || {};
+
+    window.textsecure.createTaskWithTimeout = function(task, id, options) {
+        options = options || {};
+        options.timeout = options.timeout || (1000 * 60 * 2); // two minutes
+
+        var errorForStack = new Error('for stack');
+        return function() {
+            return new Promise(function(resolve, reject) {
+                var complete = false;
+                var timer = setTimeout(function() {
+                    if (!complete) {
+                        var message =
+                            (id || '')
+                            + ' task did not complete in time. Calling stack: '
+                            + errorForStack.stack;
+
+                        console.log(message);
+                        return reject(new Error(message));
+                    }
+                }.bind(this), options.timeout);
+                var clearTimer = function() {
+                    try {
+                        var localTimer = timer;
+                        if (localTimer) {
+                            timer = null;
+                            clearTimeout(localTimer);
+                        }
+                    }
+                    catch (error) {
+                        console.log(
+                            id || '',
+                            'task ran into problem canceling timer. Calling stack:',
+                            errorForStack.stack
+                        );
+                    }
+                };
+
+                var success = function(result) {
+                    clearTimer();
+                    complete = true;
+                    return resolve(result);
+                };
+                var failure = function(error) {
+                    clearTimer();
+                    complete = true;
+                    return reject(error);
+                };
+
+                var promise = task();
+                if (!promise || !promise.then) {
+                    clearTimer();
+                    complete = true;
+                    return resolve(promise);
+                }
+
+                return promise.then(success, failure);
+            });
+        };
+    };
 })();
 })();

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -411,7 +411,10 @@
 
     queueJob: function(callback) {
         var previous = this.pending || Promise.resolve();
-        var current = this.pending = previous.then(callback, callback);
+
+        var taskWithTimeout = textsecure.createTaskWithTimeout(callback, 'conversation ' + this.id);
+
+        var current = this.pending = previous.then(taskWithTimeout, taskWithTimeout);
 
         current.then(function() {
             if (this.pending === current) {

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -480,9 +480,6 @@
                         };
 
                         message.save().then(function() {
-
-                            // throw new Error('Something went wrong!');
-
                             conversation.save().then(function() {
                                 try {
                                     conversation.trigger('newmessage', message);

--- a/js/read_receipts.js
+++ b/js/read_receipts.js
@@ -27,9 +27,9 @@
                             message.get('source') === receipt.get('sender'));
                 });
                 if (message) {
-                    this.remove(receipt);
                     message.markRead(receipt.get('read_at')).then(function() {
                         this.notifyConversation(message);
+                        this.remove(receipt);
                     }.bind(this));
                 } else {
                     console.log('No message for read receipt');

--- a/js/reliable_trigger.js
+++ b/js/reliable_trigger.js
@@ -1,0 +1,67 @@
+(function () {
+  // Pure copy from Backbone.
+
+  // jscs:disable
+
+  var arr = [];
+
+  var slice = arr.slice;
+
+  // Regular expression used to split event strings.
+  var eventSplitter = /\s+/;
+
+  // Implement fancy features of the Events API such as multiple event
+  // names `"change blur"` and jQuery-style event maps `{change: action}`
+  // in terms of the existing API.
+  var eventsApi = function(obj, action, name, rest) {
+    if (!name) return true;
+
+    // Handle event maps.
+    if (typeof name === 'object') {
+      for (var key in name) {
+        obj[action].apply(obj, [key, name[key]].concat(rest));
+      }
+      return false;
+    }
+
+    // Handle space separated event names.
+    if (eventSplitter.test(name)) {
+      var names = name.split(eventSplitter);
+      for (var i = 0, l = names.length; i < l; i++) {
+        obj[action].apply(obj, [names[i]].concat(rest));
+      }
+      return false;
+    }
+
+    return true;
+  };
+
+  // A difficult-to-believe, but optimized internal dispatch function for
+  // triggering events. Tries to keep the usual cases speedy (most internal
+  // Backbone events have 3 arguments).
+  var triggerEvents = function(events, args) {
+    var ev, i = -1, l = events.length, a1 = args[0], a2 = args[1], a3 = args[2];
+    switch (args.length) {
+      case 0: while (++i < l) (ev = events[i]).callback.call(ev.ctx); return;
+      case 1: while (++i < l) (ev = events[i]).callback.call(ev.ctx, a1); return;
+      case 2: while (++i < l) (ev = events[i]).callback.call(ev.ctx, a1, a2); return;
+      case 3: while (++i < l) (ev = events[i]).callback.call(ev.ctx, a1, a2, a3); return;
+      default: while (++i < l) (ev = events[i]).callback.apply(ev.ctx, args); return;
+    }
+  };
+
+  // Trigger one or many events, firing all bound callbacks. Callbacks are
+  // passed the same arguments as `trigger` is, apart from the event name
+  // (unless you're listening on `"all"`, which will cause your callback to
+  // receive the true name of the event as the first argument).
+  Backbone.Model.prototype.trigger = Backbone.View.prototype.trigger = Backbone.Events.trigger = function(name) {
+    if (!this._events) return this;
+    var args = slice.call(arguments, 1);
+    if (!eventsApi(this, 'trigger', name, args)) return this;
+    var events = this._events[name];
+    var allEvents = this._events.all;
+    if (events) triggerEvents(events, args);
+    if (allEvents) triggerEvents(allEvents, arguments);
+    return this;
+  };
+})();

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -457,7 +457,7 @@
                             nonblockingApproval : nonblockingApproval,
                         }).then(function() {
                             resolve(false);
-                        });
+                        }, reject);
                     } else if (!equalArrayBuffers(oldpublicKey, publicKey)) {
                         console.log("Replacing existing identity...");
                         var previousStatus = identityRecord.get('verified');
@@ -486,7 +486,7 @@
                             nonblockingApproval : nonblockingApproval,
                         }).then(function() {
                             resolve(false);
-                        });
+                        }, reject);
                     } else {
                         resolve(false);
                     }

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -366,15 +366,17 @@
 
         removeScrollDownButton: function() {
             if (this.scrollDownButton) {
-                this.scrollDownButton.remove();
+                var button = this.scrollDownButton;
                 this.scrollDownButton = null;
+                button.remove();
             }
         },
 
         removeLastSeenIndicator: function() {
             if (this.lastSeenIndicator) {
-                this.lastSeenIndicator.remove();
+                var indicator = this.lastSeenIndicator;
                 this.lastSeenIndicator = null;
+                indicator.remove();
             }
         },
 

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -146,7 +146,8 @@
             }.bind(this));
         },
         queueTask: function(task) {
-            return this.pending = this.pending.then(task, task);
+            var taskWithTimeout = textsecure.createTaskWithTimeout(task);
+            return this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
         },
         cleanSignedPreKeys: function() {
             var nextSignedKeyId = textsecure.storage.get('signedKeyId');

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -182,21 +182,29 @@ MessageReceiver.prototype.extend({
         return textsecure.storage.unprocessed.remove(id);
     },
     queueDecryptedEnvelope: function(envelope, plaintext) {
-        console.log('queueing decrypted envelope', this.getEnvelopeId(envelope));
-        var handleDecryptedEnvelope = this.handleDecryptedEnvelope.bind(this, envelope, plaintext);
-        this.pending = this.pending.then(handleDecryptedEnvelope, handleDecryptedEnvelope);
+        var id = this.getEnvelopeId(envelope);
+        console.log('queueing decrypted envelope', id);
+
+        var task = this.handleDecryptedEnvelope.bind(this, envelope, plaintext);
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task, 'queueEncryptedEnvelope ' + id);
+
+        this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
 
         return this.pending.catch(function(error) {
-            console.log('queueDecryptedEnvelope error:', error && error.stack ? error.stack : error);
+            console.log('queueDecryptedEnvelope error handling envelope', id, ':', error && error.stack ? error.stack : error);
         });
     },
     queueEnvelope: function(envelope) {
-        console.log('queueing envelope', this.getEnvelopeId(envelope));
-        var handleEnvelope = this.handleEnvelope.bind(this, envelope);
-        this.pending = this.pending.then(handleEnvelope, handleEnvelope);
+        var id = this.getEnvelopeId(envelope);
+        console.log('queueing envelope', id);
+
+        var task = this.handleEnvelope.bind(this, envelope);
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task, 'queueEnvelope ' + id);
+
+        this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
 
         return this.pending.catch(function(error) {
-            console.log('queueEnvelope error:', error && error.stack ? error.stack : error);
+            console.log('queueEnvelope error handling envelope', id, ':', error && error.stack ? error.stack : error);
         });
     },
     // Same as handleEnvelope, just without the decryption step. Necessary for handling

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -30,7 +30,10 @@ MessageReceiver.prototype.extend({
             handleRequest: this.handleRequest.bind(this),
             keepalive: { path: '/v1/keepalive', disconnect: true }
         });
+
         this.pending = Promise.resolve();
+
+        this.queueAllCached();
     },
     close: function() {
         this.socket.close(3000, 'called close');
@@ -71,25 +74,146 @@ MessageReceiver.prototype.extend({
         textsecure.crypto.decryptWebsocketMessage(request.body, this.signalingKey).then(function(plaintext) {
             var envelope = textsecure.protobuf.Envelope.decode(plaintext);
             // After this point, decoding errors are not the server's
-            // fault, and we should handle them gracefully and tell the
-            // user they received an invalid message
-            request.respond(200, 'OK');
+            //   fault, and we should handle them gracefully and tell the
+            //   user they received an invalid message
 
-            if (!this.isBlocked(envelope.source)) {
-                this.queueEnvelope(envelope);
+            if (this.isBlocked(envelope.source)) {
+                return request.respond(200, 'OK');
             }
 
+            this.addToCache(envelope, plaintext).then(function() {
+                request.respond(200, 'OK');
+                this.queueEnvelope(envelope);
+            }.bind(this), function(error) {
+                console.log(
+                    'handleRequest error trying to add message to cache:',
+                    error && error.stack ? error.stack : error
+                );
+            });
         }.bind(this)).catch(function(e) {
             request.respond(500, 'Bad encrypted websocket message');
-            console.log("Error handling incoming message:", e);
+            console.log("Error handling incoming message:", e && e.stack ? e.stack : e);
             var ev = new Event('error');
             ev.error = e;
             this.dispatchEvent(ev);
         }.bind(this));
     },
+    queueAllCached: function() {
+        this.getAllFromCache().then(function(items) {
+            for (var i = 0, max = items.length; i < max; i += 1) {
+                this.queueCached(items[i]);
+            }
+        }.bind(this));
+    },
+    queueCached: function(item) {
+        try {
+            var envelopePlaintext = this.stringToArrayBuffer(item.envelope);
+            var envelope = textsecure.protobuf.Envelope.decode(envelopePlaintext);
+
+            var decrypted = item.decrypted;
+            if (decrypted) {
+                var payloadPlaintext = this.stringToArrayBuffer(decrypted);
+                this.queueDecryptedEnvelope(envelope, payloadPlaintext);
+            } else {
+                this.queueEnvelope(envelope);
+            }
+        }
+        catch (error) {
+            console.log('queueCached error handling item', item.id);
+        }
+    },
+    getEnvelopeId: function(envelope) {
+        return envelope.source + '.' + envelope.sourceDevice + ' ' + envelope.timestamp.toNumber();
+    },
+    arrayBufferToString: function(arrayBuffer) {
+        return new dcodeIO.ByteBuffer.wrap(arrayBuffer).toString('binary');
+    },
+    stringToArrayBuffer: function(string) {
+        return new dcodeIO.ByteBuffer.wrap(string, 'binary').toArrayBuffer();
+    },
+    getAllFromCache: function() {
+        console.log('getAllFromCache');
+        return textsecure.storage.unprocessed.getAll().then(function(items) {
+            console.log('getAllFromCache loaded', items.length, 'saved envelopes');
+
+            return Promise.all(_.map(items, function(item) {
+                var attempts = 1 + (item.attempts || 0);
+                if (attempts >= 5) {
+                    console.log('getAllFromCache final attempt for envelope', item.id);
+                    return textsecure.storage.unprocessed.remove(item.id);
+                } else {
+                    return textsecure.storage.unprocessed.update(item.id, {attempts: attempts});
+                }
+            }.bind(this))).then(function() {
+                return items;
+            }, function(error) {
+                console.log(
+                    'getAllFromCache error updating items after load:',
+                    error && error.stack ? error.stack : error
+                );
+                return items;
+            });
+        }.bind(this));
+    },
+    addToCache: function(envelope, plaintext) {
+        var id = this.getEnvelopeId(envelope);
+        console.log('addToCache', id);
+        var string = this.arrayBufferToString(plaintext);
+        var data = {
+            id: id,
+            envelope: string,
+            timestamp: Date.now(),
+            attempts: 1
+        };
+        return textsecure.storage.unprocessed.add(data);
+    },
+    updateCache: function(envelope, plaintext) {
+        var id = this.getEnvelopeId(envelope);
+        console.log('updateCache', id);
+        var string = this.arrayBufferToString(plaintext);
+        var data = {
+            decrypted: string
+        };
+        return textsecure.storage.unprocessed.update(id, data);
+    },
+    removeFromCache: function(envelope) {
+        var id = this.getEnvelopeId(envelope);
+        console.log('removeFromCache', id);
+        return textsecure.storage.unprocessed.remove(id);
+    },
+    queueDecryptedEnvelope: function(envelope, plaintext) {
+        console.log('queueing decrypted envelope', this.getEnvelopeId(envelope));
+        var handleDecryptedEnvelope = this.handleDecryptedEnvelope.bind(this, envelope, plaintext);
+        this.pending = this.pending.then(handleDecryptedEnvelope, handleDecryptedEnvelope);
+
+        return this.pending.catch(function(error) {
+            console.log('queueDecryptedEnvelope error:', error && error.stack ? error.stack : error);
+        });
+    },
     queueEnvelope: function(envelope) {
+        console.log('queueing envelope', this.getEnvelopeId(envelope));
         var handleEnvelope = this.handleEnvelope.bind(this, envelope);
         this.pending = this.pending.then(handleEnvelope, handleEnvelope);
+
+        return this.pending.catch(function(error) {
+            console.log('queueEnvelope error:', error && error.stack ? error.stack : error);
+        });
+    },
+    // Same as handleEnvelope, just without the decryption step. Necessary for handling
+    //   messages which were successfully decrypted, but application logic didn't finish
+    //   processing.
+    handleDecryptedEnvelope: function(envelope, plaintext) {
+        // No decryption is required for delivery receipts, so the decrypted field of
+        //   the Unprocessed model will never be set
+
+        if (envelope.content) {
+            return this.innerHandleContentMessage(envelope, plaintext);
+        } else if (envelope.legacyMessage) {
+            return this.innerHandleLegacyMessage(envelope, plaintext);
+        } else {
+            this.removeFromCache(envelope);
+            throw new Error('Received message with no content and no legacyMessage');
+        }
     },
     handleEnvelope: function(envelope) {
         if (envelope.type === textsecure.protobuf.Envelope.Type.RECEIPT) {
@@ -101,6 +225,7 @@ MessageReceiver.prototype.extend({
         } else if (envelope.legacyMessage) {
             return this.handleLegacyMessage(envelope);
         } else {
+            this.removeFromCache(envelope);
             throw new Error('Received message with no content and no legacyMessage');
         }
     },
@@ -112,9 +237,13 @@ MessageReceiver.prototype.extend({
         }
     },
     onDeliveryReceipt: function (envelope) {
-        var ev = new Event('receipt');
-        ev.proto = envelope;
-        this.dispatchEvent(ev);
+        return new Promise(function(resolve) {
+            var ev = new Event('receipt');
+            ev.confirm = this.removeFromCache.bind(this, envelope);
+            ev.proto = envelope;
+            this.dispatchEvent(ev);
+            return resolve();
+        }.bind(this));
     },
     unpad: function(paddedPlaintext) {
         paddedPlaintext = new Uint8Array(paddedPlaintext);
@@ -138,17 +267,27 @@ MessageReceiver.prototype.extend({
         var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address);
         switch(envelope.type) {
             case textsecure.protobuf.Envelope.Type.CIPHERTEXT:
-                console.log('message from', envelope.source + '.' + envelope.sourceDevice, envelope.timestamp.toNumber());
+                console.log('message from', this.getEnvelopeId(envelope));
                 promise = sessionCipher.decryptWhisperMessage(ciphertext).then(this.unpad);
                 break;
             case textsecure.protobuf.Envelope.Type.PREKEY_BUNDLE:
-                console.log('prekey message from', envelope.source + '.' + envelope.sourceDevice, envelope.timestamp.toNumber());
+                console.log('prekey message from', this.getEnvelopeId(envelope));
                 promise = this.decryptPreKeyWhisperMessage(ciphertext, sessionCipher, address);
                 break;
             default:
                 promise = Promise.reject(new Error("Unknown message type"));
         }
-        return promise.catch(function(error) {
+        return promise.then(function(plaintext) {
+            return this.updateCache(envelope, plaintext).then(function() {
+                return plaintext;
+            }, function(error) {
+                console.log(
+                    'decrypt failed to save decrypted message contents to cache:',
+                    error && error.stack ? error.stack : error
+                );
+                return plaintext;
+            });
+        }.bind(this)).catch(function(error) {
             if (error.message === 'Unknown identity key') {
                 // create an error that the UI will pick up and ask the
                 // user if they want to re-negotiate
@@ -181,7 +320,7 @@ MessageReceiver.prototype.extend({
             throw e;
         });
     },
-    handleSentMessage: function(destination, timestamp, message, expirationStartTimestamp) {
+    handleSentMessage: function(envelope, destination, timestamp, message, expirationStartTimestamp) {
         var p = Promise.resolve();
         if ((message.flags & textsecure.protobuf.DataMessage.Flags.END_SESSION) ==
                 textsecure.protobuf.DataMessage.Flags.END_SESSION ) {
@@ -190,9 +329,11 @@ MessageReceiver.prototype.extend({
         return p.then(function() {
             return this.processDecrypted(message, this.number).then(function(message) {
                 var ev = new Event('sent');
+                ev.confirm = this.removeFromCache.bind(this, envelope);
                 ev.data = {
                     destination              : destination,
                     timestamp                : timestamp.toNumber(),
+                    device                   : envelope.sourceDevice,
                     message                  : message
                 };
                 if (expirationStartTimestamp) {
@@ -213,10 +354,12 @@ MessageReceiver.prototype.extend({
         return p.then(function() {
             return this.processDecrypted(message, envelope.source).then(function(message) {
                 var ev = new Event('message');
+                ev.confirm = this.removeFromCache.bind(this, envelope);
                 ev.data = {
-                    source    : envelope.source,
-                    timestamp : envelope.timestamp.toNumber(),
-                    message   : message
+                    source       : envelope.source,
+                    sourceDevice : envelope.sourceDevice,
+                    timestamp    : envelope.timestamp.toNumber(),
+                    message      : message
                 };
                 this.dispatchEvent(ev);
             }.bind(this));
@@ -224,27 +367,35 @@ MessageReceiver.prototype.extend({
     },
     handleLegacyMessage: function (envelope) {
         return this.decrypt(envelope, envelope.legacyMessage).then(function(plaintext) {
-            var message = textsecure.protobuf.DataMessage.decode(plaintext);
-            return this.handleDataMessage(envelope, message);
+            return this.innerHandleLegacyMessage(envelope, plaintext);
         }.bind(this));
+    },
+    innerHandleLegacyMessage: function (envelope, plaintext) {
+        var message = textsecure.protobuf.DataMessage.decode(plaintext);
+        return this.handleDataMessage(envelope, message);
     },
     handleContentMessage: function (envelope) {
         return this.decrypt(envelope, envelope.content).then(function(plaintext) {
-            var content = textsecure.protobuf.Content.decode(plaintext);
-            if (content.syncMessage) {
-                return this.handleSyncMessage(envelope, content.syncMessage);
-            } else if (content.dataMessage) {
-                return this.handleDataMessage(envelope, content.dataMessage);
-            } else if (content.nullMessage) {
-                return this.handleNullMessage(envelope, content.nullMessage);
-            } else {
-                throw new Error('Unsupported content message');
-            }
+            this.innerHandleContentMessage(envelope, plaintext);
         }.bind(this));
+    },
+    innerHandleContentMessage: function(envelope, plaintext) {
+        var content = textsecure.protobuf.Content.decode(plaintext);
+        if (content.syncMessage) {
+            return this.handleSyncMessage(envelope, content.syncMessage);
+        } else if (content.dataMessage) {
+            return this.handleDataMessage(envelope, content.dataMessage);
+        } else if (content.nullMessage) {
+            return this.handleNullMessage(envelope, content.nullMessage);
+        } else {
+            this.removeFromCache(envelope);
+            throw new Error('Unsupported content message');
+        }
     },
     handleNullMessage: function(envelope, nullMessage) {
         var encodedNumber = envelope.source + '.' + envelope.sourceDevice;
         console.log('null message from', encodedNumber, envelope.timestamp.toNumber());
+        this.removeFromCache(envelope);
     },
     handleSyncMessage: function(envelope, syncMessage) {
         if (envelope.source !== this.number) {
@@ -261,34 +412,37 @@ MessageReceiver.prototype.extend({
                     'from', envelope.source + '.' + envelope.sourceDevice
             );
             return this.handleSentMessage(
+                    envelope,
                     sentMessage.destination,
                     sentMessage.timestamp,
                     sentMessage.message,
                     sentMessage.expirationStartTimestamp
             );
         } else if (syncMessage.contacts) {
-            this.handleContacts(syncMessage.contacts);
+            this.handleContacts(envelope, syncMessage.contacts);
         } else if (syncMessage.groups) {
-            this.handleGroups(syncMessage.groups);
+            this.handleGroups(envelope, syncMessage.groups);
         } else if (syncMessage.blocked) {
-            this.handleBlocked(syncMessage.blocked);
+            this.handleBlocked(envelope, syncMessage.blocked);
         } else if (syncMessage.request) {
             console.log('Got SyncMessage Request');
+            this.removeFromCache(envelope);
         } else if (syncMessage.read && syncMessage.read.length) {
             console.log('read messages',
                     'from', envelope.source + '.' + envelope.sourceDevice);
-            this.handleRead(syncMessage.read, envelope.timestamp);
+            this.handleRead(envelope, syncMessage.read);
         } else if (syncMessage.verified) {
-            this.handleVerified(syncMessage.verified);
+            this.handleVerified(envelope, syncMessage.verified);
         } else {
             throw new Error('Got empty SyncMessage');
         }
     },
-    handleVerified: function(verified, options) {
+    handleVerified: function(envelope, verified, options) {
         options = options || {};
         _.defaults(options, {viaContactSync: false});
 
         var ev = new Event('verified');
+        ev.confirm = this.removeFromCache.bind(this, envelope);
         ev.verified = {
             state: verified.state,
             destination: verified.destination,
@@ -297,10 +451,11 @@ MessageReceiver.prototype.extend({
         ev.viaContactSync = options.viaContactSync;
         this.dispatchEvent(ev);
     },
-    handleRead: function(read, timestamp) {
+    handleRead: function(envelope, read) {
         for (var i = 0; i < read.length; ++i) {
             var ev = new Event('read');
-            ev.timestamp = timestamp.toNumber();
+            ev.confirm = this.removeFromCache.bind(this, envelope);
+            ev.timestamp = envelope.timestamp.toNumber();
             ev.read = {
               timestamp : read[i].timestamp.toNumber(),
               sender    : read[i].sender
@@ -308,7 +463,7 @@ MessageReceiver.prototype.extend({
             this.dispatchEvent(ev);
         }
     },
-    handleContacts: function(contacts) {
+    handleContacts: function(envelope, contacts) {
         console.log('contact sync');
         var eventTarget = this;
         var attachmentPointer = contacts.blob;
@@ -317,19 +472,23 @@ MessageReceiver.prototype.extend({
             var contactDetails = contactBuffer.next();
             while (contactDetails !== undefined) {
                 var ev = new Event('contact');
+                ev.confirm = this.removeFromCache.bind(this, envelope);
                 ev.contactDetails = contactDetails;
                 eventTarget.dispatchEvent(ev);
 
                 if (contactDetails.verified) {
-                    this.handleVerified(contactDetails.verified, {viaContactSync: true});
+                    this.handleVerified(envelope, contactDetails.verified, {viaContactSync: true});
                 }
 
                 contactDetails = contactBuffer.next();
             }
-            eventTarget.dispatchEvent(new Event('contactsync'));
+
+            var ev = new Event('contactsync');
+            ev.confirm = this.removeFromCache.bind(this, envelope);
+            eventTarget.dispatchEvent(ev);
         }.bind(this));
     },
-    handleGroups: function(groups) {
+    handleGroups: function(envelope, groups) {
         console.log('group sync');
         var eventTarget = this;
         var attachmentPointer = groups.blob;
@@ -358,18 +517,22 @@ MessageReceiver.prototype.extend({
                     }
                 })(groupDetails).then(function(groupDetails) {
                     var ev = new Event('group');
+                    ev.confirm = this.removeFromCache.bind(this, envelope);
                     ev.groupDetails = groupDetails;
                     eventTarget.dispatchEvent(ev);
-                }).catch(function(e) {
+                }.bind(this)).catch(function(e) {
                     console.log('error processing group', e);
                 });
                 groupDetails = groupBuffer.next();
                 promises.push(promise);
             }
+
             Promise.all(promises).then(function() {
-                eventTarget.dispatchEvent(new Event('groupsync'));
-            });
-        });
+                var ev = new Event('groupsync');
+                ev.confirm = this.removeFromCache.bind(this, envelope);
+                eventTarget.dispatchEvent(ev);
+            }.bind(this));
+        }.bind(this));
     },
     handleBlocked: function(blocked) {
         textsecure.storage.put('blocked', blocked.numbers);

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -149,8 +149,10 @@ MessageSender.prototype = {
     },
 
     queueJobForNumber: function(number, runJob) {
+        var taskWithTimeout = textsecure.createTaskWithTimeout(runJob, 'queueJobForNumber ' + number);
+
         var runPrevious = this.pendingMessages[number] || Promise.resolve();
-        var runCurrent = this.pendingMessages[number] = runPrevious.then(runJob, runJob);
+        var runCurrent = this.pendingMessages[number] = runPrevious.then(taskWithTimeout, taskWithTimeout);
         runCurrent.then(function() {
             if (this.pendingMessages[number] === runCurrent) {
                 delete this.pendingMessages[number];

--- a/libtextsecure/storage/groups.js
+++ b/libtextsecure/storage/groups.js
@@ -2,9 +2,9 @@
  * vim: ts=4:sw=4:expandtab
  */
 
-'use strict';
-
 ;(function() {
+    'use strict';
+
     /*********************
      *** Group Storage ***
      *********************/

--- a/libtextsecure/storage/unprocessed.js
+++ b/libtextsecure/storage/unprocessed.js
@@ -1,0 +1,28 @@
+/*
+ * vim: ts=4:sw=4:expandtab
+ */
+
+;(function() {
+    'use strict';
+
+    /*****************************************
+     *** Not-yet-processed message storage ***
+     *****************************************/
+    window.textsecure = window.textsecure || {};
+    window.textsecure.storage = window.textsecure.storage || {};
+
+    window.textsecure.storage.unprocessed = {
+        getAll: function() {
+            return textsecure.storage.protocol.getAllUnprocessed();
+        },
+        add: function(data) {
+            return textsecure.storage.protocol.addUnprocessed(data);
+        },
+        update: function(id, updates) {
+            return textsecure.storage.protocol.updateUnprocessed(id, updates);
+        },
+        remove: function(id) {
+            return textsecure.storage.protocol.removeUnprocessed(id);
+        },
+    };
+})();

--- a/libtextsecure/task_with_timeout.js
+++ b/libtextsecure/task_with_timeout.js
@@ -1,0 +1,65 @@
+/*
+ * vim: ts=4:sw=4:expandtab
+ */
+(function () {
+    window.textsecure = window.textsecure || {};
+
+    window.textsecure.createTaskWithTimeout = function(task, id, options) {
+        options = options || {};
+        options.timeout = options.timeout || (1000 * 60 * 2); // two minutes
+
+        var errorForStack = new Error('for stack');
+        return function() {
+            return new Promise(function(resolve, reject) {
+                var complete = false;
+                var timer = setTimeout(function() {
+                    if (!complete) {
+                        var message =
+                            (id || '')
+                            + ' task did not complete in time. Calling stack: '
+                            + errorForStack.stack;
+
+                        console.log(message);
+                        return reject(new Error(message));
+                    }
+                }.bind(this), options.timeout);
+                var clearTimer = function() {
+                    try {
+                        var localTimer = timer;
+                        if (localTimer) {
+                            timer = null;
+                            clearTimeout(localTimer);
+                        }
+                    }
+                    catch (error) {
+                        console.log(
+                            id || '',
+                            'task ran into problem canceling timer. Calling stack:',
+                            errorForStack.stack
+                        );
+                    }
+                };
+
+                var success = function(result) {
+                    clearTimer();
+                    complete = true;
+                    return resolve(result);
+                };
+                var failure = function(error) {
+                    clearTimer();
+                    complete = true;
+                    return reject(error);
+                };
+
+                var promise = task();
+                if (!promise || !promise.then) {
+                    clearTimer();
+                    complete = true;
+                    return resolve(promise);
+                }
+
+                return promise.then(success, failure);
+            });
+        };
+    };
+})();

--- a/libtextsecure/test/index.html
+++ b/libtextsecure/test/index.html
@@ -28,9 +28,10 @@
   <script type="text/javascript" src="../stringview.js" data-cover></script>
   <script type="text/javascript" src="../api.js"></script>
   <script type="text/javascript" src="../sendmessage.js" data-cover></script>
-  <script type="text/javascript" src="../event_target.js" data-></script>
-  <script type="text/javascript" src="../account_manager.js" data-></script>
-  <script type="text/javascript" src="../contacts_parser.js"></script>
+  <script type="text/javascript" src="../event_target.js" data-cover></script>
+  <script type="text/javascript" src="../account_manager.js" data-cover></script>
+  <script type="text/javascript" src="../contacts_parser.js" data-cover></script>
+  <script type="text/javascript" src="../task_with_timeout.js" data-cover></script>
 
   <script type="text/javascript" src="fake_api.js"></script>
   <script type="text/javascript" src="helpers_test.js"></script>
@@ -39,5 +40,6 @@
   <script type="text/javascript" src="contacts_parser_test.js"></script>
   <script type="text/javascript" src="generate_keys_test.js"></script>
   <script type="text/javascript" src="websocket-resources_test.js"></script>
+  <script type="text/javascript" src="task_with_timeout_test.js"></script>
 </body>
 </html>

--- a/libtextsecure/test/task_with_timeout_test.js
+++ b/libtextsecure/test/task_with_timeout_test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+describe('createTaskWithTimeout', function() {
+    it('resolves when promise resolves', function() {
+        var task = function() {
+            return Promise.resolve('hi!');
+        };
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task);
+
+        return taskWithTimeout().then(function(result) {
+            assert.strictEqual(result, 'hi!')
+        });
+    });
+    it('flows error from promise back', function() {
+        var error = new Error('original');
+        var task = function() {
+            return Promise.reject(error);
+        };
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task);
+
+        return taskWithTimeout().catch(function(flowedError) {
+            assert.strictEqual(error, flowedError);
+        });
+    });
+    it('rejects if promise takes too long', function() {
+        var error = new Error('original');
+        var complete = false;
+        var task = function() {
+            return new Promise(function(resolve) {
+                setTimeout(function() {
+                    completed = true;
+                    resolve();
+                }, 3000);
+            });
+        };
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task, this.name, {
+            timeout: 10
+        });
+
+        return taskWithTimeout().then(function() {
+            throw new Error('it was not supposed to resolve!');
+        }, function() {
+            assert.strictEqual(complete, false);
+        });
+    });
+    it('resolves if task returns something falsey', function() {
+        var task = function() {};
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task);
+        return taskWithTimeout();
+    });
+    it('resolves if task returns a non-promise', function() {
+        var task = function() {
+            return 'hi!';
+        };
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task);
+        return taskWithTimeout().then(function(result) {
+            assert.strictEqual(result, 'hi!')
+        });
+    });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -550,6 +550,7 @@
   </script>
 
   <script type="text/javascript" src="../js/components.js"></script>
+  <script type="text/javascript" src="../js/reliable_trigger.js" data-cover></script>
   <script type="text/javascript" src="test.js"></script>
 
   <script type='text/javascript' src='../js/registration.js' data-cover></script>
@@ -624,6 +625,7 @@
   <script type="text/javascript" src="storage_test.js"></script>
   <script type="text/javascript" src="keychange_listener_test.js"></script>
   <script type="text/javascript" src="emoji_util_test.js"></script>
+  <script type="text/javascript" src="reliable_trigger_test.js"></script>
 
   <script type="text/javascript" src="fixtures.js"></script>
   <script type="text/javascript" src="fixtures_test.js"></script>

--- a/test/reliable_trigger_test.js
+++ b/test/reliable_trigger_test.js
@@ -1,0 +1,147 @@
+'use strict';
+
+describe('ReliableTrigger', function() {
+    describe('trigger', function() {
+        var Model, model;
+
+        before(function() {
+            Model = Backbone.Model;
+        });
+
+        beforeEach(function() {
+            model = new Model();
+        });
+
+        it('returns successfully if this._events is falsey', function() {
+            model._events = null;
+            model.trigger('click');
+        });
+        it('handles map of events to trigger', function() {
+            var a = 0, b = 0;
+            model.on('a', function(arg) {
+                a = arg;
+            });
+            model.on('b', function(arg) {
+                b = arg;
+            });
+
+            model.trigger({
+                a: 1,
+                b: 2
+            });
+
+            assert.strictEqual(a, 1);
+            assert.strictEqual(b, 2);
+        });
+        it('handles space-separated list of events to trigger', function() {
+            var a = false, b = false;
+            model.on('a', function() {
+                a = true;
+            });
+            model.on('b', function() {
+                b = true;
+            });
+
+            model.trigger('a b');
+
+            assert.strictEqual(a, true);
+            assert.strictEqual(b, true);
+        });
+        it('calls all clients registered for "all" event', function() {
+            var count = 0;
+            model.on('all', function() {
+                count += 1;
+            });
+
+            model.trigger('left');
+            model.trigger('right');
+
+            assert.strictEqual(count, 2);
+        });
+        it('calls all clients registered for target event', function() {
+            var a = false, b = false;
+            model.on('event', function() {
+                a = true;
+            });
+            model.on('event', function() {
+                b = true;
+            });
+
+            model.trigger('event');
+
+            assert.strictEqual(a, true);
+            assert.strictEqual(b, true);
+        });
+        it('successfully returns and calls all clients even if first failed', function() {
+            var a = false, b = false;
+            model.on('event', function() {
+                a = true;
+                throw new Error('a is set, but exception is thrown');
+            });
+            model.on('event', function() {
+                b = true;
+            });
+
+            model.trigger('event');
+
+            assert.strictEqual(a, true);
+            assert.strictEqual(b, true);
+        });
+        it('calls clients with no args', function() {
+            var called = false;
+            model.on('event', function() {
+                called = true;
+            });
+
+            model.trigger('event');
+
+            assert.strictEqual(called, true);
+        });
+        it('calls clients with 1 arg', function() {
+            var args;
+            model.on('event', function() {
+                args = arguments;
+            });
+
+            model.trigger('event', 1);
+
+            assert.strictEqual(args[0], 1);
+        });
+        it('calls clients with 2 args', function() {
+            var args;
+            model.on('event', function() {
+                args = arguments;
+            });
+
+            model.trigger('event', 1, 2);
+
+            assert.strictEqual(args[0], 1);
+            assert.strictEqual(args[1], 2);
+        });
+        it('calls clients with 3 args', function() {
+            var args;
+            model.on('event', function() {
+                args = arguments;
+            });
+
+            model.trigger('event', 1, 2, 3);
+
+            assert.strictEqual(args[0], 1);
+            assert.strictEqual(args[1], 2);
+            assert.strictEqual(args[2], 3);
+        });
+        it('calls clients with 4+ args', function() {
+            var args;
+            model.on('event', function() {
+                args = arguments;
+            });
+
+            model.trigger('event', 1, 2, 3, 4);
+
+            assert.strictEqual(args[0], 1);
+            assert.strictEqual(args[1], 2);
+            assert.strictEqual(args[2], 3);
+            assert.strictEqual(args[3], 4);
+        });
+    });
+});

--- a/test/storage_test.js
+++ b/test/storage_test.js
@@ -874,4 +874,60 @@ describe("SignalProtocolStore", function() {
       }).then(done,done);
     });
   });
+
+  describe('Not yet processed messages', function() {
+    beforeEach(function() {
+      return store.getAllUnprocessed().then(function(items) {
+        return Promise.all(_.map(items, function(item) {
+          return store.removeUnprocessed(item.id);
+        }));
+      }).then(function() {
+        return store.getAllUnprocessed();
+      }).then(function(items) {
+        assert.strictEqual(items.length, 0);
+      });
+    });
+
+    it('adds two and gets them back', function() {
+      return Promise.all([
+        store.addUnprocessed({id: 2, name: 'second', timestamp: 2}),
+        store.addUnprocessed({id: 3, name: 'third', timestamp: 3}),
+        store.addUnprocessed({id: 1, name: 'first', timestamp: 1})
+      ]).then(function() {
+        return store.getAllUnprocessed();
+      }).then(function(items) {
+        assert.strictEqual(items.length, 3);
+
+        // they are in the proper order because the collection comparator is 'timestamp'
+        assert.strictEqual(items[0].name, 'first');
+        assert.strictEqual(items[1].name, 'second');
+        assert.strictEqual(items[2].name, 'third');
+      });
+    });
+
+    it('updateUnprocessed successfully updates only part of itme', function() {
+      var id = 1;
+      return store.addUnprocessed({id: id, name: 'first', timestamp: 1}).then(function() {
+        return store.updateUnprocessed(id, {name: 'updated'});
+      }).then(function() {
+        return store.getAllUnprocessed();
+      }).then(function(items) {
+        assert.strictEqual(items.length, 1);
+        assert.strictEqual(items[0].name, 'updated');
+        assert.strictEqual(items[0].timestamp, 1);
+      });
+    });
+
+    it('removeUnprocessed successfully deletes item', function() {
+      var id = 1;
+      return store.addUnprocessed({id: id, name: 'first', timestamp: 1}).then(function() {
+        return store.removeUnprocessed(id);
+      }).then(function() {
+        return store.getAllUnprocessed();
+      }).then(function(items) {
+        assert.strictEqual(items.length, 0);
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
When a message is first received, we cache it. After we've decrypted it, we update that cached copy of the message. The message is only removed from our cache when the application confirms that it is done processing it. On startup we load all messages from the cache and attempt to process them once more. We'll try five times before giving up.

Additionally, for messages visible to the user, we check for duplicates before letting the application process any incoming message.

Architecture:
- Two new migrations. The first is for `unprocessed` messages, with one currently-unused index by `timestamp` (when the message was received). The second is to add a `unique` index to the `messages` data store on three fields `[source, sourceDevice, sent_at]`
- All events (except `error`) emitted by `MessageReceiver` now include a `confirm` property, a function which will remove the original incoming envelope from the cache. This is expected to be called after the application has fully processed the message.
- We save both the original `envelope` and the fully-decrypted message because our protocol layer is stateful. If we decrypt a message, we throw away the key used to decrypt that message. Attempting to decrypt it again will cause an error.