### PR TITLE
Move debug log to the View menu

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -37,6 +37,12 @@ const template = [
     label: 'View',
     submenu: [
       {
+        label: 'Debug Log'
+      },
+      {
+        type: 'separator'
+      },
+      {
         role: 'reload'
       },
       {

--- a/background.html
+++ b/background.html
@@ -30,7 +30,6 @@
                 <button class='hamburger' alt='signal menu'></button>
                 <ul class='menu-list'>
                     <li class='showSettings'>{{ settings }}</li>
-                    <li class='show-debug-log'>{{ submitDebugLog }}</li>
                     <li class='restart-signal'>{{ restartSignal }}</li>
                 </ul>
               </div>

--- a/js/background.js
+++ b/js/background.js
@@ -73,7 +73,7 @@
         }
 
         Whisper.events.on('showDebugLog', function() {
-            appView.inboxView.showDebugLog();
+            appView.openDebugLog();
         });
         Whisper.events.on('unauthorized', function() {
             appView.inboxView.networkStatusView.update();

--- a/js/background.js
+++ b/js/background.js
@@ -72,6 +72,9 @@
             appView.openInstaller();
         }
 
+        Whisper.events.on('showDebugLog', function() {
+            appView.inboxView.showDebugLog();
+        });
         Whisper.events.on('unauthorized', function() {
             appView.inboxView.networkStatusView.update();
         });

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -18,6 +18,17 @@
           this.el.append(view.el);
           this.delegateEvents();
         },
+        openDebugLog: function() {
+            this.closeDebugLog();
+            this.debugLogView = new Whisper.DebugLogView();
+            this.debugLogView.$el.appendTo(this.el);
+        },
+        closeDebugLog: function() {
+          if (this.debugLogView) {
+            this.debugLogView.remove();
+            this.debugLogView = null;
+          }
+        },
         openInstaller: function() {
           this.closeInstaller();
           this.installView = new Whisper.InstallView();

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -139,7 +139,6 @@
             'click #header': 'focusHeader',
             'click .conversation': 'focusConversation',
             'click .global-menu .hamburger': 'toggleMenu',
-            'click .show-debug-log': 'showDebugLog',
             'click .showSettings': 'showSettings',
             'select .gutter .conversation-list-item': 'openConversation',
             'input input.search': 'filterContacts',
@@ -190,10 +189,6 @@
         },
         toggleMenu: function() {
             this.$('.global-menu .menu-list').toggle();
-        },
-        showDebugLog: function() {
-            this.$('.debug-log').remove();
-            new Whisper.DebugLogView().$el.appendTo(this.el);
         },
         showLightbox: function(e) {
             this.$el.append(e.target);

--- a/main.js
+++ b/main.js
@@ -153,6 +153,12 @@ function createWindow () {
   });
 }
 
+function showDebugLog() {
+  if (mainWindow) {
+    mainWindow.webContents.send('debug-log')
+  }
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
@@ -169,6 +175,9 @@ app.on('ready', function() {
     template[3].submenu[3].click = function() {
       mainWindow.show();
     };
+    template[2].submenu[0].click = showDebugLog;
+  } else {
+    template[1].submenu[0].click = showDebugLog;
   }
 
   const menu = Menu.buildFromTemplate(template);

--- a/preload.js
+++ b/preload.js
@@ -24,6 +24,9 @@
     console.log('restart');
     ipc.send('restart');
   };
+  ipc.on('debug-log', function() {
+    Whisper.events.trigger('showDebugLog');
+  });
   /**
   * Enables spell-checking and the right-click context menu in text editors.
   * Electron (`webFrame.setSpellCheckProvider`) only underlines misspelled words;


### PR DESCRIPTION
Electron users can now access the debug log UI from the menu bar (View -> Debug Log), making it possible to submit logs even if you haven't finished registration, or if you are registered but the inbox view just hasn't appeared yet.

This required extracting the management of a DebugLogView out of InboxView, and moving it up a level (in the view/DOM hierarchy) to AppView.