### PR TITLE
MessageReceiver: Ensure that we queue all cached first

### DIFF
--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -33,9 +33,7 @@ MessageReceiver.prototype.extend({
             keepalive: { path: '/v1/keepalive', disconnect: true }
         });
 
-        this.pending = Promise.resolve();
-
-        this.queueAllCached();
+        this.pending = this.queueAllCached();
     },
     close: function() {
         this.socket.close(3000, 'called close');
@@ -156,7 +154,7 @@ MessageReceiver.prototype.extend({
         this.dispatchEvent(ev);
     },
     queueAllCached: function() {
-        this.getAllFromCache().then(function(items) {
+        return this.getAllFromCache().then(function(items) {
             for (var i = 0, max = items.length; i < max; i += 1) {
                 this.queueCached(items[i]);
             }


### PR DESCRIPTION
I notice some unpredictability with 30+ cached - sometimes the loading screen would wait until they were all dealt with before starting up, sometimes the loading screen would disappear quickly.

This makes it predictable. When `MessageReceiver` starts up, the very first thing added to the queue are the messages we weren't able to successfully process.