### PR TITLE
Animated loading screens on startup and first conversation load

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,4 +1,22 @@
 {
+    "loading": {
+      "message": "Loading...",
+      "description": "Message shown on the loading screen before we've loaded any messages"
+    },
+    "upgradingDatabase": {
+      "message": "Upgrading database. This may take some time...",
+      "description": "Message shown on the loading screen when we're changing database structure on first run of a new version"
+    },
+    "loadingMessages": {
+      "message": "Loading messages. $count$ so far...",
+      "description": "Message shown on the loading screen when we're catching up on the backlog of messages",
+      "placeholders": {
+        "count": {
+          "content": "$1",
+          "example": "5"
+        }
+      }
+    },
     "me": {
       "message": "Me",
       "description": "The label for yourself when shown in a group member list"

--- a/background.html
+++ b/background.html
@@ -10,6 +10,7 @@
         <span class='dot'></span>
         <span class='dot'></span>
       </div>
+      <div class='message'>{{ message }}</div>
     </div>
   </script>
   <script type='text/x-tmpl-mustache' id='conversation-loading-screen'>

--- a/background.html
+++ b/background.html
@@ -2,6 +2,26 @@
 <html>
 <head>
   <meta charset='utf-8'>
+  <script type='text/x-tmpl-mustache' id='app-loading-screen'>
+    <div class='content'>
+      <img src='/images/icon_128.png'>
+      <div class='container'>
+        <span class='dot'></span>
+        <span class='dot'></span>
+        <span class='dot'></span>
+      </div>
+    </div>
+  </script>
+  <script type='text/x-tmpl-mustache' id='conversation-loading-screen'>
+    <div class='content'>
+      <img src='/images/icon_128.png'>
+      <div class='container'>
+        <span class='dot'></span>
+        <span class='dot'></span>
+        <span class='dot'></span>
+      </div>
+    </div>
+  </script>
   <script type='text/x-tmpl-mustache' id='two-column'>
     <div class='gutter'>
         <div class='network-status-container'></div>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,17 @@
         <script type="text/javascript" src="js/chromium.js"></script>
     </head>
     <body id="signal-container" class='signal index'>
+        <div class='app-loading-screen'>
+            <div class='content'>
+              <img src='/images/icon_128.png'>
+              <div class='container'>
+                <span class='dot'></span>
+                <span class='dot'></span>
+                <span class='dot'></span>
+              </div>
+              <div class='message'>Loading...</div>
+            </div>
+        </div>
         <script type="text/javascript" src="js/index.js"></script>
     </body>
 </html>

--- a/js/background.js
+++ b/js/background.js
@@ -123,6 +123,7 @@
         messageReceiver.addEventListener('verified', onVerified);
         messageReceiver.addEventListener('error', onError);
         messageReceiver.addEventListener('empty', onEmpty);
+        messageReceiver.addEventListener('progress', onProgress);
 
         window.textsecure.messaging = new textsecure.MessageSender(
             SERVER_URL, SERVER_PORTS, USERNAME, PASSWORD
@@ -157,6 +158,14 @@
                 view.onEmpty();
             }
         }, 500);
+    }
+    function onProgress(ev) {
+        var count = ev.count;
+
+        var view = window.owsDesktopApp.inboxView;
+        if (view) {
+            view.onProgress(count);
+        }
     }
 
     function onContactReceived(ev) {

--- a/js/background.js
+++ b/js/background.js
@@ -343,11 +343,15 @@
                     if (!conversation_timestamp || message_timestamp > conversation_timestamp) {
                         conversation.set({ timestamp: message.get('sent_at') });
                     }
-                    conversation.save();
+
                     conversation.trigger('newmessage', message);
                     if (initialLoadComplete) {
                         conversation.notify(message);
                     }
+
+                    return new Promise(function(resolve, reject) {
+                        conversation.save().then(resolve, reject);
+                    });
                 });
             });
         }

