### PR TITLE
isUntrusted: Return false if firstUse is true

### DIFF
--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -726,7 +726,8 @@
                 var identityRecord = new IdentityRecord({id: identifier});
                 identityRecord.fetch().then(function() {
                     if (Date.now() - identityRecord.get('timestamp') < TIMESTAMP_THRESHOLD
-                        && !identityRecord.get('nonblockingApproval')) {
+                        && !identityRecord.get('nonblockingApproval')
+                        && !identityRecord.get('firstUse')) {
                         resolve(true);
                     } else {
                         resolve(false);


### PR DESCRIPTION
Because users will see this upon first trying to communicate with a new contact if they're quick about it.
