### PR TITLE
Fix: Too many automatic upgrade dialogs

### DIFF
--- a/app/auto_update.js
+++ b/app/auto_update.js
@@ -19,7 +19,13 @@ function checkForUpdates() {
   autoUpdater.checkForUpdates();
 }
 
+var showingDialog = false;
 function showUpdateDialog() {
+  if (showingDialog) {
+    return;
+  }
+  showingDialog = true;
+
   const options = {
     type: 'info',
     buttons: [
@@ -38,6 +44,8 @@ function showUpdateDialog() {
       windowState.markShouldQuit();
       autoUpdater.quitAndInstall();
     }
+
+    showingDialog = false;
   });
 }
 

--- a/aptly.sh
+++ b/aptly.sh
@@ -13,22 +13,6 @@ SNAPSHOT=signal-desktop_v$VERSION
 GPG_KEYID=57F6FB06
 aptly repo add $REPO $DEB_PATH/$REPO\_$VERSION\_*.deb
 
-while true; do
-    read -p "Create snapshot?" yn
-    case $yn in
-        [Yy]* ) break;;
-        [Nn]* ) exit;;
-        * ) echo "Please answer yes or no.";
-    esac
-done
 aptly snapshot create $SNAPSHOT from repo $REPO
-while true; do
-    read -p "Deploy snapshot?" yn
-    case $yn in
-        [Yy]* ) break;;
-        [Nn]* ) exit;;
-        * ) echo "Please answer yes or no.";
-    esac
-done
 aptly publish switch -gpg-key=$GPG_KEYID $DISTRO $SNAPSHOT
 aptly publish switch -gpg-key=$GPG_KEYID -config=.aptly.conf $DISTRO s3:$ENDPOINT: $SNAPSHOT


### PR DESCRIPTION
Today our automatic upgrade logic checks every hour to see if there is a new upgrade available. If there is, we pop a dialog for the user to decide whether to upgrade later or right now.

Previously we were popping that dialog once an hour, no matter whether the user had made a decision or not. This ensures that we never show more than one dialog.