### PR TITLE
A couple synchronization/logging fixes: disappearing messages, read/delivery receipts

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -381,6 +381,9 @@
         });
 
         receipt.on('remove', ev.confirm);
+
+        // Calling this directly so we can wait for completion
+        return Whisper.ReadReceipts.onReceipt(receipt);
     }
 
     function onVerified(ev) {
@@ -447,6 +450,9 @@
         });
 
         receipt.on('remove', ev.confirm);
+
+        // Calling this directly so we can wait for completion
+        return Whisper.DeliveryReceipts.onReceipt(receipt);
     }
 
     window.owsDesktopApp = {

--- a/js/delivery_receipts.js
+++ b/js/delivery_receipts.js
@@ -6,9 +6,6 @@
     window.Whisper = window.Whisper || {};
 
     Whisper.DeliveryReceipts = new (Backbone.Collection.extend({
-        initialize: function() {
-            this.on('add', this.onReceipt);
-        },
         forMessage: function(conversation, message) {
             var recipients;
             if (conversation.isPrivate()) {
@@ -25,7 +22,7 @@
         },
         onReceipt: function(receipt) {
             var messages  = new Whisper.MessageCollection();
-            messages.fetchSentAt(receipt.get('timestamp')).then(function() {
+            return messages.fetchSentAt(receipt.get('timestamp')).then(function() {
                 if (messages.length === 0) { return; }
                 var message = messages.find(function(message) {
                     return (!message.isIncoming() && receipt.get('source') === message.get('conversationId'));
@@ -44,18 +41,21 @@
             }).then(function(message) {
                 if (message) {
                     var deliveries = message.get('delivered') || 0;
-                    message.save({
-                        delivered: deliveries + 1
-                    }).then(function() {
-                        // notify frontend listeners
-                        var conversation = ConversationController.get(
-                            message.get('conversationId')
-                        );
-                        if (conversation) {
-                            conversation.trigger('delivered', message);
-                        }
+                    return new Promise(function(resolve, reject) {
+                        message.save({
+                            delivered: deliveries + 1
+                        }).then(function() {
+                            // notify frontend listeners
+                            var conversation = ConversationController.get(
+                                message.get('conversationId')
+                            );
+                            if (conversation) {
+                                conversation.trigger('delivered', message);
+                            }
 
-                        this.remove(receipt);
+                            this.remove(receipt);
+                            resolve();
+                        }.bind(this), reject);
                     }.bind(this));
                     // TODO: consider keeping a list of numbers we've
                     // successfully delivered to?

--- a/js/expiring_messages.js
+++ b/js/expiring_messages.js
@@ -11,8 +11,8 @@
         var expired = new Whisper.MessageCollection();
         expired.on('add', function(message) {
             console.log('message', message.get('sent_at'), 'expired');
-            message.destroy();
             message.getConversation().trigger('expired', message);
+            message.destroy();
         });
         expired.on('reset', checkExpiringMessages);
 

--- a/js/expiring_messages.js
+++ b/js/expiring_messages.js
@@ -12,6 +12,9 @@
         expired.on('add', function(message) {
             console.log('message', message.get('sent_at'), 'expired');
             message.getConversation().trigger('expired', message);
+
+            // We delete after the trigger to allow the conversation time to process
+            //   the expiration before the message is removed from the database.
             message.destroy();
         });
         expired.on('reset', checkExpiringMessages);

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38698,8 +38698,7 @@ MessageReceiver.prototype.extend({
         }
     },
     handleNullMessage: function(envelope, nullMessage) {
-        var encodedNumber = envelope.source + '.' + envelope.sourceDevice;
-        console.log('null message from', encodedNumber, envelope.timestamp.toNumber());
+        console.log('null message from', encodedNumber, this.getEnvelopeId(envelope));
         this.removeFromCache(envelope);
     },
     handleSyncMessage: function(envelope, syncMessage) {
@@ -38714,7 +38713,8 @@ MessageReceiver.prototype.extend({
             console.log('sent message to',
                     sentMessage.destination,
                     sentMessage.timestamp.toNumber(),
-                    'from', envelope.source + '.' + envelope.sourceDevice
+                    'from',
+                    this.getEnvelopeId(envelope)
             );
             return this.handleSentMessage(
                     envelope,

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38370,6 +38370,7 @@ MessageReceiver.prototype.extend({
         this.incoming = [];
 
         var dispatchEmpty = function() {
+            console.log('MessageReceiver: emitting \'empty\' event');
             var ev = new Event('empty');
             return this.dispatchAndWait(ev);
         }.bind(this);
@@ -38681,7 +38682,7 @@ MessageReceiver.prototype.extend({
     },
     handleContentMessage: function (envelope) {
         return this.decrypt(envelope, envelope.content).then(function(plaintext) {
-            this.innerHandleContentMessage(envelope, plaintext);
+            return this.innerHandleContentMessage(envelope, plaintext);
         }.bind(this));
     },
     innerHandleContentMessage: function(envelope, plaintext) {

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -815,28 +815,34 @@
 
     notify: function(message) {
         if (!message.isIncoming()) {
-            return;
+            return Promise.resolve();
         }
         if (window.isOpen() && window.isFocused()) {
-            return;
+            return Promise.resolve();
         }
+
         window.drawAttention();
         var sender = ConversationController.create({
             id: message.get('source'), type: 'private'
         });
         var conversationId = this.id;
-        sender.fetch().then(function() {
-            sender.getNotificationIcon().then(function(iconUrl) {
-                console.log('adding notification');
-                Whisper.Notifications.add({
-                    title          : sender.getTitle(),
-                    message        : message.getNotificationText(),
-                    iconUrl        : iconUrl,
-                    imageUrl       : message.getImageUrl(),
-                    conversationId : conversationId,
-                    messageId      : message.id
-                });
-            });
+
+        return new Promise(function(resolve, reject) {
+            sender.fetch().then(function() {
+                sender.getNotificationIcon().then(function(iconUrl) {
+                    console.log('adding notification');
+                    Whisper.Notifications.add({
+                        title          : sender.getTitle(),
+                        message        : message.getNotificationText(),
+                        iconUrl        : iconUrl,
+                        imageUrl       : message.getImageUrl(),
+                        conversationId : conversationId,
+                        messageId      : message.id
+                    });
+
+                    return resolve();
+                }, reject);
+            }, reject);
         });
     },
     hashCode: function() {

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -510,22 +510,22 @@
 
                                         console.log('done with handleDataMessage', message.idForLogging());
 
-                                        if (confirm) {
-                                            confirm();
-                                        }
+                                        confirm();
                                         return resolve();
                                     }
                                     catch (e) {
                                         handleError(e);
                                     }
                                 }, function(error) {
-                                    console.log('handleDataMessage: Message', message.idForLogging(), 'was deleted');
+                                    try {
+                                        console.log('handleDataMessage: Message', message.idForLogging(), 'was deleted');
 
-                                    if (confirm) {
                                         confirm();
+                                        return resolve();
                                     }
-
-                                    return resolve();
+                                    catch (e) {
+                                        handleError(e);
+                                    }
                                 });
                             }, handleError);
                         }, handleError);

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -518,7 +518,15 @@
                                     catch (e) {
                                         handleError(e);
                                     }
-                                }, handleError);
+                                }, function(error) {
+                                    console.log('handleDataMessage: Message', message.idForLogging(), 'was deleted');
+
+                                    if (confirm) {
+                                        confirm();
+                                    }
+
+                                    return resolve();
+                                });
                             }, handleError);
                         }, handleError);
                     });

--- a/js/read_receipts.js
+++ b/js/read_receipts.js
@@ -5,9 +5,6 @@
     'use strict';
     window.Whisper = window.Whisper || {};
     Whisper.ReadReceipts = new (Backbone.Collection.extend({
-        initialize: function() {
-            this.on('add', this.onReceipt);
-        },
         forMessage: function(message) {
             var receipt = this.findWhere({
                 sender: message.get('source'),
@@ -21,13 +18,13 @@
         },
         onReceipt: function(receipt) {
             var messages  = new Whisper.MessageCollection();
-            messages.fetchSentAt(receipt.get('timestamp')).then(function() {
+            return messages.fetchSentAt(receipt.get('timestamp')).then(function() {
                 var message = messages.find(function(message) {
                     return (message.isIncoming() && message.isUnread() &&
                             message.get('source') === receipt.get('sender'));
                 });
                 if (message) {
-                    message.markRead(receipt.get('read_at')).then(function() {
+                    return message.markRead(receipt.get('read_at')).then(function() {
                         this.notifyConversation(message);
                         this.remove(receipt);
                     }.bind(this));

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -456,8 +456,7 @@ MessageReceiver.prototype.extend({
         }
     },
     handleNullMessage: function(envelope, nullMessage) {
-        var encodedNumber = envelope.source + '.' + envelope.sourceDevice;
-        console.log('null message from', encodedNumber, envelope.timestamp.toNumber());
+        console.log('null message from', encodedNumber, this.getEnvelopeId(envelope));
         this.removeFromCache(envelope);
     },
     handleSyncMessage: function(envelope, syncMessage) {
@@ -472,7 +471,8 @@ MessageReceiver.prototype.extend({
             console.log('sent message to',
                     sentMessage.destination,
                     sentMessage.timestamp.toNumber(),
-                    'from', envelope.source + '.' + envelope.sourceDevice
+                    'from',
+                    this.getEnvelopeId(envelope)
             );
             return this.handleSentMessage(
                     envelope,

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -128,6 +128,7 @@ MessageReceiver.prototype.extend({
         this.incoming = [];
 
         var dispatchEmpty = function() {
+            console.log('MessageReceiver: emitting \'empty\' event');
             var ev = new Event('empty');
             return this.dispatchAndWait(ev);
         }.bind(this);
@@ -439,7 +440,7 @@ MessageReceiver.prototype.extend({
     },
     handleContentMessage: function (envelope) {
         return this.decrypt(envelope, envelope.content).then(function(plaintext) {
-            this.innerHandleContentMessage(envelope, plaintext);
+            return this.innerHandleContentMessage(envelope, plaintext);
         }.bind(this));
     },
     innerHandleContentMessage: function(envelope, plaintext) {


### PR DESCRIPTION
Three main changes:
- Delivery and read receipts are now handled in such a way that the overall `MessageReceiver` queue knows how to wait until they are resolved. This means that as we catch up, processing a large number of messages on startup, we'll also be done processing their read receipts by the time the loading screen goes away. This means we won't have ongoing changes to conversation unread counts once the inbox is shown. This also prevents a race condition with disappearing messages, where the message is deleted, but we load and display the conversation before all the deletes propagate, so we show a message that doesn't exist in the database (it went away on restart, but it's the kind of thing that reduces confidence in disappearing messages).
- Promises from `MessageReceiver.handleDataMessage()` weren't properly flowed back, leading to an errant notification at the end of processing a large number of messages on startup of the app.
- If we find that a message has been deleted between the `message.save()` and `message.fetch()` in `handleDataMessage()`, we log it and remove the message from the cache as normal. This can happen sometimes with disappearing messages.

A couple other logging/debuggability and Promise flow fixes.