### PR TITLE
Fetch conversations first!

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -158,7 +158,7 @@
             return;
         }
 
-        ConversationController.findOrCreatePrivateById(id).then(function(conversation) {
+        return ConversationController.findOrCreatePrivateById(id).then(function(conversation) {
             return new Promise(function(resolve, reject) {
                 conversation.save({
                     name: details.name,

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -87,19 +87,31 @@
             return conversation;
         },
         findOrCreatePrivateById: function(id) {
-            var conversation = conversations.add({ id: id, type: 'private' });
+            var conversation = conversations.add({
+                id: id,
+                type: 'private'
+            });
             return new Promise(function(resolve, reject) {
                 conversation.fetch().then(function() {
                     resolve(conversation);
-                }).fail(function() {
-                    var saved = conversation.save(); // false or indexedDBRequest
-                    if (saved) {
-                        saved.then(function() {
-                            resolve(conversation);
-                        }).fail(reject);
-                    } else {
-                        reject();
-                    }
+                }, function() {
+                    conversation.save().then(function() {
+                        resolve(conversation);
+                    }, reject);
+                });
+            });
+        },
+        findOrCreateById: function(id) {
+            var conversation = conversations.add({
+                id: id
+            });
+            return new Promise(function(resolve, reject) {
+                conversation.fetch().then(function() {
+                    resolve(conversation);
+                }, function() {
+                    conversation.save().then(function() {
+                        resolve(conversation);
+                    }, reject);
                 });
             });
         },

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -116,8 +116,11 @@
             });
         },
         getAllGroupsInvolvingId: function(id) {
-            return conversations.filter(function(conversation) {
-                return !conversation.isPrivate() && conversation.hasMember(id);
+            var groups = new Whisper.GroupCollection();
+            return groups.fetchGroups(id).then(function() {
+                return groups.map(function(group) {
+                    return conversations.add(group);
+                });
             });
         },
         updateInbox: function() {

--- a/js/debugLog.js
+++ b/js/debugLog.js
@@ -40,7 +40,7 @@
         }
     });
 
-    var MAX_MESSAGES = 3000;
+    var MAX_MESSAGES = 5000;
     var PHONE_REGEX = /\+\d{7,12}(\d{3})/g;
     var log = new DebugLog();
     if (window.console) {

--- a/js/keychange_listener.js
+++ b/js/keychange_listener.js
@@ -17,11 +17,9 @@
           conversation.fetch().then(function() {
             conversation.addKeyChange(id);
           });
-          var groups = new Whisper.GroupCollection();
-          return groups.fetchGroups(id).then(function() {
-            groups.each(function(conversation) {
-              conversation = ConversationController.add(conversation);
-              conversation.addKeyChange(id);
+          ConversationController.getAllGroupsInvolvingId(id).then(function(groups) {
+            _.forEach(groups, function(group) {
+              group.addKeyChange(id);
             });
           });
         });

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -320,9 +320,10 @@
         message.save().then(this.trigger.bind(this,'newmessage', message));
 
         if (this.isPrivate()) {
-            var groups = ConversationController.getAllGroupsInvolvingId(id);
-            _.forEach(groups, function(group) {
-                group.addVerifiedChange(id, verified, options);
+            ConversationController.getAllGroupsInvolvingId(id).then(function(groups) {
+                _.forEach(groups, function(group) {
+                    group.addVerifiedChange(id, verified, options);
+                });
             });
         }
     },

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -84,24 +84,26 @@
     },
     safeFetch: function() {
         // new Promise necessary because a fetch will fail if convo not in db yet
-        return new Promise(function(resolve) { this.fetch().always(resolve); }.bind(this));
+        return new Promise(function(resolve) {
+            this.fetch().always(resolve);
+        }.bind(this));
     },
     setVerifiedDefault: function(options) {
         var DEFAULT = this.verifiedEnum.DEFAULT;
         return this.queueJob(function() {
-            return this.safeFetch().then(this._setVerified.bind(this, DEFAULT, options));
+            return this._setVerified(DEFAULT, options);
         }.bind(this));
     },
     setVerified: function(options) {
         var VERIFIED = this.verifiedEnum.VERIFIED;
         return this.queueJob(function() {
-            return this.safeFetch().then(this._setVerified.bind(this, VERIFIED, options));
+            return this._setVerified(VERIFIED, options);
         }.bind(this));
     },
     setUnverified: function(options) {
         var UNVERIFIED = this.verifiedEnum.UNVERIFIED;
         return this.queueJob(function() {
-            return this.safeFetch().then(this._setVerified.bind(this, UNVERIFIED, options));
+            return this._setVerified(UNVERIFIED, options);
         }.bind(this));
     },
     _setVerified: function(verified, options) {

--- a/js/reliable_trigger.js
+++ b/js/reliable_trigger.js
@@ -111,7 +111,7 @@
   // passed the same arguments as `trigger` is, apart from the event name
   // (unless you're listening on `"all"`, which will cause your callback to
   // receive the true name of the event as the first argument).
-  Backbone.Model.prototype.trigger = Backbone.View.prototype.trigger = Backbone.Events.trigger = function(name) {
+  function trigger(name) {
     if (!this._events) return this;
     var args = slice.call(arguments, 1);
     if (!eventsApi(this, 'trigger', name, args)) return this;
@@ -120,6 +120,12 @@
     if (events) triggerEvents(events, name, args);
     if (allEvents) triggerEvents(allEvents, name, arguments);
     return this;
-  };
+  }
+
+  Backbone.Model.prototype.trigger
+    = Backbone.View.prototype.trigger
+    = Backbone.Collection.prototype.trigger
+    = Backbone.Events.trigger
+    = trigger;
 })();
 


### PR DESCRIPTION
Discovered a class of issues around conversation handling - either saving over what's in the database, or relying on what's in memory instead of going to database to be sure. Now we always pull from the database first.

Primarily affects these scenarios:
- Contact sync
- Verification sync
- Group sync

One other small change: applying our overridden `Backbone` trigger to `Collection` as well.