### PR TITLE
Electron: Load locale only after 'ready' event

### DIFF
--- a/app/locale.js
+++ b/app/locale.js
@@ -24,25 +24,31 @@ function getLocaleMessages(locale) {
   return JSON.parse(fs.readFileSync(targetFile, 'utf-8'));
 }
 
-// Load locale - if we can't load messages for the current locale, we
-// default to 'en'
-//
-// possible locales:
-// https://github.com/electron/electron/blob/master/docs/api/locales.md
-let localeName = normalizeLocaleName(app.getLocale());
-let messages;
+function load() {
+  // Load locale - if we can't load messages for the current locale, we
+  // default to 'en'
+  //
+  // possible locales:
+  // https://github.com/electron/electron/blob/master/docs/api/locales.md
+  let localeName = normalizeLocaleName(app.getLocale());
+  let messages;
 
-try {
-  messages = getLocaleMessages(localeName);
-} catch (e) {
-  console.log('Problem loading messages for locale ', localeName, e.stack);
-  console.log('Falling back to en locale');
+  try {
+    messages = getLocaleMessages(localeName);
+  } catch (e) {
+    console.log('Problem loading messages for locale ', localeName, e.stack);
+    console.log('Falling back to en locale');
 
-  localeName = 'en';
-  messages = getLocaleMessages(localeName);
+    localeName = 'en';
+    messages = getLocaleMessages(localeName);
+  }
+
+  return {
+    name: localeName,
+    messages
+  };
 }
 
 module.exports = {
-  name: localeName,
-  messages
-}
+  load: load
+};

--- a/main.js
+++ b/main.js
@@ -40,9 +40,14 @@ if (config.environment === 'production' && !process.mas) {
 const userConfig = require('./app/user_config');
 let windowConfig = userConfig.get('window');
 
-const locale = require('./app/locale');
+const loadLocale = require('./app/locale').load;
+let locale;
 
 function createWindow () {
+  if (!locale) {
+    locale = loadLocale();
+  }
+
   const windowOptions = Object.assign({
     width: 800,
     height: 610,


### PR DESCRIPTION
I noticed that on Linux we were always falling back to the 'en' locale because the local we got from `app.getLocale()` seemed to be a blank string. Not sure if this will fix the Linux situation, but I know for sure that it is required for Windows:

> **Note:** On Windows you have to call it after the `ready` events gets emitted.

(via: https://github.com/electron/electron/blob/master/docs/api/app.md#appgetlocale)

Update: This has been verified as fixing the problem on Linux.