### PR TITLE
Set messageKeysLimit to unlimited if communicating with our devices

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38576,11 +38576,11 @@ MessageReceiver.prototype.extend({
         var address = new libsignal.SignalProtocolAddress(envelope.source, envelope.sourceDevice);
 
         var ourNumber = textsecure.storage.user.getNumber();
-        var theirNumber = address.toString().split('.')[0];
+        var number = address.toString().split('.')[0];
         var options = {};
 
         // No limit on message keys if we're communicating with our other devices
-        if (ourNumber === theirNumber) {
+        if (ourNumber === number) {
             options.messageKeysLimit = false;
         }
 
@@ -38896,11 +38896,11 @@ MessageReceiver.prototype.extend({
         var address = libsignal.SignalProtocolAddress.fromString(from);
 
         var ourNumber = textsecure.storage.user.getNumber();
-        var theirNumber = address.toString().split('.')[0];
+        var number = address.toString().split('.')[0];
         var options = {};
 
         // No limit on message keys if we're communicating with our other devices
-        if (ourNumber === theirNumber) {
+        if (ourNumber === number) {
             options.messageKeysLimit = false;
         }
 
@@ -39182,11 +39182,11 @@ OutgoingMessage.prototype = {
             var address = new libsignal.SignalProtocolAddress(number, deviceId);
 
             var ourNumber = textsecure.storage.user.getNumber();
-            var theirNumber = address.toString().split('.')[0];
+            var number = address.toString().split('.')[0];
             var options = {};
 
             // No limit on message keys if we're communicating with our other devices
-            if (ourNumber === theirNumber) {
+            if (ourNumber === number) {
                 options.messageKeysLimit = false;
             }
 

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -36169,7 +36169,14 @@ libsignal.SessionBuilder = function (storage, remoteAddress) {
   this.processV3 = builder.processV3.bind(builder);
 };
 
-function SessionCipher(storage, remoteAddress) {
+function SessionCipher(storage, remoteAddress, options) {
+  options = options || {};
+
+  if (typeof options.messageKeysLimit === 'undefined') {
+    options.messageKeysLimit = 1000;
+  }
+
+  this.messageKeysLimit = options.messageKeysLimit;
   this.remoteAddress = remoteAddress;
   this.storage = storage;
 }
@@ -36442,7 +36449,7 @@ SessionCipher.prototype = {
     });
   },
   fillMessageKeys: function(chain, counter) {
-      if (Object.keys(chain.messageKeys).length >= 1000) {
+      if (this.messageKeysLimit && Object.keys(chain.messageKeys).length >= this.messageKeysLimit) {
           console.log("Too many message keys for chain");
           return Promise.resolve(); // Stalker, much?
       }
@@ -36565,8 +36572,8 @@ SessionCipher.prototype = {
   }
 };
 
-libsignal.SessionCipher = function(storage, remoteAddress) {
-    var cipher = new SessionCipher(storage, remoteAddress);
+libsignal.SessionCipher = function(storage, remoteAddress, options) {
+    var cipher = new SessionCipher(storage, remoteAddress, options);
 
     // returns a Promise that resolves to a ciphertext object
     this.encrypt = cipher.encrypt.bind(cipher);
@@ -38567,7 +38574,17 @@ MessageReceiver.prototype.extend({
     decrypt: function(envelope, ciphertext) {
         var promise;
         var address = new libsignal.SignalProtocolAddress(envelope.source, envelope.sourceDevice);
-        var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address);
+
+        var ourNumber = textsecure.storage.user.getNumber();
+        var theirNumber = address.toString().split('.')[0];
+        var options = {};
+
+        // No limit on message keys if we're communicating with our other devices
+        if (ourNumber === theirNumber) {
+            options.messageKeysLimit = false;
+        }
+
+        var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address, options);
         switch(envelope.type) {
             case textsecure.protobuf.Envelope.Type.CIPHERTEXT:
                 console.log('message from', this.getEnvelopeId(envelope));
@@ -38877,7 +38894,17 @@ MessageReceiver.prototype.extend({
     },
     tryMessageAgain: function(from, ciphertext) {
         var address = libsignal.SignalProtocolAddress.fromString(from);
-        var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address);
+
+        var ourNumber = textsecure.storage.user.getNumber();
+        var theirNumber = address.toString().split('.')[0];
+        var options = {};
+
+        // No limit on message keys if we're communicating with our other devices
+        if (ourNumber === theirNumber) {
+            options.messageKeysLimit = false;
+        }
+
+        var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address, options);
         console.log('retrying prekey whisper message');
         return this.decryptPreKeyWhisperMessage(ciphertext, sessionCipher, address).then(function(plaintext) {
             var finalMessage = textsecure.protobuf.DataMessage.decode(plaintext);
@@ -39153,7 +39180,17 @@ OutgoingMessage.prototype = {
 
         return Promise.all(deviceIds.map(function(deviceId) {
             var address = new libsignal.SignalProtocolAddress(number, deviceId);
-            var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address);
+
+            var ourNumber = textsecure.storage.user.getNumber();
+            var theirNumber = address.toString().split('.')[0];
+            var options = {};
+
+            // No limit on message keys if we're communicating with our other devices
+            if (ourNumber === theirNumber) {
+                options.messageKeysLimit = false;
+            }
+
+            var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address, options);
             ciphers[address.getDeviceId()] = sessionCipher;
             return sessionCipher.encrypt(plaintext).then(function(ciphertext) {
                 return {

--- a/libtextsecure/libsignal-protocol.js
+++ b/libtextsecure/libsignal-protocol.js
@@ -36032,7 +36032,14 @@ libsignal.SessionBuilder = function (storage, remoteAddress) {
   this.processV3 = builder.processV3.bind(builder);
 };
 
-function SessionCipher(storage, remoteAddress) {
+function SessionCipher(storage, remoteAddress, options) {
+  options = options || {};
+
+  if (typeof options.messageKeysLimit === 'undefined') {
+    options.messageKeysLimit = 1000;
+  }
+
+  this.messageKeysLimit = options.messageKeysLimit;
   this.remoteAddress = remoteAddress;
   this.storage = storage;
 }
@@ -36305,7 +36312,7 @@ SessionCipher.prototype = {
     });
   },
   fillMessageKeys: function(chain, counter) {
-      if (Object.keys(chain.messageKeys).length >= 1000) {
+      if (this.messageKeysLimit && Object.keys(chain.messageKeys).length >= this.messageKeysLimit) {
           console.log("Too many message keys for chain");
           return Promise.resolve(); // Stalker, much?
       }
@@ -36428,8 +36435,8 @@ SessionCipher.prototype = {
   }
 };
 
-libsignal.SessionCipher = function(storage, remoteAddress) {
-    var cipher = new SessionCipher(storage, remoteAddress);
+libsignal.SessionCipher = function(storage, remoteAddress, options) {
+    var cipher = new SessionCipher(storage, remoteAddress, options);
 
     // returns a Promise that resolves to a ciphertext object
     this.encrypt = cipher.encrypt.bind(cipher);

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -327,11 +327,11 @@ MessageReceiver.prototype.extend({
         var address = new libsignal.SignalProtocolAddress(envelope.source, envelope.sourceDevice);
 
         var ourNumber = textsecure.storage.user.getNumber();
-        var theirNumber = address.toString().split('.')[0];
+        var number = address.toString().split('.')[0];
         var options = {};
 
         // No limit on message keys if we're communicating with our other devices
-        if (ourNumber === theirNumber) {
+        if (ourNumber === number) {
             options.messageKeysLimit = false;
         }
 
@@ -647,11 +647,11 @@ MessageReceiver.prototype.extend({
         var address = libsignal.SignalProtocolAddress.fromString(from);
 
         var ourNumber = textsecure.storage.user.getNumber();
-        var theirNumber = address.toString().split('.')[0];
+        var number = address.toString().split('.')[0];
         var options = {};
 
         // No limit on message keys if we're communicating with our other devices
-        if (ourNumber === theirNumber) {
+        if (ourNumber === number) {
             options.messageKeysLimit = false;
         }
 

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -325,7 +325,17 @@ MessageReceiver.prototype.extend({
     decrypt: function(envelope, ciphertext) {
         var promise;
         var address = new libsignal.SignalProtocolAddress(envelope.source, envelope.sourceDevice);
-        var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address);
+
+        var ourNumber = textsecure.storage.user.getNumber();
+        var theirNumber = address.toString().split('.')[0];
+        var options = {};
+
+        // No limit on message keys if we're communicating with our other devices
+        if (ourNumber === theirNumber) {
+            options.messageKeysLimit = false;
+        }
+
+        var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address, options);
         switch(envelope.type) {
             case textsecure.protobuf.Envelope.Type.CIPHERTEXT:
                 console.log('message from', this.getEnvelopeId(envelope));
@@ -635,7 +645,17 @@ MessageReceiver.prototype.extend({
     },
     tryMessageAgain: function(from, ciphertext) {
         var address = libsignal.SignalProtocolAddress.fromString(from);
-        var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address);
+
+        var ourNumber = textsecure.storage.user.getNumber();
+        var theirNumber = address.toString().split('.')[0];
+        var options = {};
+
+        // No limit on message keys if we're communicating with our other devices
+        if (ourNumber === theirNumber) {
+            options.messageKeysLimit = false;
+        }
+
+        var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address, options);
         console.log('retrying prekey whisper message');
         return this.decryptPreKeyWhisperMessage(ciphertext, sessionCipher, address).then(function(plaintext) {
             var finalMessage = textsecure.protobuf.DataMessage.decode(plaintext);

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -137,7 +137,17 @@ OutgoingMessage.prototype = {
 
         return Promise.all(deviceIds.map(function(deviceId) {
             var address = new libsignal.SignalProtocolAddress(number, deviceId);
-            var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address);
+
+            var ourNumber = textsecure.storage.user.getNumber();
+            var theirNumber = address.toString().split('.')[0];
+            var options = {};
+
+            // No limit on message keys if we're communicating with our other devices
+            if (ourNumber === theirNumber) {
+                options.messageKeysLimit = false;
+            }
+
+            var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address, options);
             ciphers[address.getDeviceId()] = sessionCipher;
             return sessionCipher.encrypt(plaintext).then(function(ciphertext) {
                 return {

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -139,11 +139,11 @@ OutgoingMessage.prototype = {
             var address = new libsignal.SignalProtocolAddress(number, deviceId);
 
             var ourNumber = textsecure.storage.user.getNumber();
-            var theirNumber = address.toString().split('.')[0];
+            var number = address.toString().split('.')[0];
             var options = {};
 
             // No limit on message keys if we're communicating with our other devices
-            if (ourNumber === theirNumber) {
+            if (ourNumber === number) {
                 options.messageKeysLimit = false;
             }
 


### PR DESCRIPTION
~_Note: Dependent on the work in this PR: https://github.com/WhisperSystems/libsignal-protocol-javascript/pull/29. Need to merge that PR and pull `dist/libsignal-protocol.js` from that project into this PR._~

This PR uses the new ability to set the `messageKeysLimit` on `SessionCipher` to remove the limit when communicating with your own devices. We only do this for `SessionCipher` objects which are used for encryption/decryption - there are a number of other instantiations which are used entirely to do session management.

A number of open issues reference this error "Too many message keys for chain": https://github.com/WhisperSystems/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20%22Too%20many%20message%20keys%20for%20chain%22

Hopefully these changes will fix that issue. At the very least it will help us get at the root problem.