### PR TITLE
ConversationController.findOrCreateById instead of private-specific method

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -158,7 +158,7 @@
             return;
         }
 
-        return ConversationController.findOrCreatePrivateById(id).then(function(conversation) {
+        return ConversationController.findOrCreateById(id, 'private').then(function(conversation) {
             return new Promise(function(resolve, reject) {
                 conversation.save({
                     name: details.name,
@@ -174,7 +174,7 @@
         var details = ev.groupDetails;
         var id = details.id;
 
-        return ConversationController.findOrCreateById(id).then(function(conversation) {
+        return ConversationController.findOrCreateById(id, 'group').then(function(conversation) {
             var updates = {
                 name: details.name,
                 members: details.members,
@@ -311,8 +311,10 @@
             }
             var envelope = ev.proto;
             var message = initIncomingMessage(envelope.source, envelope.timestamp.toNumber());
+
             message.saveErrors(e).then(function() {
-                ConversationController.findOrCreatePrivateById(message.get('conversationId')).then(function(conversation) {
+                var id = message.get('conversationId');
+                ConversationController.findOrCreateById(id, 'private').then(function(conversation) {
                     conversation.set({
                         active_at: Date.now(),
                         unreadCount: conversation.get('unreadCount') + 1
@@ -379,7 +381,7 @@
         console.log('got verified sync for', number, state,
             ev.viaContactSync ? 'via contact sync' : '');
 
-        return ConversationController.findOrCreatePrivateById(number).then(function(contact) {
+        return ConversationController.findOrCreateById(number, 'private').then(function(contact) {
             var options = {
                 viaSyncMessage: true,
                 viaContactSync: ev.viaContactSync,

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -86,24 +86,10 @@
             var conversation = conversations.add(attrs, {merge: true});
             return conversation;
         },
-        findOrCreatePrivateById: function(id) {
+        findOrCreateById: function(id, type) {
             var conversation = conversations.add({
                 id: id,
-                type: 'private'
-            });
-            return new Promise(function(resolve, reject) {
-                conversation.fetch().then(function() {
-                    resolve(conversation);
-                }, function() {
-                    conversation.save().then(function() {
-                        resolve(conversation);
-                    }, reject);
-                });
-            });
-        },
-        findOrCreateById: function(id) {
-            var conversation = conversations.add({
-                id: id
+                type: type
             });
             return new Promise(function(resolve, reject) {
                 conversation.fetch().then(function() {

--- a/js/views/conversation_search_view.js
+++ b/js/views/conversation_search_view.js
@@ -97,8 +97,9 @@
         createConversation: function() {
             var conversation = this.new_contact_view.model;
             if (this.new_contact_view.model.isValid()) {
-                ConversationController.findOrCreatePrivateById(
-                    this.new_contact_view.model.id
+                ConversationController.findOrCreateById(
+                    this.new_contact_view.model.id,
+                    'private'
                 ).then(function(conversation) {
                     this.trigger('open', conversation);
                     this.initNewContact();


### PR DESCRIPTION
Anyway, `findOrCreateById` with no `type` specified didn't succeed, because the conversation didn't validate. Discovered this problem handling sync'd group details when setting up a new desktop instance today.
