### PR TITLE
Full export, migration banner, and full migration workflow

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3,6 +3,30 @@
       "message": "Loading...",
       "description": "Message shown on the loading screen before we've loaded any messages"
     },
+    "migrationWarning": {
+      "message": "The Signal Desktop Chrome app has been deprecated. Would you like to migrate to the new Signal Desktop now?",
+      "description": "Warning notification that this version of the app has been deprecated and the user must migrate"
+    },
+    "migrate": {
+      "message": "Migrate",
+      "description": "Button label to begin migrating this client to Electron"
+    },
+    "confirmMigration": {
+      "message": "Begin migration? You will not be able to send or receive messages from this computer while the migration is in progress",
+      "description": "Confirmation dialogue when beginning migration"
+    },
+    "migrationDisconnecting": {
+      "message": "Disconnecting",
+      "description": "Displayed while we wait for pending incoming messages to process"
+    },
+    "exporting": {
+      "message": "Please wait while we export your data from Chrome. You can still use Signal on your phone and other devices during this time.",
+      "description": "Message shown on the migration screen while we export data"
+    },
+    "exportComplete": {
+      "message": "Your data has been exported. To complete the migration, install the Signal-Desktop for your OS and import the backup file.",
+      "description": "Message shown on the migration screen when we are done exporting data"
+    },
     "upgradingDatabase": {
       "message": "Upgrading database. This may take some time...",
       "description": "Message shown on the loading screen when we're changing database structure on first run of a new version"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -7,12 +7,28 @@
       "message": "The Signal Desktop Chrome app has been deprecated. Would you like to migrate to the new Signal Desktop now?",
       "description": "Warning notification that this version of the app has been deprecated and the user must migrate"
     },
+    "exportInstructions": {
+      "message": "The first step is to choose a directory to store this application's exported data. Please select an empty directory with enough free space.",
+      "description": "Description of the export process"
+    },
     "migrate": {
       "message": "Migrate",
       "description": "Button label to begin migrating this client to Electron"
     },
