### PR TITLE
A number of small fixes

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38667,8 +38667,7 @@ MessageReceiver.prototype.extend({
         }.bind(this));
     },
     handleDataMessage: function(envelope, message) {
-        var encodedNumber = envelope.source + '.' + envelope.sourceDevice;
-        console.log('data message from', encodedNumber, envelope.timestamp.toNumber());
+        console.log('data message from', this.getEnvelopeId(envelope));
         var p = Promise.resolve();
         if ((message.flags & textsecure.protobuf.DataMessage.Flags.END_SESSION) ==
                 textsecure.protobuf.DataMessage.Flags.END_SESSION ) {
@@ -38716,7 +38715,7 @@ MessageReceiver.prototype.extend({
         }
     },
     handleNullMessage: function(envelope, nullMessage) {
-        console.log('null message from', encodedNumber, this.getEnvelopeId(envelope));
+        console.log('null message from', this.getEnvelopeId(envelope));
         this.removeFromCache(envelope);
     },
     handleSyncMessage: function(envelope, syncMessage) {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38283,6 +38283,10 @@ MessageReceiver.prototype.extend({
         });
 
         this.pending = this.queueAllCached();
+
+        // Ensures that an immediate 'empty' event from the websocket will fire only after
+        //   all cached envelopes are processed.
+        this.incoming = [this.pending];
     },
     close: function() {
         this.socket.close(3000, 'called close');

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -39434,7 +39434,7 @@ MessageSender.prototype = {
     },
 
     tryMessageAgain: function(number, encodedMessage, timestamp) {
-        var proto = textsecure.protobuf.DataMessage.decode(encodedMessage);
+        var proto = textsecure.protobuf.Content.decode(encodedMessage);
         return this.sendIndividualProto(number, proto, timestamp);
     },
 

--- a/js/views/key_verification_view.js
+++ b/js/views/key_verification_view.js
@@ -62,7 +62,7 @@
 
             var dialog = new Whisper.ConfirmationDialogView({
                 message: i18n('changedRightAfterVerify', this.model.getTitle(), this.model.getTitle()),
-                resolve: function() {},
+                hideCancel: true
             });
 
             dialog.$el.insertBefore(this.el);

--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -96,7 +96,6 @@
             var dialog = new Whisper.ConfirmationDialogView({
                 message: i18n('deleteWarning'),
                 okText: i18n('delete'),
-                hideCancel: true,
                 resolve: function() {
                     this.model.destroy();
                     this.resetPanel();

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -281,40 +281,38 @@
         renderErrors: function() {
             var errors = this.model.get('errors');
 
+
+            this.$('.error-icon-container').remove();
+            if (this.errorIconView) {
+                this.errorIconView.remove();
+                this.errorIconView = null;
+            }
             if (_.size(errors) > 0) {
                 if (this.model.isIncoming()) {
                     this.$('.content').text(this.model.getDescription()).addClass('error-message');
                 }
                 this.errorIconView = new ErrorIconView({ model: errors[0] });
                 this.errorIconView.render().$el.appendTo(this.$('.bubble'));
-            } else {
-                this.$('.error-icon-container').remove();
-                if (this.errorIconView) {
-                    this.errorIconView.remove();
-                    this.errorIconView = null;
-                }
             }
 
+            this.$('.meta .hasRetry').remove();
+            if (this.networkErrorView) {
+                this.networkErrorView.remove();
+                this.networkErrorView = null;
+            }
             if (this.model.hasNetworkError()) {
                 this.networkErrorView = new NetworkErrorView({model: this.model});
                 this.$('.meta').prepend(this.networkErrorView.render().el);
-            } else {
-                this.$('.meta .hasRetry').remove();
-                if (this.networkErrorView) {
-                    this.networkErrorView.remove();
-                    this.networkErrorView = null;
-                }
             }
 
+            this.$('.meta .some-failed').remove();
+            if (this.someFailedView) {
+                this.someFailedView.remove();
+                this.someFailedView = null;
+            }
             if (this.model.someRecipientsFailed()) {
                 this.someFailedView = new SomeFailedView();
                 this.$('.meta').prepend(this.someFailedView.render().el);
-            } else {
-                this.$('.meta .some-failed').remove();
-                if (this.someFailedView) {
-                    this.someFailedView.remove();
-                    this.someFailedView = null;
-                }
             }
         },
         renderControl: function() {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -418,8 +418,7 @@ MessageReceiver.prototype.extend({
         }.bind(this));
     },
     handleDataMessage: function(envelope, message) {
-        var encodedNumber = envelope.source + '.' + envelope.sourceDevice;
-        console.log('data message from', encodedNumber, envelope.timestamp.toNumber());
+        console.log('data message from', this.getEnvelopeId(envelope));
         var p = Promise.resolve();
         if ((message.flags & textsecure.protobuf.DataMessage.Flags.END_SESSION) ==
                 textsecure.protobuf.DataMessage.Flags.END_SESSION ) {
@@ -467,7 +466,7 @@ MessageReceiver.prototype.extend({
         }
     },
     handleNullMessage: function(envelope, nullMessage) {
-        console.log('null message from', encodedNumber, this.getEnvelopeId(envelope));
+        console.log('null message from', this.getEnvelopeId(envelope));
         this.removeFromCache(envelope);
     },
     handleSyncMessage: function(envelope, syncMessage) {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -34,6 +34,10 @@ MessageReceiver.prototype.extend({
         });
 
         this.pending = this.queueAllCached();
+
+        // Ensures that an immediate 'empty' event from the websocket will fire only after
+        //   all cached envelopes are processed.
+        this.incoming = [this.pending];
     },
     close: function() {
         this.socket.close(3000, 'called close');

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -144,7 +144,7 @@ MessageSender.prototype = {
     },
 
     tryMessageAgain: function(number, encodedMessage, timestamp) {
-        var proto = textsecure.protobuf.DataMessage.decode(encodedMessage);
+        var proto = textsecure.protobuf.Content.decode(encodedMessage);
         return this.sendIndividualProto(number, proto, timestamp);
     },
 

--- a/stylesheets/android-dark.scss
+++ b/stylesheets/android-dark.scss
@@ -7,6 +7,9 @@ $text-dark: #CCCCCC;
 $text-dark_l2: darken($text-dark, 30%);
 
 .android-dark {
+  .app-loading-screen {
+    background-color: $grey-dark;
+  }
   .gutter .content {
     background-color: $grey-dark;
   }

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -2109,6 +2109,8 @@ li.entry .error-icon-container {
 
 .android-dark {
   color: #CCCCCC; }
+  .android-dark .app-loading-screen {
+    background-color: #333333; }
   .android-dark .gutter .content {
     background-color: #333333; }
   .android-dark a {


### PR DESCRIPTION
Went through the new features ready for release to the Chrome Web Store today, and made a number of small fixes:

- _Key verification error popup: Remove cancel, empty resolve()_ - this shows if we find that a contact's verification number has changed when we try to verify the old number. It didn't need anything but an 'ok' button.
- _Make the application loading screen dark in the dark theme_ - It flashes from white to dark gray on startup because the base index.html doesn't know about theming, but after that it's on-theme.
- _Fix 'retry message' scenario: they are now content messages_ - It seems that because of some of the legacy-related changes [like this commit](https://github.com/WhisperSystems/Signal-Desktop/commit/3afe3780638a776e68511acc1510c25d7df27bc9), we need to use a Content message to decode the message that was about to go out the door before we can retry it. This throws errors otherwise.
- _MessageReceiver: Process cached before dismissing loading screen_ - I noticed that sometimes a very quick websocket connect can result in the loading being dismissed before the unprocessed cache has a chance to be queued. This should fix that.
- _MessageReceiver: Fix envelope id logging and make it consistent_ - We were throwing an error on processing null messages, referencing a nonexistent variable. This moves towards more usage of that common logging id generation method.
- _MessageView: Always remove errors on re-render to prevent doubles_ - We were getting duplicates on re-renders of messages with errors. Now we always erase.
- _Restore 'cancel' button on delete message confirmation dialog_ - We were getting nothing but the 'delete' button on the 'are you sure?' confirmation, which was wrong. Seems it was mixed up with the key verification popup which had too many buttons above.
