### PR TITLE
ConversationView: when windows are closed, call unload()

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -163,7 +163,7 @@
             this.window.addEventListener('focus', this.onFocus);
 
             extension.windows.onClosed(function () {
-                this.unload();
+                this.unload('windows closed');
             }.bind(this));
 
             this.fetchMessages();
@@ -211,14 +211,14 @@
 
             var oneHourAgo = Date.now() - 60 * 60 * 1000;
             if (this.isHidden() && this.lastActivity < oneHourAgo) {
-                this.unload();
+                this.unload('inactivity');
             } else if (this.view.atBottom()) {
                 this.trim();
             }
         },
 
-        unload: function() {
-            console.log('unloading conversation', this.model.id, 'due to inactivity');
+        unload: function(reason) {
+            console.log('unloading conversation', this.model.id, 'due to:', reason);
 
             this.timerMenu.remove();
             this.fileInput.remove();

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -163,11 +163,7 @@
             this.window.addEventListener('focus', this.onFocus);
 
             extension.windows.onClosed(function () {
-                this.window.removeEventListener('resize', onResize);
-                this.window.removeEventListener('focus', onFocus);
-                window.autosize.destroy(this.$messageField);
-                this.remove();
-                this.model.messageCollection.reset([]);
+                this.unload();
             }.bind(this));
 
             this.fetchMessages();
@@ -249,6 +245,8 @@
 
             this.window.removeEventListener('resize', this.onResize);
             this.window.removeEventListener('focus', this.onFocus);
+
+            window.autosize.destroy(this.$messageField);
 
             this.view.remove();
 


### PR DESCRIPTION
`unload()` is a more comprehensive method for doing what the close handler was trying to do before. We were missing just one thing in `unload()`, however - stopping the autosize management for the message composition text box. 