### PR TITLE
AppView.createInbox() - set this.inboxView immediately to be ready

### DIFF
--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -59,12 +59,14 @@
           this.closeInstaller();
 
           if (!this.inboxView) {
+            // We create the inbox immediately to make sure we're ready to receive the
+            //   empty event after getting down to zero messages in the queue.
+            this.inboxView = new Whisper.InboxView({
+              model: self,
+              window: window,
+              initialLoadComplete: options.initialLoadComplete
+            });
             return ConversationController.updateInbox().then(function() {
-                this.inboxView = new Whisper.InboxView({
-                  model: self,
-                  window: window,
-                  initialLoadComplete: options.initialLoadComplete
-                });
                 this.openView(this.inboxView);
             }.bind(this));
           } else {


### PR DESCRIPTION
If the 'empty' event is fired between the `updateInbox()` call and the new `InboxView()` call afterwards, then the loading screen will never go away. We fix that by immediately creating the `InboxView` but only adding it to the DOM when the backing data is ready.