### PR TITLE
Minimize time travel logging

### DIFF
--- a/js/rotate_signed_prekey_listener.js
+++ b/js/rotate_signed_prekey_listener.js
@@ -39,17 +39,17 @@
         var time = storage.get('nextSignedKeyRotationTime', now);
 
         if (scheduledTime !== time || !timeout) {
-            scheduledTime = time;
-
             console.log('Next signed key rotation scheduled for', new Date(time));
-            var waitTime = time - now;
-            if (waitTime < 0) {
-                waitTime = 0;
-            }
-
-            clearTimeout(timeout);
-            timeout = setTimeout(runWhenOnline, waitTime);
         }
+
+        scheduledTime = time;
+        var waitTime = time - now;
+        if (waitTime < 0) {
+            waitTime = 0;
+        }
+
+        clearTimeout(timeout);
+        timeout = setTimeout(runWhenOnline, waitTime);
     }
 
     Whisper.RotateSignedPreKeyListener = {

--- a/js/rotate_signed_prekey_listener.js
+++ b/js/rotate_signed_prekey_listener.js
@@ -7,6 +7,7 @@
     window.Whisper = window.Whisper || {};
     var ROTATION_INTERVAL = 48 * 60 * 60 * 1000;
     var timeout;
+    var scheduledTime;
 
     function scheduleNextRotation() {
         var now = Date.now();
@@ -35,14 +36,20 @@
 
     function setTimeoutForNextRun() {
         var now = Date.now();
-        var scheduledTime = storage.get('nextSignedKeyRotationTime', now);
-        console.log('Next signed key rotation scheduled for', new Date(scheduledTime));
-        var waitTime = scheduledTime - now;
-        if (waitTime < 0) {
-            waitTime = 0;
+        var time = storage.get('nextSignedKeyRotationTime', now);
+
+        if (scheduledTime !== time || !timeout) {
+            scheduledTime = time;
+
+            console.log('Next signed key rotation scheduled for', new Date(time));
+            var waitTime = time - now;
+            if (waitTime < 0) {
+                waitTime = 0;
+            }
+
+            clearTimeout(timeout);
+            timeout = setTimeout(runWhenOnline, waitTime);
         }
-        clearTimeout(timeout);
-        timeout = setTimeout(runWhenOnline, waitTime);
     }
 
     Whisper.RotateSignedPreKeyListener = {

--- a/js/wall_clock_listener.js
+++ b/js/wall_clock_listener.js
@@ -7,12 +7,11 @@
     window.Whisper = window.Whisper || {};
 
     var lastTime;
-    var interval = 1000;
+    var interval = 5000;
     var events;
     function checkTime() {
       var currentTime = Date.now();
       if (currentTime > (lastTime + interval * 2)) {
-          console.log('time travel detected!');
           events.trigger('timetravel');
       }
       lastTime = currentTime;
@@ -22,7 +21,7 @@
       init: function(_events) {
           events = _events;
           lastTime = Date.now();
-          setInterval(checkTime, 1000);
+          setInterval(checkTime, interval);
       }
     };
 }());

--- a/js/wall_clock_listener.js
+++ b/js/wall_clock_listener.js
@@ -7,7 +7,7 @@
     window.Whisper = window.Whisper || {};
 
     var lastTime;
-    var interval = 5000;
+    var interval = 1000;
     var events;
     function checkTime() {
       var currentTime = Date.now();


### PR DESCRIPTION
I left Electron running overnight last night, and my log was completely filled with two log entries: 'time travel detected!' and 'Next signed key rotation...'

This PR solves that by:
1. Removing the `console.log()` call when we detect time travel
2. ~~Reducing how often we check for time travel - every 5 seconds instead of every second~~
3. ~~Only calling `setTImeout()` to schedule the signed key rotation if the scheduled time has changed, or if we haven't scheduled a timer yet.~~