### PR TITLE
Unload conversations and old messages every half-hour

### DIFF
--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -19,6 +19,7 @@
             this.on('add remove change:unreadCount',
                 _.debounce(this.updateUnreadCount.bind(this), 1000)
             );
+            this.startPruning();
         },
         comparator: function(m1, m2) {
             var timestamp1 = m1.get('timestamp');
@@ -65,6 +66,14 @@
             if (newUnreadCount === 0) {
                 window.clearAttention();
             }
+        },
+        startPruning: function() {
+            var halfHour = 30 * 60 * 1000;
+            this.interval = setInterval(function() {
+                this.forEach(function(conversation) {
+                    conversation.trigger('prune');
+                });
+            }.bind(this), halfHour);
         }
     }))();
 

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -13,6 +13,7 @@
             this.on('destroy', this.revokeImageUrl);
             this.on('change:expirationStartTimestamp', this.setToExpire);
             this.on('change:expireTimer', this.setToExpire);
+            this.on('unload', this.revokeImageUrl);
             this.setToExpire();
         },
         idForLogging: function() {

--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -81,6 +81,21 @@
     events: {
         'click': 'onclick'
     },
+    unload: function() {
+        this.blob = null;
+
+        if (this.lightBoxView) {
+            this.lightBoxView.remove();
+        }
+        if (this.fileView) {
+            this.fileView.remove();
+        }
+        if (this.view) {
+            this.view.remove();
+        }
+
+        this.remove();
+    },
     getFileType: function() {
         switch(this.model.contentType) {
             case 'video/quicktime': return 'mov';
@@ -89,10 +104,10 @@
     },
     onclick: function(e) {
         if (this.isImage()) {
-            var view = new Whisper.LightboxView({ model: this });
-            view.render();
-            view.$el.appendTo(this.el);
-            view.$el.trigger('show');
+            this.lightBoxView = new Whisper.LightboxView({ model: this });
+            this.lightBoxView.render();
+            this.lightBoxView.$el.appendTo(this.el);
+            this.lightBoxView.$el.trigger('show');
 
         } else {
             this.saveFile();


### PR DESCRIPTION
Today the application keeps all previously-viewed conversations and messages (including attachments) in memory until restart. This can add up to a whole lot of memory usage, especially in high-traffic conversations with lots of large media.

This change sets up a timer in `ConversationController` to tell all conversations to prune themselves every half-hour. When a `ConversationView` finds that its conversation has emitted this `prune` event, it will do one of two things:
1. If it's been over an hour since the conversation has been opened or scrolled, and it's not currently showing, we'll unload it completely. We'll need to load it up once more, from scratch, when the user requests it.
2. If the conversation doesn't meet those criteria, but we're scrolled to the bottom (showing the most recent messages), we'll unload all but the most recent 100 messages. In very active conversations, this will keep the history from getting too long.

A good amount of work was required to ensure we call `remove()` on all views and subviews created to display images, errors, timers, and so on.
