### PR TITLE
Read receipts: Log sender and timestamp when related msg not found

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -338,7 +338,7 @@
         var read_at   = ev.timestamp;
         var timestamp = ev.read.timestamp;
         var sender    = ev.read.sender;
-        console.log('read receipt ', sender, timestamp);
+        console.log('read receipt', sender, timestamp);
         var receipt = Whisper.ReadReceipts.add({
             sender    : sender,
             timestamp : timestamp,

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38704,8 +38704,8 @@ MessageReceiver.prototype.extend({
             ev.confirm = this.removeFromCache.bind(this, envelope);
             ev.timestamp = envelope.timestamp.toNumber();
             ev.read = {
-              timestamp : read[i].timestamp.toNumber(),
-              sender    : read[i].sender
+                timestamp : read[i].timestamp.toNumber(),
+                sender    : read[i].sender
             }
             this.dispatchEvent(ev);
         }

--- a/js/read_receipts.js
+++ b/js/read_receipts.js
@@ -32,7 +32,10 @@
                         this.remove(receipt);
                     }.bind(this));
                 } else {
-                    console.log('No message for read receipt');
+                    console.log(
+                        'No message for read receipt',
+                        receipt.get('sender'), receipt.get('timestamp')
+                    );
                 }
             }.bind(this));
         },

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -465,8 +465,8 @@ MessageReceiver.prototype.extend({
             ev.confirm = this.removeFromCache.bind(this, envelope);
             ev.timestamp = envelope.timestamp.toNumber();
             ev.read = {
-              timestamp : read[i].timestamp.toNumber(),
-              sender    : read[i].sender
+                timestamp : read[i].timestamp.toNumber(),
+                sender    : read[i].sender
             }
             this.dispatchEvent(ev);
         }


### PR DESCRIPTION
With the new caching of unprocessed envelopes, I've noticed that read receipts are pretty frequently left in the cache because the target message wasn't found. 

This adds some logging to help track down the underlying problem.