### PR TITLE
Conversation.markRead() - wait for all database saves

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -533,7 +533,9 @@
             Whisper.Notifications.remove(Whisper.Notifications.where({
                 messageId: this.id
             }));
-            return this.save();
+            return new Promise(function(resolve, reject) {
+                this.save().then(resolve, reject);
+            }.bind(this));
         },
         isExpiring: function() {
             return this.get('expireTimer') && this.get('expirationStartTimestamp');


### PR DESCRIPTION
I was thinking about how we might get duplicate read receipts sent by one client, and then I realized that we do queue `markRead()` calls, but we don't wait for all of their database writes to complete before returning. 

So it's definitely possible for two `markRead()` calls, right in a row (say from a click and also from the lazy scroll), to send read receipts for the same message. The first `getUnread()` call returns the full set, and the second returns some subset of the first because the database writes are incomplete.

Now it's one atomic action.