+    "export": {
+      "message": "Choose directory",
+      "description": "Button to allow the user to export all data from app as part of migration process"
+    },
+    "exportAgain": {
+      "message": "Export again",
+      "description": "If user has already exported once, this button allows user to do it again if needed"
+    },
+    "exportError": {
+      "message": "Unfortunately, something went wrong during the export. First, double-check your target empty directory for write access and enough space. Then, please submit a debug log so we can help you get migrated!",
+      "description": "Helper text if the user went forward on migrating the app, but ran into an error"
+    },
     "confirmMigration": {
-      "message": "Begin migration? You will not be able to send or receive messages from this computer while the migration is in progress",
+      "message": "Start migration process? You will not be able to send or receive messages from this computer while the migration is in progress",
       "description": "Confirmation dialogue when beginning migration"
     },
     "migrationDisconnecting": {
@@ -24,8 +40,18 @@
       "description": "Message shown on the migration screen while we export data"
     },
     "exportComplete": {
-      "message": "Your data has been exported. To complete the migration, install the Signal-Desktop for your OS and import the backup file.",
-      "description": "Message shown on the migration screen when we are done exporting data"
+      "message": "Your data has been exported to <b>$location$</b>. To complete the migration, <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/214507138-How-do-I-install-Signal-Desktop-'>install the new Signal-Desktop</a> and import this data.",
+      "description": "Message shown on the migration screen when we are done exporting data",
+      "placeholders": {
+        "location": {
+          "content": "$1",
+          "example": "/Users/someone/somewhere"
+        }
+      }
+    },
+    "selectedLocation": {
+      "message": "your selected location",
+      "description": "Message shown as the export location if we didn't capture the target directory"
     },
     "upgradingDatabase": {
       "message": "Upgrading database. This may take some time...",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -32,7 +32,7 @@
       "description": "Confirmation dialogue when beginning migration"
     },
     "migrationDisconnecting": {
-      "message": "Disconnecting",
+      "message": "Disconnecting...",
       "description": "Displayed while we wait for pending incoming messages to process"
     },
     "exporting": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -40,7 +40,7 @@
       "description": "Message shown on the migration screen while we export data"
     },
     "exportComplete": {
-      "message": "Your data has been exported to <b>$location$</b>. To complete the migration, <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/214507138-How-do-I-install-Signal-Desktop-'>install the new Signal Desktop</a> and import this data.",
+      "message": "Your data has been exported to: <p><b>$location$</b></p> To complete the migration, <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/214507138-How-do-I-install-Signal-Desktop-'>install the new Signal Desktop</a> and import this data.",
       "description": "Message shown on the migration screen when we are done exporting data",
       "placeholders": {
         "location": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -8,7 +8,7 @@
       "description": "Warning notification that this version of the app has been deprecated and the user must migrate"
     },
     "exportInstructions": {
-      "message": "The first step is to choose a directory to store this application's exported data. Please select an empty directory with enough free space.",
+      "message": "The first step is to choose a directory to store this application's exported data. It will contain your message history and sensitive cryptographic data, so be sure to save it somewhere private.",
       "description": "Description of the export process"
     },
     "migrate": {
@@ -28,7 +28,7 @@
       "description": "Helper text if the user went forward on migrating the app, but ran into an error"
     },
     "confirmMigration": {
-      "message": "Start migration process? You will not be able to send or receive messages from this computer while the migration is in progress",
+      "message": "Start migration process? You will not be able to send or receive Signal messages from this application while the migration is in progress.",
       "description": "Confirmation dialogue when beginning migration"
     },
     "migrationDisconnecting": {
@@ -36,11 +36,11 @@
       "description": "Displayed while we wait for pending incoming messages to process"
     },
     "exporting": {
-      "message": "Please wait while we export your data from Chrome. You can still use Signal on your phone and other devices during this time.",
+      "message": "Please wait while we export your data. You can still use Signal on your phone and other devices during this time. You can also <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/214507138-How-do-I-install-Signal-Desktop-'>install the new Signal Desktop</a>.",
       "description": "Message shown on the migration screen while we export data"
     },
     "exportComplete": {
-      "message": "Your data has been exported to <b>$location$</b>. To complete the migration, <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/214507138-How-do-I-install-Signal-Desktop-'>install the new Signal-Desktop</a> and import this data.",
+      "message": "Your data has been exported to <b>$location$</b>. To complete the migration, <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/214507138-How-do-I-install-Signal-Desktop-'>install the new Signal Desktop</a> and import this data.",
       "description": "Message shown on the migration screen when we are done exporting data",
       "placeholders": {
         "location": {

--- a/background.html
+++ b/background.html
@@ -731,6 +731,7 @@
   <script type='text/javascript' src='js/wall_clock_listener.js'></script>
   <script type='text/javascript' src='js/rotate_signed_prekey_listener.js'></script>
   <script type='text/javascript' src='js/keychange_listener.js'></script>
+  <script type='text/javascript' src='js/backup.js'></script>
   <script type='text/javascript' src='js/background.js'></script>
 </head>
 <body>

--- a/background.html
+++ b/background.html
@@ -5,12 +5,22 @@
   <script type='text/x-tmpl-mustache' id='app-migration-screen'>
     <div class='content'>
       <img src='/images/icon_128.png'>
-      <div class='container'>
-        <span class='dot'></span>
-        <span class='dot'></span>
-        <span class='dot'></span>
+      {{ ^hideProgress }}
+        <div class='container'>
+          <span class='dot'></span>
+          <span class='dot'></span>
+          <span class='dot'></span>
+        </div>
+      {{ /hideProgress }}
+      <div class='message'>{{& message }}</div>
+      <div>
+        {{ #exportButton }}
+          <button class='export grey'>{{ exportButton }}</button>
+        {{ /exportButton }}
+        {{ #debugLogButton }}
+          <button class='debug-log grey'>{{ debugLogButton }}</button>
+        {{ /debugLogButton }}
       </div>
-      <div class='message'>{{ message }}</div>
     </div>
   </script>
   <script type='text/x-tmpl-mustache' id='app-loading-screen'>
@@ -94,7 +104,9 @@
   </script>
   <script type='text/x-tmpl-mustache' id='migration_alert'>
     <button class='migrate'>{{ migrate }}</button>
-    {{ migrationWarning }}
+    <div class='message'>
+      {{ migrationWarning }}
+    </div>
   </script>
   <script type='text/x-tmpl-mustache' id='banner'>
     <div class='body'>

--- a/background.html
+++ b/background.html
@@ -2,6 +2,17 @@
 <html>
 <head>
   <meta charset='utf-8'>
+  <script type='text/x-tmpl-mustache' id='app-migration-screen'>
+    <div class='content'>
+      <img src='/images/icon_128.png'>
+      <div class='container'>
+        <span class='dot'></span>
+        <span class='dot'></span>
+        <span class='dot'></span>
+      </div>
+      <div class='message'>{{ message }}</div>
+    </div>
+  </script>
   <script type='text/x-tmpl-mustache' id='app-loading-screen'>
     <div class='content'>
       <img src='/images/icon_128.png'>
@@ -80,6 +91,10 @@
       <button class='upgrade'>{{ upgrade }}</button>
     </a>
     {{ expiredWarning }}
+  </script>
+  <script type='text/x-tmpl-mustache' id='migration_alert'>
+    <button class='migrate'>{{ migrate }}</button>
+    {{ migrationWarning }}
   </script>
   <script type='text/x-tmpl-mustache' id='banner'>
     <div class='body'>
@@ -727,6 +742,7 @@
   <script type='text/javascript' src='js/views/install_view.js'></script>
   <script type='text/javascript' src='js/views/banner_view.js'></script>
   <script type='text/javascript' src='js/views/identity_key_send_error_view.js'></script>
+  <script type='text/javascript' src='js/views/migration_view.js'></script>
 
   <script type='text/javascript' src='js/wall_clock_listener.js'></script>
   <script type='text/javascript' src='js/rotate_signed_prekey_listener.js'></script>

--- a/js/background.js
+++ b/js/background.js
@@ -100,9 +100,21 @@
         return new textsecure.SyncRequest(textsecure.messaging, messageReceiver);
     };
 
+    Whisper.events.on('shutdown', function() {
+      if (messageReceiver) {
+        messageReceiver.close().then(function() {
+          messageReceiver = null;
+          Whisper.events.trigger('shutdown-complete');
+        });
+      } else {
+        Whisper.events.trigger('shutdown-complete');
+      }
+    });
+
     function init(firstRun) {
         window.removeEventListener('online', init);
         if (!Whisper.Registration.isDone()) { return; }
+        if (Whisper.Migration.inProgress()) { return; }
 
         if (messageReceiver) { messageReceiver.close(); }
 

--- a/js/background.js
+++ b/js/background.js
@@ -100,7 +100,7 @@
         return new textsecure.SyncRequest(textsecure.messaging, messageReceiver);
     };
 
-    Whisper.events.on('shutdown', function() {
+    Whisper.events.on('start-shutdown', function() {
       if (messageReceiver) {
         messageReceiver.close().then(function() {
           messageReceiver = null;

--- a/js/backup.js
+++ b/js/backup.js
@@ -1,0 +1,255 @@
+;(function () {
+  'use strict';
+  window.Whisper = window.Whisper || {};
+
+  function stringToBlob(string) {
+    var buffer = dcodeIO.ByteBuffer.wrap(string).toArrayBuffer();
+    return new Blob([buffer]);
+  }
+
+  function stringify(object) {
+    for (var key in object) {
+      var val = object[key];
+      if (val instanceof ArrayBuffer) {
+        object[key] = {
+          type: 'ArrayBuffer',
+          encoding: 'base64',
+          data: dcodeIO.ByteBuffer.wrap(val).toString('base64')
+        };
+      } else if (val instanceof Object) {
+        object[key] = stringify(val);
+      }
+    }
+    return object;
+  }
+
+  function unstringify(object) {
+    if (!(object instanceof Object)) {
+      throw new Error('unstringify expects an object');
+    }
+    for (var key in object) {
+      var val = object[key];
+      if (val &&
+          val.type === 'ArrayBuffer' &&
+          val.encoding === 'base64' &&
+          typeof val.data === 'string' ) {
+        object[key] = dcodeIO.ByteBuffer.wrap(val.data, 'base64').toArrayBuffer();
+      } else if (val instanceof Object) {
+        object[key] = unstringify(object[key]);
+      }
+    }
+    return object;
+  }
+
+  function createOutputStream(fileWriter) {
+    var wait = Promise.resolve();
+    var count = 0;
+    return {
+      write: function(string) {
+        var i = count++;
+        wait = wait.then(function() {
+          return new Promise(function(resolve, reject) {
+            fileWriter.onwriteend = resolve;
+            fileWriter.onerror = reject;
+            fileWriter.onabort = reject;
+            fileWriter.write(stringToBlob(string));
+          });
+        });
+        return wait;
+      },
+      wait: function() {
+        return wait;
+      }
+    };
+  }
+
+  /**
+  * Export all data from an IndexedDB database
+  * @param {IDBDatabase} idb_db
+  */
+  function exportToJsonFile(idb_db, fileWriter) {
+    var storeNames = idb_db.objectStoreNames;
+    storeNames = _.without(storeNames, 'messages');
+    var exportedStoreNames = [];
+    console.log('Exporting', storeNames.toString());
+    if (storeNames.length === 0) {
+      throw new Error('No stores to export');
+    }
+
+    var stream = createOutputStream(fileWriter);
+
+    stream.write('{');
+
+    _.each(storeNames, function(storeName) {
+      var transaction = idb_db.transaction(storeNames, "readwrite");
+      transaction.onerror = function(e) { console.log(e); };
+      transaction.oncomplete = function() { console.log('complete'); };
+
+      var store = transaction.objectStore(storeName);
+      var request = store.openCursor();
+      var count = 0;
+      request.onerror = function(e) { console.log(e); };
+      request.onsuccess = function(event) {
+        if (count === 0) {
+          console.log('cursor opened');
+          stream.write('"' + storeName + '": [');
+        }
+
+        var cursor = event.target.result;
+        if (cursor) {
+          if (count > 0) {
+            stream.write(',');
+          }
+          var jsonString = JSON.stringify(stringify(cursor.value));
+          stream.write(jsonString);
+          cursor.continue();
+          count++;
+        } else {
+          // no more
+          stream.write(']');
+          console.log('Exported', count, storeName);
+
+          exportedStoreNames.push(storeName);
+          if (exportedStoreNames.length < storeNames.length) {
+            stream.write(',');
+          } else {
+            console.log('Exported all stores');
+            stream.write('}').then(function() {
+              console.log('finished writing');
+            });
+          }
+        }
+      };
+    });
+  }
+
+  /**
+  * Import data from JSON into an IndexedDB database. This does not delete any existing data
+  *  from the database, so keys could clash
+  *
+  * @param {IDBDatabase} idb_db
+  * @param {string} jsonString - data to import, one key per object store
+  */
+  function importFromJsonString(idb_db, jsonString) {
+    console.log('Beginning import');
+    return new Promise(function(resolve, reject) {
+      var transaction = idb_db.transaction(idb_db.objectStoreNames, "readwrite");
+      transaction.onerror = reject;
+      var importObject = JSON.parse(jsonString);
+      _.each(idb_db.objectStoreNames, function(storeName) {
+          console.log('Importing', storeName);
+          var count = 0;
+          _.each(importObject[storeName], function(toAdd) {
+              toAdd = unstringify(toAdd);
+              console.log('Importing', toAdd);
+              var request = transaction.objectStore(storeName).put(toAdd, toAdd.id);
+              request.onsuccess = function(event) {
+                count++;
+                console.log(count);
+                if (count == importObject[storeName].length) {
+                  // added all objects for this store
+                  delete importObject[storeName];
+                  if (_.keys(importObject).length === 0) {
+                    // added all object stores
+                    console.log('Import complete');
+                    resolve();
+                  }
+                }
+              };
+              request.onerror = function(event) {
+                console.log('Error adding object to store');
+                console.log(event.target.error);
+              };
+          });
+      });
+    });
+  }
+
+  function openDatabase() {
+    var migrations = Whisper.Database.migrations;
+    var version = migrations[migrations.length - 1].version;
+    var DBOpenRequest = window.indexedDB.open('signal', version);
+
+    return new Promise(function(resolve, reject) {
+      // these two event handlers act on the IDBDatabase object,
+      // when the database is opened successfully, or not
+      DBOpenRequest.onerror = reject;
+      DBOpenRequest.onsuccess = function() {
+        resolve(DBOpenRequest.result);
+      };
+
+      // This event handles the event whereby a new version of
+      // the database needs to be created Either one has not
+      // been created before, or a new version number has been
+      // submitted via the window.indexedDB.open line above
+      DBOpenRequest.onupgradeneeded = reject;
+    });
+  }
+
+  function chooseFile(type) {
+    return new Promise(function(resolve, reject) {
+      type = type || 'openFile';
+      var w = extension.windows.getViews()[0];
+      if (w && w.chrome && w.chrome.fileSystem) {
+        w.chrome.fileSystem.chooseEntry({
+          type: type, suggestedName: 'signal-desktop-backup.json'
+        }, function(entry) {
+          if (!entry) {
+            reject();
+          } else {
+            resolve(entry);
+          }
+        });
+      }
+    });
+  }
+
+  function getFileWriter() {
+    console.log('Selecting location to save backup file');
+    return chooseFile('saveFile').then(function(entry) {
+      return new Promise(function(resolve, reject) {
+        entry.createWriter(function(fileWriter) {
+          resolve(fileWriter);
+        }, reject);
+      });
+    });
+  }
+
+  function getFileString() {
+    return chooseFile().then(function(entry) {
+      return new Promise(function(resolve, reject) {
+        var file = entry.file(function(file) {
+          var reader = new FileReader();
+          reader.onload = function(e) {
+            resolve(e.target.result);
+          };
+          reader.onerror = reject;
+          reader.onabort = reject;
+          reader.readAsText(file);
+        }, reject);
+      });
+    });
+  }
+
+  Whisper.Backup = {
+    createBackupFile: function() {
+      return getFileWriter().then(function(fileWriter) {
+        return openDatabase().then(function(db) {
+          return exportToJsonFile(db, fileWriter);
+        });
+      }).catch(function(error) {
+        console.log(error);
+      });
+    },
+    restoreFromBackupFile: function() {
+      return getFileString().then(function(jsonString) {
+        return openDatabase().then(function(db) {
+          return importFromJsonString(db, jsonString);
+        });
+      }).catch(function(error) {
+        console.log(error);
+      });
+    }
+  };
+
+}());

--- a/js/backup.js
+++ b/js/backup.js
@@ -313,7 +313,7 @@
   }
 
   function sanitizeFileName(filename) {
-    return filename.toString().replace(/[^a-z0-9.:+()'"#\- ]/gi, '_');
+    return filename.toString().replace(/[^a-z0-9.,+()'"#\- ]/gi, '_');
   }
 
   function exportConversation(idb_db, name, conversation, dir) {
@@ -609,17 +609,26 @@
     });
   }
 
+  function getTimestamp() {
+    return moment().format('YYYY MMM Do [at] h.mm.ss a')
+  }
+
   Whisper.Backup = {
     backupToDirectory: function() {
       return getDirectory().then(function(directoryEntry) {
         var idb;
+        var dir;
         return openDatabase().then(function(idb_db) {
           idb = idb_db;
-          return exportNonMessages(idb_db, directoryEntry);
+          var name = 'Signal Export ' + getTimestamp();
+          return createDirectory(directoryEntry, name);
+        }).then(function(directory) {
+          dir = directory;
+          return exportNonMessages(idb, dir);
         }).then(function() {
-          return exportConversations(idb, directoryEntry);
+          return exportConversations(idb, dir);
         }).then(function() {
-          return getDisplayPath(directoryEntry);
+          return getDisplayPath(dir);
         });
       }).then(function(path) {
         console.log('done backing up!');

--- a/js/backup.js
+++ b/js/backup.js
@@ -56,9 +56,6 @@
           });
         });
         return wait;
-      },
-      wait: function() {
-        return wait;
       }
     };
   }
@@ -470,19 +467,19 @@
   function getDirectory() {
     return new Promise(function(resolve, reject) {
       var w = extension.windows.getViews()[0];
-      if (w && w.chrome && w.chrome.fileSystem) {
-        w.chrome.fileSystem.chooseEntry({
-          type: 'openDirectory'
-        }, function(entry) {
-          if (!entry) {
-            var error = new Error('Error choosing directory');
-            error.name = 'ChooseError';
-            reject(error);
-          } else {
-            resolve(entry);
-          }
-        });
+      if (!w || !w.chrome || !w.chrome.fileSystem) {
+        return reject(new Error('Ran into problem accessing Chrome filesystem API'));
       }
+
+      w.chrome.fileSystem.chooseEntry({type: 'openDirectory'}, function(entry) {
+        if (!entry) {
+          var error = new Error('Error choosing directory');
+          error.name = 'ChooseError';
+          return reject(error);
+        }
+
+        return resolve(entry);
+      });
     });
   }
 
@@ -610,7 +607,7 @@
   }
 
   function getTimestamp() {
-    return moment().format('YYYY MMM Do [at] h.mm.ss a')
+    return moment().format('YYYY MMM Do [at] h.mm.ss a');
   }
 
   Whisper.Backup = {

--- a/js/backup.js
+++ b/js/backup.js
@@ -71,7 +71,7 @@
     var storeNames = idb_db.objectStoreNames;
     storeNames = _.without(storeNames, 'messages');
     var exportedStoreNames = [];
-    console.log('Exporting', storeNames.toString());
+    console.log('Exporting', storeNames.join(', '));
     if (storeNames.length === 0) {
       throw new Error('No stores to export');
     }
@@ -231,7 +231,417 @@
     });
   }
 
+  function createDirectory(parent, name) {
+    var sanitized = sanitizeFileName(name);
+    return new Promise(function(resolve, reject) {
+      parent.getDirectory(sanitized, {create: true, exclusive: true}, resolve, reject);
+    });
+  }
+
+  function createFileAndWriter(parent, name) {
+    var sanitized = sanitizeFileName(name);
+    return new Promise(function(resolve, reject) {
+      parent.getFile(sanitized, {create: true, exclusive: true}, function(file) {
+        return file.createWriter(function(writer) {
+          resolve(writer);
+        }, reject);
+      }, reject);
+    });
+  }
+
+  function readFileAsText(parent, name) {
+    return new Promise(function(resolve, reject) {
+      parent.getFile(name, {create: false, exclusive: true}, function(fileEntry) {
+        fileEntry.file(function(file) {
+          var reader = new FileReader();
+          reader.onload = function(e) {
+            resolve(e.target.result);
+          };
+          reader.onerror = reject;
+          reader.onabort = reject;
+          reader.readAsText(file);
+        }, reject);
+      }, reject);
+    });
+  }
+
+  function readFileAsArrayBuffer(parent, name) {
+    return new Promise(function(resolve, reject) {
+      parent.getFile(name, {create: false, exclusive: true}, function(fileEntry) {
+        fileEntry.file(function(file) {
+          var reader = new FileReader();
+          reader.onload = function(e) {
+            resolve(e.target.result);
+          };
+          reader.onerror = reject;
+          reader.onabort = reject;
+          reader.readAsArrayBuffer(file);
+        }, reject);
+      }, reject);
+    });
+  }
+
+  function getAttachmentFileName(attachment) {
+    return attachment.fileName || (attachment.id + '.' + attachment.contentType.split('/')[1]);
+  }
+
+  function readAttachment(parent, message, attachment) {
+    var name = getAttachmentFileName(attachment);
+    var sanitized = sanitizeFileName(name);
+    var attachmentDir = message.received_at;
+    return new Promise(function(resolve, reject) {
+      parent.getDirectory(attachmentDir, {create: false, exclusive: true}, function(dir) {
+        return readFileAsArrayBuffer(dir, sanitized ).then(function(contents) {
+          attachment.data = contents;
+          return resolve()
+        }, reject);
+      }, reject);
+    });
+  }
+
+  function writeAttachment(dir, attachment) {
+    var filename = getAttachmentFileName(attachment);
+    return createFileAndWriter(dir, filename).then(function(writer) {
+      var stream = createOutputStream(writer);
+      stream.write(attachment.data);
+    });
+  }
+
+  function writeAttachments(parentDir, name, messageId, attachments) {
+    console.log('writeAttachments: starting conversation', name);
+    return createDirectory(parentDir, messageId).then(function(dir) {
+      return Promise.all(_.map(attachments, function(attachment) {
+        return writeAttachment(dir, attachment);
+      }));
+    }).then(function() {
+      console.log('writeAttachments: done exporting conversation', name);
+    }, function(error) {
+      console.log(
+        'writeAttachments: error exporting conversation',
+        name,
+        ':',
+        error && error.stack ? error.stack : error
+      );
+      return Promise.reject(error);
+    });
+  }
+
+  function arrayBufferToString(arrayBuffer) {
+      return new dcodeIO.ByteBuffer.wrap(arrayBuffer).toString('binary');
+  }
+
+  function stringToArrayBuffer(string) {
+      return new dcodeIO.ByteBuffer.wrap(string, 'binary').toArrayBuffer();
+  }
+
+  function sanitizeFileName(filename) {
+    return filename.toString().replace(/[^a-z0-9.:+()'"#\- ]/gi, '_');
+  }
+
+  function exportConversation(idb_db, name, conversation, dir) {
+    console.log('exporting conversation', name);
+    return createFileAndWriter(dir, 'messages.json').then(function(writer) {
+      return new Promise(function(resolve, reject) {
+
+        var transaction = idb_db.transaction('messages', "readwrite");
+        transaction.onerror = function(e) {
+          console.log(
+            'exportConversation transaction error for conversation',
+            name,
+            ':',
+            e && e.stack ? e.stack : e
+          );
+          return reject(e);
+        };
+        transaction.oncomplete = function() {
+          // this doesn't really mean anything - we may have attachment processing to do
+        };
+
+        var store = transaction.objectStore('messages');
+        var index = store.index('conversation');
+
+        var range = IDBKeyRange.bound([conversation.id, 0], [conversation.id, Number.MAX_VALUE]);
+
+        var promiseChain = Promise.resolve();
+        var count = 0;
+        var request = index.openCursor(range);
+
+        var stream = createOutputStream(writer);
+        stream.write('{"messages":[');
+
+        request.onerror = function(e) {
+          console.log(
+            'exportConversation: error pulling messages for conversation',
+            name,
+            ':',
+            e && e.stack ? e.stack : e
+          );
+          return reject(e);
+        };
+        request.onsuccess = function(event) {
+          var cursor = event.target.result;
+          if (cursor) {
+            if (count !== 0) {
+              stream.write(',');
+            }
+
+            var message = cursor.value;
+            var messageId = message.received_at;
+            var attachments = message.attachments;
+
+            message.attachments = _.map(attachments, function(attachment) {
+              return _.omit(attachment, ['data']);
+            });
+
+            var jsonString = JSON.stringify(stringify(message));
+            stream.write(jsonString);
+
+            if (attachments.length) {
+              var process = function() {
+                return writeAttachments(dir, name, messageId, attachments);
+              };
+              promiseChain = promiseChain.then(process);
+            }
+
+            count += 1;
+            cursor.continue();
+          } else {
+            stream.write(']}');
+            return promiseChain.then(function() {
+              console.log('exportConversation: done exporting conversation', name);
+              return resolve();
+            }, function(error) {
+              console.log(
+                'exportConversation: error exporting conversation',
+                name,
+                ':',
+                error && error.stack ? error.stack : error
+              );
+              return reject(error);
+            });
+          }
+        };
+      });
+    });
+  }
+
+  function getConversationDirName(conversation) {
+    var name = conversation.active_at || 'never';
+    if (conversation.type === 'private') {
+      name += ' (' + (conversation.name || conversation.id) + ')';
+    } else {
+      name += ' (' + conversation.name + ')';
+    }
+    return name;
+  }
+
+  function getConversationLoggingName(conversation) {
+    var name = conversation.active_at || 'never';
+    name += ' (' + conversation.id + ')';
+    return name;
+  }
+
+  function exportConversations(idb_db, parentDir) {
+    return new Promise(function(resolve, reject) {
+      var transaction = idb_db.transaction('conversations', "readwrite");
+      transaction.onerror = function(e) {
+        console.log(
+          'exportConversations: transaction error:',
+          e && e.stack ? e.stack : e
+        );
+        return reject(e);
+      };
+      transaction.oncomplete = function() {
+        console.log('done scheduling conversation exports');
+      };
+
+      var promiseChain = Promise.resolve();
+      var store = transaction.objectStore('conversations');
+      var request = store.openCursor();
+      request.onerror = function(e) {
+        console.log(
+          'exportConversations: error pulling conversations:',
+          e && e.stack ? e.stack : e
+        );
+        return reject(e);
+      };
+      request.onsuccess = function(event) {
+        var cursor = event.target.result;
+        if (cursor && cursor.value) {
+          var conversation = cursor.value;
+          var dir = getConversationDirName(conversation);
+          var name = getConversationLoggingName(conversation);
+
+          var process = function() {
+            return createDirectory(parentDir, dir).then(function(dir) {
+              return exportConversation(idb_db, name, conversation, dir);
+            });
+          }
+          console.log('scheduling conversation', name);
+
+          promiseChain = promiseChain.then(process);
+          cursor.continue();
+        } else {
+          return promiseChain.then(resolve, reject);
+        }
+      };
+    });
+  }
+
+  function getDirectory() {
+    return new Promise(function(resolve, reject) {
+      var w = extension.windows.getViews()[0];
+      if (w && w.chrome && w.chrome.fileSystem) {
+        w.chrome.fileSystem.chooseEntry({
+          type: 'openDirectory'
+        }, function(entry) {
+          if (!entry) {
+            reject();
+          } else {
+            resolve(entry);
+          }
+        });
+      }
+    });
+  }
+
+  function getDirContents(dir) {
+    return new Promise(function(resolve, reject) {
+      var reader = dir.createReader();
+      var contents = [];
+
+      var getContents = function() {
+        reader.readEntries(function(results) {
+          if (results.length) {
+            contents = contents.concat(results);
+            getContents();
+          } else {
+            return resolve(contents);
+          }
+        }, function(error) {
+          return reject(error);
+        });
+      };
+
+      getContents();
+    });
+  }
+
+  function loadAttachments(dir, message) {
+    return Promise.all(_.map(message.attachments, function(attachment) {
+      return readAttachment(dir, message, attachment);
+    }));
+  }
+
+  function saveAllMessages(store, messages) {
+    if (!messages.length) {
+      return Promise.resolve();
+    }
+
+    return new Promise(function(resolve, reject) {
+      var conversationId = messages[0].conversationId;
+      console.log('saving', messages.length, 'messages for conversation', conversationId);
+      var count = 0;
+
+      _.forEach(messages, function() {
+        var request = store.put(message, message.id);
+        request.onsuccess = function(event) {
+          count += 1;
+          if (count === messages.length) {
+            console.log('Done saving messages for conversation', conversationId);
+            resolve();
+          }
+        };
+        request.onerror = function(event) {
+          console.log('Error adding object to store:', error);
+          reject();
+        };
+      });
+    });
+  }
+
+  function importConversation(store, dir) {
+    return readFileAsText(dir, 'messages.json').then(function(contents) {
+      var promiseChain = Promise.resolve();
+
+      var json = JSON.parse(contents);
+      var messages = json.messages;
+      _.forEach(messages, function(message) {
+        message = unstringify(message);
+
+        if (message.attachments && message.attachments.length) {
+          var process = function() {
+            return loadAttachments(dir, message);
+          }
+
+          promiseChain = promiseChain.then(process);
+        }
+      });
+
+      return promiseChain.then(function() {
+        return saveAllMessages(store, messages);
+      });
+    });
+  }
+
+  function importConversations(idb_db, dir) {
+    return getDirContents(dir).then(function(contents) {
+      var transaction = idb_db.transaction('messages', "readwrite");
+      transaction.onerror = function(e) {
+        console.log(
+          'importConversations transaction error:',
+          e && e.stack ? e.stack : e
+        );
+        return reject(e);
+      };
+      var store = transaction.objectStore('messages');
+      var promiseChain = Promise.resolve();
+
+      _.forEach(contents, function(conversationDir) {
+        if (!conversationDir.isDirectory) {
+          return;
+        }
+
+        var process = function() {
+          return importConversation(store, conversationDir);
+        };
+
+        promiseChain = promiseChain.then(process);
+      });
+
+      return promiseChain;
+    });
+  }
+
   Whisper.Backup = {
+    backupMessages: function() {
+      return getDirectory().then(function(directoryEntry) {
+        return openDatabase().then(function(idb_db) {
+          return exportConversations(idb_db, directoryEntry);
+        });
+      }).then(function() {
+        console.log('done backing up all messages and attachments');
+      }, function(error) {
+        console.log(
+          'the whole thing went wrong',
+          error && error.stack ? error.stack : error
+        );
+      });
+    },
+    importMessages: function() {
+      return getDirectory().then(function(directoryEntry) {
+        return openDatabase().then(function(idb_db) {
+          return importConversations(idb_db, directoryEntry);
+        });
+      }).then(function() {
+        console.log('done restoring all messages and attachments');
+      }, function(error) {
+        console.log(
+          'the whole thing went wrong',
+          error && error.stack ? error.stack : error
+        );
+      });
+    },
     createBackupFile: function() {
       return getFileWriter().then(function(fileWriter) {
         return openDatabase().then(function(db) {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38405,17 +38405,12 @@ MessageReceiver.prototype.extend({
         this.incoming = [];
 
         var queueDispatch = function() {
-            // resetting count to zero so everything queued after this starts over again
-            this.count = 0;
-
             return this.addToQueue(function() {
               console.log('drained');
             });
         }.bind(this);
 
-        // We first wait for all recently-received messages (this.incoming) to be queued,
-        //   then we add a task to emit the 'empty' event to the queue, so all message
-        //   processing is complete by the time it runs.
+        // This promise will resolve when there are no more messages to be processed.
         return Promise.all(incoming).then(queueDispatch, queueDispatch);
     },
     updateProgress: function(count) {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38292,7 +38292,7 @@ MessageReceiver.prototype.extend({
     },
     close: function() {
         this.socket.close(3000, 'called close');
-        delete this.listeners;
+        return this.drain();
     },
     onopen: function() {
         console.log('websocket open');
@@ -38399,6 +38399,24 @@ MessageReceiver.prototype.extend({
         //   then we add a task to emit the 'empty' event to the queue, so all message
         //   processing is complete by the time it runs.
         Promise.all(incoming).then(queueDispatch, queueDispatch);
+    },
+    drain: function() {
+        var incoming = this.incoming;
+        this.incoming = [];
+
+        var queueDispatch = function() {
+            // resetting count to zero so everything queued after this starts over again
+            this.count = 0;
+
+            return this.addToQueue(function() {
+              console.log('drained');
+            });
+        }.bind(this);
+
+        // We first wait for all recently-received messages (this.incoming) to be queued,
+        //   then we add a task to emit the 'empty' event to the queue, so all message
+        //   processing is complete by the time it runs.
+        return Promise.all(incoming).then(queueDispatch, queueDispatch);
     },
     updateProgress: function(count) {
         // count by 10s

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -149,7 +149,9 @@
                 var banner = new Whisper.ExpiredAlertBanner().render();
                 banner.$el.prependTo(this.$el);
                 this.$el.addClass('expired');
-            } else if (storage.get('migrationState') > 0) {
+            } else if (Whisper.Migration.inProgress()) {
+                this.appLoadingScreen.remove();
+                this.appLoadingScreen = null;
                 this.showMigrationScreen();
             } else {
                 var migrationBanner = new Whisper.MigrationAlertBanner().render();
@@ -178,7 +180,7 @@
             'click .migrate': 'confirmMigration'
         },
         confirmMigration: function() {
-            this.confirm(i18n('confirmMigration')).then(this.showMigrationScreen.bind(this));
+            this.confirm(i18n('confirmMigration'), i18n('migrate')).then(this.showMigrationScreen.bind(this));
         },
         showMigrationScreen: function() {
             this.migrationScreen = new Whisper.MigrationView();

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -153,7 +153,7 @@
                 this.appLoadingScreen.remove();
                 this.appLoadingScreen = null;
                 this.showMigrationScreen();
-            } else {
+            } else if (storage.get('migrationEnabled')) {
                 var migrationBanner = new Whisper.MigrationAlertBanner().render();
                 migrationBanner.$el.prependTo(this.$el);
             }

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -149,6 +149,11 @@
                 var banner = new Whisper.ExpiredAlertBanner().render();
                 banner.$el.prependTo(this.$el);
                 this.$el.addClass('expired');
+            } else if (storage.get('migrationState') > 0) {
+                this.showMigrationScreen();
+            } else {
+                var migrationBanner = new Whisper.MigrationAlertBanner().render();
+                migrationBanner.$el.prependTo(this.$el);
             }
         },
         render_attributes: {
@@ -169,7 +174,16 @@
             'select .gutter .conversation-list-item': 'openConversation',
             'input input.search': 'filterContacts',
             'click .restart-signal': 'reloadBackgroundPage',
-            'show .lightbox': 'showLightbox'
+            'show .lightbox': 'showLightbox',
+            'click .migrate': 'confirmMigration'
+        },
+        confirmMigration: function() {
+            this.confirm(i18n('confirmMigration')).then(this.showMigrationScreen.bind(this));
+        },
+        showMigrationScreen: function() {
+            this.migrationScreen = new Whisper.MigrationView();
+            this.migrationScreen.render();
+            this.migrationScreen.$el.prependTo(this.el);
         },
         startConnectionListener: function() {
             this.interval = setInterval(function() {
@@ -287,4 +301,14 @@
         }
     });
 
+    Whisper.MigrationAlertBanner = Whisper.View.extend({
+        templateName: 'migration_alert',
+        className: 'expiredAlert clearfix',
+        render_attributes: function() {
+            return {
+                migrationWarning: i18n('migrationWarning'),
+                migrate: i18n('migrate'),
+            };
+        }
+    });
 })();

--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -1,0 +1,69 @@
+;(function () {
+  'use strict';
+  window.Whisper = window.Whisper || {};
+
+  var State = {
+    DISCONNECTING: 1,
+    EXPORTING: 2,
+    COMPLETE: 3
+  };
+
+  Whisper.Migration = {
+    isComplete: function() {
+      return storage.get('migrationState') === State.COMPLETE;
+    },
+    inProgress: function() {
+      return storage.get('migrationState') > 0;
+    },
+    markComplete: function() {
+      storage.put('migrationState', State.COMPLETE);
+    },
+    cancel: function() {
+      storage.remove('migrationState');
+    },
+    beginExport: function() {
+      storage.put('migrationState', State.EXPORTING);
+      return Whisper.Backup.backupToDirectory();
+    },
+    init: function() {
+      storage.put('migrationState', State.DISCONNECTING);
+      Whisper.events.trigger('shutdown');
+    }
+
+  };
+
+  Whisper.MigrationView = Whisper.View.extend({
+    templateName: 'app-migration-screen',
+    className: 'app-loading-screen',
+    initialize: function() {
+      Whisper.events.on('shutdown-complete', this.beginMigration.bind(this));
+
+      Whisper.Migration.init();
+    },
+    render_attributes: function() {
+      switch (storage.get('migrationState')) {
+        case State.COMPLETE:
+          return { message: i18n('exportComplete') };
+        case State.EXPORTING:
+          return { message: i18n('exporting') };
+        case State.DISCONNECTING:
+          return { message: i18n('migrationDisconnecting') };
+      }
+    },
+    beginMigration: function() {
+      Whisper.Migration.beginExport()
+        .then(this.completeMigration.bind(this))
+        .catch(this.cancelMigration.bind(this));
+      this.render();
+    },
+    completeMigration: function() {
+      // disable this client
+      Whisper.Migration.markComplete();
+      this.render();
+    },
+    cancelMigration: function(error) {
+      Whisper.Migration.cancel();
+      this.remove();
+    }
+  });
+}());

--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -84,6 +84,7 @@
           var location = Whisper.Migration.getExportLocation() || i18n('selectedLocation');
           message = i18n('exportComplete', location);
           exportButton = i18n('exportAgain');
+          debugLogButton = null;
           break;
         case State.EXPORTING:
           message = i18n('exporting');

--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -31,7 +31,7 @@
     },
     init: function() {
       storage.put('migrationState', State.DISCONNECTING);
-      Whisper.events.trigger('shutdown');
+      Whisper.events.trigger('start-shutdown');
     },
     everComplete: function() {
       return Boolean(storage.get('migrationEverCompleted'));

--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -141,9 +141,20 @@
       this.render();
     },
     beginMigration: function() {
-      Whisper.Migration.beginExport()
-        .then(this.completeMigration.bind(this))
-        .catch(this.onError.bind(this));
+      // tells MessageReceiver to disconnect and drain its queue, will fire
+      //   'shutdown-complete' event when that is done.
+      Whisper.Migration.init();
+
+      Whisper.events.on('shutdown-complete', function() {
+        Whisper.Migration.beginExport()
+          .then(this.completeMigration.bind(this))
+          .catch(this.onError.bind(this));
+
+        // Rendering because we're now in the 'exporting' state
+        this.render();
+      }.bind(this));
+
+      // Rendering because we're now in the 'disconnected' state
       this.render();
     },
     completeMigration: function(target) {
@@ -162,7 +173,7 @@
     },
     cancelMigration: function() {
       Whisper.Migration.cancel();
-      this.remove();
+      this.render();
     }
   });
 }());

--- a/js/views/whisper_view.js
+++ b/js/views/whisper_view.js
@@ -47,10 +47,11 @@
             this.$el.html(Mustache.render(template, attrs, partials));
             return this;
         },
-        confirm: function(message) {
+        confirm: function(message, okText) {
             return new Promise(function(resolve, reject) {
                 var dialog = new Whisper.ConfirmationDialogView({
                     message: message,
+                    okText: okText,
                     resolve: resolve,
                     reject: reject
                 });

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -154,17 +154,12 @@ MessageReceiver.prototype.extend({
         this.incoming = [];
 
         var queueDispatch = function() {
-            // resetting count to zero so everything queued after this starts over again
-            this.count = 0;
-
             return this.addToQueue(function() {
               console.log('drained');
             });
         }.bind(this);
 
-        // We first wait for all recently-received messages (this.incoming) to be queued,
-        //   then we add a task to emit the 'empty' event to the queue, so all message
-        //   processing is complete by the time it runs.
+        // This promise will resolve when there are no more messages to be processed.
         return Promise.all(incoming).then(queueDispatch, queueDispatch);
     },
     updateProgress: function(count) {

--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
     "permissions": [
       "unlimitedStorage",
       "notifications",
-      {"fileSystem": ["write"]},
+      {"fileSystem": ["write", "directory"]},
       "alarms",
       "fullscreen",
       "audioCapture"

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -524,7 +524,6 @@ input[type=text], input[type=search], textarea {
 .expiredAlert {
   background: #F3F3A7;
   padding: 10px;
-  line-height: 36px;
 
   button {
     float: right;
@@ -536,6 +535,10 @@ input[type=text], input[type=search], textarea {
     padding: 0 20px;
     background: $blue;
     margin-left: 20px;
+  }
+
+  .message {
+    padding: 10px 0;
   }
 }
 
@@ -574,6 +577,9 @@ input[type=text], input[type=search], textarea {
     margin-right: auto;
     width: 78px;
     height: 22px;
+  }
+  .message {
+    max-width: 35em;
   }
 
   .dot {

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -579,6 +579,7 @@ input[type=text], input[type=search], textarea {
     height: 22px;
   }
   .message {
+    -webkit-user-select: text;
     max-width: 35em;
   }
 

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -514,6 +514,7 @@ input[type=text]:active, input[type=text]:focus, input[type=search]:active, inpu
     width: 78px;
     height: 22px; }
   .app-loading-screen .message {
+    -webkit-user-select: text;
     max-width: 35em; }
   .app-loading-screen .dot {
     width: 14px;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -471,8 +471,7 @@ input[type=text]:active, input[type=text]:focus, input[type=search]:active, inpu
 
 .expiredAlert {
   background: #F3F3A7;
-  padding: 10px;
-  line-height: 36px; }
+  padding: 10px; }
   .expiredAlert button {
     float: right;
     border: none;
@@ -483,6 +482,8 @@ input[type=text]:active, input[type=text]:focus, input[type=search]:active, inpu
     padding: 0 20px;
     background: #2090ea;
     margin-left: 20px; }
+  .expiredAlert .message {
+    padding: 10px 0; }
 
 .inbox {
   position: relative; }
@@ -512,6 +513,8 @@ input[type=text]:active, input[type=text]:focus, input[type=search]:active, inpu
     margin-right: auto;
     width: 78px;
     height: 22px; }
+  .app-loading-screen .message {
+    max-width: 35em; }
   .app-loading-screen .dot {
     width: 14px;
     height: 14px;

--- a/test/index.html
+++ b/test/index.html
@@ -626,6 +626,7 @@
   <script type='text/javascript' src='../js/views/scroll_down_button_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/banner_view.js' data-cover></script>
   <script type="text/javascript" src='../js/views/identity_key_send_error_view.js' data-cover></script>
+  <script type='text/javascript' src='../js/views/migration_view.js'></script>
 
   <script type="text/javascript" src="views/whisper_view_test.js"></script>
   <script type="text/javascript" src="views/group_update_view_test.js"></script>
@@ -637,6 +638,7 @@
   <script type="text/javascript" src="views/network_status_view_test.js"></script>
   <script type="text/javascript" src="views/last_seen_indicator_view_test.js"></script>
   <script type='text/javascript' src='views/scroll_down_button_view_test.js'></script>
+
 
   <script type="text/javascript" src="models/conversations_test.js"></script>
   <script type="text/javascript" src="models/messages_test.js"></script>


### PR DESCRIPTION
To support testing, this is all behind a flag for now. To enable it, open up the dev tools to the background window and enter this:

```javascript
window.storage.put('migrationEnabled', true);
window.location.reload();
```
Once you've gone through the export process, the application will be disabled to prevent conflicts between two duplicate devices. If you haven't really migrated to a new install, you can reset your export status like this:

```javascript
window.storage.put('migrationState', 0);
window.storage.put('migrationEverCompleted', false);
window.location.reload();
```

The flow goes like this:
1. Banner at the top telling the user that the build is expired, they should move to the new Signal Desktop. 'Migrate' button which shows a confirmation dialog.
2.  A page that looks like the application loading screen introducing the process. 'Choose directory' button.
3. 'Disconnecting' screen. We'll wait for both the websocket to close and all incoming messages to finish processing. There shouldn't be a big backlog because we've already waited at the loading screen for the pre-launch backlog to be processed. 'Submit debug log' button available in case we have some sort of error that leaves the user here.
4. 'In progress' screen when the real export happens, with the three animated dots. Same 'Submit debug log' button.
5. 'Done' screen. 'Submit debug log' button, as well as 'Export again' button. The directory where we put the files is shown, as is a link to a page with download links for Electron.
6. Error screen. Same as completion screen, but we ask the user to double-check their filesystem (any file, even writable, where we want to write will cause errors) and ask them to submit a debug log.

Once the user has selected a directory in Step 2, we'll always come back to this screen when the application starts. Once they are here, they can't get back without editing the underlying data manually.

Up to that point, the user has one opportunity to cancel out and continue using the app: in Step 1 when they hit that first 'Migrate' button they can cancel out of the resultant confirmation dialog