--- a/js/background.js
+++ b/js/background.js
@@ -443,7 +443,11 @@
             return ConversationController.updateInbox().then(function() {
                 try {
                     if (self.inboxView) { self.inboxView.remove(); }
-                    self.inboxView = new Whisper.InboxView({model: self, window: destWindow});
+                    self.inboxView = new Whisper.InboxView({
+                        model: self,
+                        window: destWindow,
+                        initialLoadComplete: initialLoadComplete
+                    });
                     self.openConversation(getOpenConversation());
 
                     return self.inboxView;

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38349,6 +38349,24 @@ MessageReceiver.prototype.extend({
             return this.dispatchAndWait(ev);
         }.bind(this)));
     },
+    addToQueue: function(task) {
+        var count = this.count += 1;
+        var current = this.pending = this.pending.then(task, task);
+
+        var cleanup = function() {
+            this.updateProgress(count);
+            // We want to clear out the promise chain whenever possible because it could
+            //   lead to large memory usage over time:
+            //   https://github.com/nodejs/node/issues/6673#issuecomment-244331609
+            if (this.pending === current) {
+                this.pending = Promise.resolve();
+            }
+        }.bind(this);
+
+        current.then(cleanup, cleanup);
+
+        return current;
+    },
     onEmpty: function() {
         var incoming = this.incoming;
         this.incoming = [];
@@ -38362,7 +38380,7 @@ MessageReceiver.prototype.extend({
             // resetting count to zero so everything queued after this starts over again
             this.count = 0;
 
-            this.pending = this.pending.then(dispatchEmpty, dispatchEmpty);
+            this.addToQueue(dispatchEmpty);
         }.bind(this);
 
         Promise.all(incoming).then(scheduleDispatch, scheduleDispatch);
@@ -38460,34 +38478,26 @@ MessageReceiver.prototype.extend({
         return textsecure.storage.unprocessed.remove(id);
     },
     queueDecryptedEnvelope: function(envelope, plaintext) {
-        var count = this.count += 1;
         var id = this.getEnvelopeId(envelope);
         console.log('queueing decrypted envelope', id);
 
         var task = this.handleDecryptedEnvelope.bind(this, envelope, plaintext);
         var taskWithTimeout = textsecure.createTaskWithTimeout(task, 'queueEncryptedEnvelope ' + id);
+        var promise = this.addToQueue(taskWithTimeout);
 
-        this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
-
-        return this.pending.then(function() {
-            this.updateProgress(count);
-        }.bind(this), function(error) {
+        return promise.catch(function(error) {
             console.log('queueDecryptedEnvelope error handling envelope', id, ':', error && error.stack ? error.stack : error);
         });
     },
     queueEnvelope: function(envelope) {
-        var count = this.count += 1;
         var id = this.getEnvelopeId(envelope);
         console.log('queueing envelope', id);
 
         var task = this.handleEnvelope.bind(this, envelope);
         var taskWithTimeout = textsecure.createTaskWithTimeout(task, 'queueEnvelope ' + id);
+        var promise = this.addToQueue(taskWithTimeout);
 
-        this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
-
-        return this.pending.then(function() {
-            this.updateProgress(count);
-        }.bind(this), function(error) {
+        return promise.catch(function(error) {
             console.log('queueEnvelope error handling envelope', id, ':', error && error.stack ? error.stack : error);
         });
     },

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38606,7 +38606,7 @@ MessageReceiver.prototype.extend({
             var returnError = function() {
                 return Promise.reject(error);
             };
-            this.dispatchAndWait(ev).then(returnError, returnError);
+            return this.dispatchAndWait(ev).then(returnError, returnError);
         }.bind(this));
     },
     decryptPreKeyWhisperMessage: function(ciphertext, sessionCipher, address) {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38245,6 +38245,8 @@ var TextSecureServer = (function() {
  */
 
 function MessageReceiver(url, ports, username, password, signalingKey) {
+    this.count = 0;
+
     this.url = url;
     this.signalingKey = signalingKey;
     this.username = username;
@@ -38357,10 +38359,22 @@ MessageReceiver.prototype.extend({
         }.bind(this);
 
         var scheduleDispatch = function() {
+            // resetting count to zero so everything queued after this starts over again
+            this.count = 0;
+
             this.pending = this.pending.then(dispatchEmpty, dispatchEmpty);
         }.bind(this);
 
         Promise.all(incoming).then(scheduleDispatch, scheduleDispatch);
+    },
+    updateProgress: function(count) {
+        // count by 10s
+        if (count % 10 !== 0) {
+            return;
+        }
+        var ev = new Event('progress');
+        ev.count = count;
+        this.dispatchEvent(ev);
     },
     queueAllCached: function() {
         this.getAllFromCache().then(function(items) {
@@ -38446,6 +38460,7 @@ MessageReceiver.prototype.extend({
         return textsecure.storage.unprocessed.remove(id);
     },
     queueDecryptedEnvelope: function(envelope, plaintext) {
+        var count = this.count += 1;
         var id = this.getEnvelopeId(envelope);
         console.log('queueing decrypted envelope', id);
 
@@ -38454,11 +38469,14 @@ MessageReceiver.prototype.extend({
 
         this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
 
-        return this.pending.catch(function(error) {
+        return this.pending.then(function() {
+            this.updateProgress(count);
+        }.bind(this), function(error) {
             console.log('queueDecryptedEnvelope error handling envelope', id, ':', error && error.stack ? error.stack : error);
         });
     },
     queueEnvelope: function(envelope) {
+        var count = this.count += 1;
         var id = this.getEnvelopeId(envelope);
         console.log('queueing envelope', id);
 
@@ -38467,7 +38485,9 @@ MessageReceiver.prototype.extend({
 
         this.pending = this.pending.then(taskWithTimeout, taskWithTimeout);
 
-        return this.pending.catch(function(error) {
+        return this.pending.then(function() {
+            this.updateProgress(count);
+        }.bind(this), function(error) {
             console.log('queueEnvelope error handling envelope', id, ':', error && error.stack ? error.stack : error);
         });
     },

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37484,13 +37484,16 @@ window.textsecure.utils = function() {
                 this.listeners = {};
             }
             var listeners = this.listeners[ev.type];
+            var results = [];
             if (typeof listeners === 'object') {
-                for (var i=0; i < listeners.length; ++i) {
-                    if (typeof listeners[i] === 'function') {
-                        listeners[i].call(null, ev);
+                for (var i = 0, max = listeners.length; i < max; i += 1) {
+                    var listener = listeners[i];
+                    if (typeof listener === 'function') {
+                        results.push(listener.call(null, ev));
                     }
                 }
             }
+            return results;
         },
         addEventListener: function(eventName, callback) {
             if (typeof eventName !== 'string') {
@@ -38284,22 +38287,25 @@ MessageReceiver.prototype.extend({
     onerror: function(error) {
         console.log('websocket error');
     },
+    dispatchAndWait: function(event) {
+        return Promise.all(this.dispatchEvent(event));
+    },
     onclose: function(ev) {
         console.log('websocket closed', ev.code, ev.reason || '');
         if (ev.code === 3000) {
             return;
         }
-        var eventTarget = this;
         // possible 403 or network issue. Make an request to confirm
-        this.server.getDevices(this.number).
-            then(this.connect.bind(this)). // No HTTP error? Reconnect
-            catch(function(e) {
+        this.server.getDevices(this.number)
+            .then(this.connect.bind(this)) // No HTTP error? Reconnect
+            .catch(function(e) {
                 var ev = new Event('error');
                 ev.error = e;
-                eventTarget.dispatchEvent(ev);
-            });
+                this.dispatchAndWait(ev);
+            }.bind(this));
     },
     handleRequest: function(request) {
+        this.incoming = this.incoming || [];
         // We do the message decryption here, instead of in the ordered pending queue,
         // to avoid exposing the time it took us to process messages through the time-to-ack.
 
@@ -38307,10 +38313,14 @@ MessageReceiver.prototype.extend({
         if (request.path !== '/api/v1/message') {
             console.log('got request', request.verb, request.path);
             request.respond(200, 'OK');
+
+            if (request.verb === 'PUT' && request.path === '/api/v1/queue/empty') {
+                this.onEmpty();
+            }
             return;
         }
 
-        textsecure.crypto.decryptWebsocketMessage(request.body, this.signalingKey).then(function(plaintext) {
+        this.incoming.push(textsecure.crypto.decryptWebsocketMessage(request.body, this.signalingKey).then(function(plaintext) {
             var envelope = textsecure.protobuf.Envelope.decode(plaintext);
             // After this point, decoding errors are not the server's
             //   fault, and we should handle them gracefully and tell the
@@ -38320,7 +38330,7 @@ MessageReceiver.prototype.extend({
                 return request.respond(200, 'OK');
             }
 
-            this.addToCache(envelope, plaintext).then(function() {
+            return this.addToCache(envelope, plaintext).then(function() {
                 request.respond(200, 'OK');
                 this.queueEnvelope(envelope);
             }.bind(this), function(error) {
@@ -38334,8 +38344,23 @@ MessageReceiver.prototype.extend({
             console.log("Error handling incoming message:", e && e.stack ? e.stack : e);
             var ev = new Event('error');
             ev.error = e;
-            this.dispatchEvent(ev);
-        }.bind(this));
+            return this.dispatchAndWait(ev);
+        }.bind(this)));
+    },
+    onEmpty: function() {
+        var incoming = this.incoming;
+        this.incoming = [];
+
+        var dispatchEmpty = function() {
+            var ev = new Event('empty');
+            return this.dispatchAndWait(ev);
+        }.bind(this);
+
+        var scheduleDispatch = function() {
+            this.pending = this.pending.then(dispatchEmpty, dispatchEmpty);
+        }.bind(this);
+
+        Promise.all(incoming).then(scheduleDispatch, scheduleDispatch);
     },
     queueAllCached: function() {
         this.getAllFromCache().then(function(items) {
@@ -38484,12 +38509,11 @@ MessageReceiver.prototype.extend({
         }
     },
     onDeliveryReceipt: function (envelope) {
-        return new Promise(function(resolve) {
+        return new Promise(function(resolve, reject) {
             var ev = new Event('receipt');
             ev.confirm = this.removeFromCache.bind(this, envelope);
             ev.proto = envelope;
-            this.dispatchEvent(ev);
-            return resolve();
+            this.dispatchAndWait(ev).then(resolve, reject);
         }.bind(this));
     },
     unpad: function(paddedPlaintext) {
@@ -38548,8 +38572,11 @@ MessageReceiver.prototype.extend({
             var ev = new Event('error');
             ev.error = error;
             ev.proto = envelope;
-            this.dispatchEvent(ev);
-            return Promise.reject(error);
+
+            var returnError = function() {
+                return Promise.reject(error);
+            };
+            this.dispatchAndWait(ev).then(returnError, returnError);
         }.bind(this));
     },
     decryptPreKeyWhisperMessage: function(ciphertext, sessionCipher, address) {
@@ -38586,7 +38613,7 @@ MessageReceiver.prototype.extend({
                 if (expirationStartTimestamp) {
                   ev.data.expirationStartTimestamp = expirationStartTimestamp.toNumber();
                 }
-                this.dispatchEvent(ev);
+                return this.dispatchAndWait(ev);
             }.bind(this));
         }.bind(this));
     },
@@ -38608,7 +38635,7 @@ MessageReceiver.prototype.extend({
                     timestamp    : envelope.timestamp.toNumber(),
                     message      : message
                 };
-                this.dispatchEvent(ev);
+                return this.dispatchAndWait(ev);
             }.bind(this));
         }.bind(this));
     },
@@ -38696,9 +38723,10 @@ MessageReceiver.prototype.extend({
             identityKey: verified.identityKey.toArrayBuffer()
         };
         ev.viaContactSync = options.viaContactSync;
-        this.dispatchEvent(ev);
+        return this.dispatchAndWait(ev);
     },
     handleRead: function(envelope, read) {
+        var results = [];
         for (var i = 0; i < read.length; ++i) {
             var ev = new Event('read');
             ev.confirm = this.removeFromCache.bind(this, envelope);
@@ -38707,24 +38735,30 @@ MessageReceiver.prototype.extend({
                 timestamp : read[i].timestamp.toNumber(),
                 sender    : read[i].sender
             }
-            this.dispatchEvent(ev);
+            results.push(this.dispatchAndWait(ev));
         }
+        return Promise.all(results);
     },
     handleContacts: function(envelope, contacts) {
         console.log('contact sync');
         var eventTarget = this;
         var attachmentPointer = contacts.blob;
         return this.handleAttachment(attachmentPointer).then(function() {
+            var results = [];
             var contactBuffer = new ContactBuffer(attachmentPointer.data);
             var contactDetails = contactBuffer.next();
             while (contactDetails !== undefined) {
                 var ev = new Event('contact');
                 ev.confirm = this.removeFromCache.bind(this, envelope);
                 ev.contactDetails = contactDetails;
-                eventTarget.dispatchEvent(ev);
+                results.push(eventTarget.dispatchAndWait(ev));
 
                 if (contactDetails.verified) {
-                    this.handleVerified(envelope, contactDetails.verified, {viaContactSync: true});
+                    results.push(this.handleVerified(
+                        envelope,
+                        contactDetails.verified,
+                        {viaContactSync: true}
+                    ));
                 }
 
                 contactDetails = contactBuffer.next();
@@ -38732,12 +38766,13 @@ MessageReceiver.prototype.extend({
 
             var ev = new Event('contactsync');
             ev.confirm = this.removeFromCache.bind(this, envelope);
-            eventTarget.dispatchEvent(ev);
+            results.push(eventTarget.dispatchAndWait(ev));
+
+            return Promise.all(results);
         }.bind(this));
     },
     handleGroups: function(envelope, groups) {
         console.log('group sync');
-        var eventTarget = this;
         var attachmentPointer = groups.blob;
         return this.handleAttachment(attachmentPointer).then(function() {
             var groupBuffer = new GroupBuffer(attachmentPointer.data);
@@ -38766,7 +38801,7 @@ MessageReceiver.prototype.extend({
                     var ev = new Event('group');
                     ev.confirm = this.removeFromCache.bind(this, envelope);
                     ev.groupDetails = groupDetails;
-                    eventTarget.dispatchEvent(ev);
+                    return this.dispatchAndWait(ev);
                 }.bind(this)).catch(function(e) {
                     console.log('error processing group', e);
                 });
@@ -38777,7 +38812,7 @@ MessageReceiver.prototype.extend({
             Promise.all(promises).then(function() {
                 var ev = new Event('groupsync');
                 ev.confirm = this.removeFromCache.bind(this, envelope);
-                eventTarget.dispatchEvent(ev);
+                return this.dispatchAndWait(ev);
             }.bind(this));
         }.bind(this));
     },
@@ -38805,9 +38840,9 @@ MessageReceiver.prototype.extend({
             attachment.data = data;
         }
 
-        return this.server.getAttachment(attachment.id).
-        then(decryptAttachment).
-        then(updateAttachment);
+        return this.server.getAttachment(attachment.id)
+            .then(decryptAttachment)
+            .then(updateAttachment);
     },
     tryMessageAgain: function(from, ciphertext) {
         var address = libsignal.SignalProtocolAddress.fromString(from);

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -344,7 +344,7 @@
 
         // Lastly, we don't send read receipts for any message marked read due to a read
         //   receipt. That's a notification explosion we don't need.
-        this.queueJob(function() {
+        return this.queueJob(function() {
             return this.markRead(message.get('received_at'), {sendReadReceipts: false});
         }.bind(this));
     },

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -342,7 +342,10 @@
                 this.send(promise);
             }
         },
-        handleDataMessage: function(dataMessage, confirm) {
+        handleDataMessage: function(dataMessage, confirm, options) {
+            options = options || {};
+            _.defaults(options, {initialLoadComplete: true});
+
             // This function can be called from the background script on an
             // incoming message or from the frontend after the user accepts an
             // identity key change.
@@ -357,7 +360,7 @@
             console.log('queuing handleDataMessage', message.idForLogging());
 
             var conversation = ConversationController.create({id: conversationId});
-            conversation.queueJob(function() {
+            return conversation.queueJob(function() {
                 return new Promise(function(resolve) {
                     conversation.fetch().always(function() {
                         console.log('starting handleDataMessage', message.idForLogging());
@@ -500,7 +503,7 @@
                                             //   because we need to start expiration timers, etc.
                                             message.markRead();
                                         }
-                                        if (message.get('unread')) {
+                                        if (message.get('unread') && options.initialLoadComplete) {
                                             conversation.notify(message);
                                         }
 

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -59,10 +59,7 @@
 
     Whisper.ConversationLoadingScreen = Whisper.View.extend({
         templateName: 'conversation-loading-screen',
-        className: 'conversation-loading-screen',
-        render_attributes: {
-            loading: i18n('loading')
-        }
+        className: 'conversation-loading-screen'
     });
 
     Whisper.ConversationTitleView = Whisper.View.extend({

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -60,6 +60,15 @@
         }
     });
 
+
+    Whisper.AppLoadingScreen = Whisper.View.extend({
+        templateName: 'app-loading-screen',
+        className: 'app-loading-screen',
+        render_attributes: {
+            loading: i18n('loading')
+        }
+    });
+
     Whisper.InboxView = Whisper.View.extend({
         templateName: 'two-column',
         className: 'inbox',
@@ -71,6 +80,7 @@
                     .addClass(theme);
         },
         initialize: function (options) {
+            this.ready = false;
             this.render();
             this.applyTheme();
             this.$el.attr('tabindex', '1');
@@ -79,6 +89,10 @@
                 el: this.$('.conversation-stack'),
                 model: { window: options.window }
             });
+
+            this.appLoadingScreen = new Whisper.AppLoadingScreen();
+            this.appLoadingScreen.render();
+            this.appLoadingScreen.$el.prependTo(this.el);
 
             var inboxCollection = getInboxCollection();
 
@@ -145,6 +159,13 @@
             'input input.search': 'filterContacts',
             'click .restart-signal': 'reloadBackgroundPage',
             'show .lightbox': 'showLightbox'
+        },
+        onEmpty: function() {
+            var view = this.appLoadingScreen;
+            if (view) {
+                this.appLoadingScreen = null;
+                view.remove();
+            }
         },
         focusConversation: function(e) {
             if (e && this.$(e.target).closest('.placeholder').length) {

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -80,6 +80,8 @@
                     .addClass(theme);
         },
         initialize: function (options) {
+            options = options || {};
+
             this.ready = false;
             this.render();
             this.applyTheme();
@@ -90,9 +92,11 @@
                 model: { window: options.window }
             });
 
-            this.appLoadingScreen = new Whisper.AppLoadingScreen();
-            this.appLoadingScreen.render();
-            this.appLoadingScreen.$el.prependTo(this.el);
+            if (!options.initialLoadComplete) {
+                this.appLoadingScreen = new Whisper.AppLoadingScreen();
+                this.appLoadingScreen.render();
+                this.appLoadingScreen.$el.prependTo(this.el);
+            }
 
             var inboxCollection = getInboxCollection();
 

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -102,6 +102,7 @@
                 this.appLoadingScreen = new Whisper.AppLoadingScreen();
                 this.appLoadingScreen.render();
                 this.appLoadingScreen.$el.prependTo(this.el);
+                this.startConnectionListener();
             }
 
             var inboxCollection = getInboxCollection();
@@ -169,6 +170,27 @@
             'input input.search': 'filterContacts',
             'click .restart-signal': 'reloadBackgroundPage',
             'show .lightbox': 'showLightbox'
+        },
+        startConnectionListener: function() {
+            this.interval = setInterval(function() {
+                var status = window.getSocketStatus();
+                switch(status) {
+                    case WebSocket.CONNECTING:
+                        break;
+                    case WebSocket.OPEN:
+                        clearInterval(this.interval);
+                        // if we've connected, we can wait for real empty event
+                        this.interval = null;
+                        break;
+                    case WebSocket.CLOSING:
+                    case WebSocket.CLOSED:
+                        clearInterval(this.interval);
+                        this.interval = null;
+                        // if we failed to connect, we pretend we got an empty event
+                        this.onEmpty();
+                        break;
+                }
+            }.bind(this), 1000);
         },
         onEmpty: function() {
             var view = this.appLoadingScreen;

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -64,8 +64,14 @@
     Whisper.AppLoadingScreen = Whisper.View.extend({
         templateName: 'app-loading-screen',
         className: 'app-loading-screen',
+        updateProgress: function(count) {
+            if (count > 0) {
+                var message = i18n('loadingMessages', count.toString());
+                this.$('.message').text(message);
+            }
+        },
         render_attributes: {
-            loading: i18n('loading')
+            message: i18n('loading')
         }
     });
 
@@ -169,6 +175,12 @@
             if (view) {
                 this.appLoadingScreen = null;
                 view.remove();
+            }
+        },
+        onProgress: function(count) {
+            var view = this.appLoadingScreen;
+            if (view) {
+                view.updateProgress(count);
             }
         },
         focusConversation: function(e) {

--- a/libtextsecure/event_target.js
+++ b/libtextsecure/event_target.js
@@ -23,13 +23,16 @@
                 this.listeners = {};
             }
             var listeners = this.listeners[ev.type];
+            var results = [];
             if (typeof listeners === 'object') {
-                for (var i=0; i < listeners.length; ++i) {
-                    if (typeof listeners[i] === 'function') {
-                        listeners[i].call(null, ev);
+                for (var i = 0, max = listeners.length; i < max; i += 1) {
+                    var listener = listeners[i];
+                    if (typeof listener === 'function') {
+                        results.push(listener.call(null, ev));
                     }
                 }
             }
+            return results;
         },
         addEventListener: function(eventName, callback) {
             if (typeof eventName !== 'string') {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -56,12 +56,12 @@ MessageReceiver.prototype.extend({
             return;
         }
         // possible 403 or network issue. Make an request to confirm
-        this.server.getDevices(this.number)
+        return this.server.getDevices(this.number)
             .then(this.connect.bind(this)) // No HTTP error? Reconnect
             .catch(function(e) {
                 var ev = new Event('error');
                 ev.error = e;
-                this.dispatchAndWait(ev);
+                return this.dispatchAndWait(ev);
             }.bind(this));
     },
     handleRequest: function(request) {
@@ -134,14 +134,17 @@ MessageReceiver.prototype.extend({
             return this.dispatchAndWait(ev);
         }.bind(this);
 
-        var scheduleDispatch = function() {
+        var queueDispatch = function() {
             // resetting count to zero so everything queued after this starts over again
             this.count = 0;
 
             this.addToQueue(dispatchEmpty);
         }.bind(this);
 
-        Promise.all(incoming).then(scheduleDispatch, scheduleDispatch);
+        // We first wait for all recently-received messages (this.incoming) to be queued,
+        //   then we add a task to emit the 'empty' event to the queue, so all message
+        //   processing is complete by the time it runs.
+        Promise.all(incoming).then(queueDispatch, queueDispatch);
     },
     updateProgress: function(count) {
         // count by 10s
@@ -529,7 +532,6 @@ MessageReceiver.prototype.extend({
     },
     handleContacts: function(envelope, contacts) {
         console.log('contact sync');
-        var eventTarget = this;
         var attachmentPointer = contacts.blob;
         return this.handleAttachment(attachmentPointer).then(function() {
             var results = [];
@@ -539,7 +541,7 @@ MessageReceiver.prototype.extend({
                 var ev = new Event('contact');
                 ev.confirm = this.removeFromCache.bind(this, envelope);
                 ev.contactDetails = contactDetails;
-                results.push(eventTarget.dispatchAndWait(ev));
+                results.push(this.dispatchAndWait(ev));
 
                 if (contactDetails.verified) {
                     results.push(this.handleVerified(
@@ -554,7 +556,7 @@ MessageReceiver.prototype.extend({
 
             var ev = new Event('contactsync');
             ev.confirm = this.removeFromCache.bind(this, envelope);
-            results.push(eventTarget.dispatchAndWait(ev));
+            results.push(this.dispatchAndWait(ev));
 
             return Promise.all(results);
         }.bind(this));

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -364,7 +364,7 @@ MessageReceiver.prototype.extend({
             var returnError = function() {
                 return Promise.reject(error);
             };
-            this.dispatchAndWait(ev).then(returnError, returnError);
+            return this.dispatchAndWait(ev).then(returnError, returnError);
         }.bind(this));
     },
     decryptPreKeyWhisperMessage: function(ciphertext, sessionCipher, address) {

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -32,6 +32,51 @@
 .conversation {
   background-color: white;
   height: 100%;
+  position: relative;
+
+  .conversation-loading-screen {
+    z-index: 99;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    background-color: #eee;
+    display: flex;
+    align-items: center;
+
+    .content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    .container {
+      position: absolute;
+      left: 50%;
+      width: 78px;
+      transform: translate(-50%, 0);
+    }
+
+    .dot {
+      width: 14px;
+      height: 14px;
+      border: 3px solid $blue;
+      border-radius: 50%;
+      float: left;
+      margin: 0 6px;
+      transform: scale(0);
+
+      animation: loading 1500ms ease infinite 0ms;
+      &:nth-child(2) {
+        animation: loading 1500ms ease infinite 333ms;
+      }
+      &:nth-child(3) {
+        animation: loading 1500ms ease infinite 666ms;
+      }
+    }
+  }
 
   .panel {
     height: calc(100% - #{$header-height});

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -539,6 +539,64 @@ input[type=text], input[type=search], textarea {
   }
 }
 
+.inbox {
+  position: relative;
+}
+
+@keyframes loading {
+  50% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.app-loading-screen {
+  z-index: 1000;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: white;
+  display: flex;
+  align-items: center;
+
+  .content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .container {
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 0);
+    width: 78px;
+  }
+
+  .dot {
+    width: 14px;
+    height: 14px;
+    border: 3px solid $blue;
+    border-radius: 50%;
+    float: left;
+    margin: 0 6px;
+    transform: scale(0);
+
+    animation: loading 1500ms ease infinite 0ms;
+    &:nth-child(2) {
+      animation: loading 1500ms ease infinite 333ms;
+    }
+    &:nth-child(3) {
+      animation: loading 1500ms ease infinite 666ms;
+    }
+  }
+}
+
 //yellow border fix
 .inbox:focus {
     outline: none;

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -565,17 +565,15 @@ input[type=text], input[type=search], textarea {
   align-items: center;
 
   .content {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
   }
-
   .container {
-    position: absolute;
-    left: 50%;
-    transform: translate(-50%, 0);
+    margin-left: auto;
+    margin-right: auto;
     width: 78px;
+    height: 22px;
   }
 
   .dot {

--- a/stylesheets/android-dark.scss
+++ b/stylesheets/android-dark.scss
@@ -88,6 +88,9 @@ $text-dark_l2: darken($text-dark, 30%);
   .conversation.placeholder .conversation-header {
     display: none;
   }
+  .conversation .conversation-loading-screen {
+    background-color: $grey-dark_l3;
+  }
   .avatar, .conversation-header, .bubble {
     @include dark-avatar-colors;
   }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -484,6 +484,49 @@ input[type=text]:active, input[type=text]:focus, input[type=search]:active, inpu
     background: #2090ea;
     margin-left: 20px; }
 
+.inbox {
+  position: relative; }
+
+@keyframes loading {
+  50% {
+    transform: scale(1);
+    opacity: 1; }
+  100% {
+    opacity: 0; } }
+.app-loading-screen {
+  z-index: 1000;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: white;
+  display: flex;
+  align-items: center; }
+  .app-loading-screen .content {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%); }
+  .app-loading-screen .container {
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 0);
+    width: 78px; }
+  .app-loading-screen .dot {
+    width: 14px;
+    height: 14px;
+    border: 3px solid #2090ea;
+    border-radius: 50%;
+    float: left;
+    margin: 0 6px;
+    transform: scale(0);
+    animation: loading 1500ms ease infinite 0ms; }
+    .app-loading-screen .dot:nth-child(2) {
+      animation: loading 1500ms ease infinite 333ms; }
+    .app-loading-screen .dot:nth-child(3) {
+      animation: loading 1500ms ease infinite 666ms; }
+
 .inbox:focus {
   outline: none; }
 
@@ -1035,7 +1078,41 @@ input.search {
 
 .conversation {
   background-color: white;
-  height: 100%; }
+  height: 100%;
+  position: relative; }
+  .conversation .conversation-loading-screen {
+    z-index: 99;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    background-color: #eee;
+    display: flex;
+    align-items: center; }
+    .conversation .conversation-loading-screen .content {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%); }
+    .conversation .conversation-loading-screen .container {
+      position: absolute;
+      left: 50%;
+      width: 78px;
+      transform: translate(-50%, 0); }
+    .conversation .conversation-loading-screen .dot {
+      width: 14px;
+      height: 14px;
+      border: 3px solid #2090ea;
+      border-radius: 50%;
+      float: left;
+      margin: 0 6px;
+      transform: scale(0);
+      animation: loading 1500ms ease infinite 0ms; }
+      .conversation .conversation-loading-screen .dot:nth-child(2) {
+        animation: loading 1500ms ease infinite 333ms; }
+      .conversation .conversation-loading-screen .dot:nth-child(3) {
+        animation: loading 1500ms ease infinite 666ms; }
   .conversation .panel {
     height: calc(100% - 64px);
     overflow-y: scroll; }
@@ -2083,6 +2160,8 @@ li.entry .error-icon-container {
     border-color: #333333; }
   .android-dark .conversation.placeholder .conversation-header {
     display: none; }
+  .android-dark .conversation .conversation-loading-screen {
+    background-color: #171717; }
   .android-dark .avatar.red, .android-dark .conversation-header.red, .android-dark .bubble.red {
     background-color: #D32F2F; }
   .android-dark .avatar.pink, .android-dark .conversation-header.pink, .android-dark .bubble.pink {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -504,15 +504,14 @@ input[type=text]:active, input[type=text]:focus, input[type=search]:active, inpu
   display: flex;
   align-items: center; }
   .app-loading-screen .content {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%); }
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center; }
   .app-loading-screen .container {
-    position: absolute;
-    left: 50%;
-    transform: translate(-50%, 0);
-    width: 78px; }
+    margin-left: auto;
+    margin-right: auto;
+    width: 78px;
+    height: 22px; }
   .app-loading-screen .dot {
     width: 14px;
     height: 14px;

--- a/test/fixtures_test.js
+++ b/test/fixtures_test.js
@@ -13,14 +13,17 @@ describe("Fixtures", function() {
   it('renders', function(done) {
     ConversationController.updateInbox().then(function() {
       var view = new Whisper.InboxView({window: window});
+      view.onEmpty();
       view.$el.prependTo($('#render-android'));
 
       var view = new Whisper.InboxView({window: window});
       view.$el.removeClass('android').addClass('ios');
+      view.onEmpty();
       view.$el.prependTo($('#render-ios'));
 
       var view = new Whisper.InboxView({window: window});
       view.$el.removeClass('android').addClass('android-dark');
+      view.onEmpty();
       view.$el.prependTo($('#render-android-dark'));
     }).then(done, done);
   });

--- a/test/index.html
+++ b/test/index.html
@@ -16,6 +16,26 @@
   </div>
   <div id="render-ios" class='index' style="width: 800; height: 500; margin:10px; border: solid 1px black;">
   </div>
+  <script type='text/x-tmpl-mustache' id='app-loading-screen'>
+    <div class='content'>
+      <img src='/images/icon_128.png'>
+      <div class='container'>
+        <span class='dot'></span>
+        <span class='dot'></span>
+        <span class='dot'></span>
+      </div>
+    </div>
+  </script>
+  <script type='text/x-tmpl-mustache' id='conversation-loading-screen'>
+    <div class='content'>
+      <img src='/images/icon_128.png'>
+      <div class='container'>
+        <span class='dot'></span>
+        <span class='dot'></span>
+        <span class='dot'></span>
+      </div>
+    </div>
+  </script>
   <script type='text/x-tmpl-mustache' id='two-column'>
     <div class='gutter'>
         <div class='network-status-container'></div>


### PR DESCRIPTION
A number of changes needed to be made so that `MessageReceiver` could know when its queue was truly processed:
- `dispatchEvent()` now surfaces the return values of all listeners back as an array of results
- `MessageReceiver` now has an `incoming` property, an array of all promises which encompass the initial decrypt, response to the server, caching, and finally queuing for all all in-flight envelopes. It allows us to ensure that when we get that 'empty' notification from the server, we can wait for all messages that came in right before that to be queued.
- when doing handling of an envelope in the primary queue, we wait until processing of that envelope is complete before moving onto the next one. This change has the biggest potential for larger effects on application behavior, but it's also necessary to ensure that we can wait until that flurry of catch-up behavior is complete.
- `MessageReceiver` now emits a new event, `empty`, when the server has told us that we've reached the end of its queue, _and we've processed all of the messages up to this point_

Note that we do __not__ pop notifications until that first `empty` event comes through from `MessageReceiver`. Any message which is still new after we've processed the whole queue will not result in a desktop notification. The user will need to rely on conversation badge counts.

Two new loading screens which look the same except for placement and background color:
- Application-wide loading screen (white background color) only shows once, when the inbox is first shown, up until we get that `empty` event from `MessageReceiver`.
- Conversation loading screens (same as conversation background color) show only on initial conversation load, displaying until profile and verified state fetches are complete, as well as the fetch of messages from the database. This prevents last seen indicator rendering delays by waiting until everything is in place before we show it.