### PR TITLE
Disappearing messages: Performance and synchronization

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -514,7 +514,7 @@
     },
     "someRecipientsFailed": {
         "message": "Some recipients failed.",
-        "description": "Informational label, for messages where some recipients succeeded, others failed"
+        "description": "When you send to multiple recipients via a group, and the message went to some recipients but not others."
     },
     "showMore": {
         "message": "Details",

--- a/js/expiring_messages.js
+++ b/js/expiring_messages.js
@@ -17,7 +17,7 @@
             //   the expiration before the message is removed from the database.
             message.destroy();
         });
-        expired.on('reset', checkExpiringMessages);
+        expired.on('reset', throttledCheckExpiringMessages);
 
         expired.fetchExpired();
     }
@@ -38,13 +38,14 @@
         });
         expiring.fetchNextExpiring();
     }
+    var throttledCheckExpiringMessages = _.throttle(checkExpiringMessages, 1000);
 
     Whisper.ExpiringMessagesListener = {
         init: function(events) {
             checkExpiringMessages();
-            events.on('timetravel', checkExpiringMessages);
+            events.on('timetravel', throttledCheckExpiringMessages);
         },
-        update: checkExpiringMessages
+        update: throttledCheckExpiringMessages
     };
 
     var TimerOption = Backbone.Model.extend({

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38745,20 +38745,20 @@ MessageReceiver.prototype.extend({
                     sentMessage.expirationStartTimestamp
             );
         } else if (syncMessage.contacts) {
-            this.handleContacts(envelope, syncMessage.contacts);
+            return this.handleContacts(envelope, syncMessage.contacts);
         } else if (syncMessage.groups) {
-            this.handleGroups(envelope, syncMessage.groups);
+            return this.handleGroups(envelope, syncMessage.groups);
         } else if (syncMessage.blocked) {
-            this.handleBlocked(envelope, syncMessage.blocked);
+            return this.handleBlocked(envelope, syncMessage.blocked);
         } else if (syncMessage.request) {
             console.log('Got SyncMessage Request');
-            this.removeFromCache(envelope);
+            return this.removeFromCache(envelope);
         } else if (syncMessage.read && syncMessage.read.length) {
             console.log('read messages',
                     'from', envelope.source + '.' + envelope.sourceDevice);
-            this.handleRead(envelope, syncMessage.read);
+            return this.handleRead(envelope, syncMessage.read);
         } else if (syncMessage.verified) {
-            this.handleVerified(envelope, syncMessage.verified);
+            return this.handleVerified(envelope, syncMessage.verified);
         } else {
             throw new Error('Got empty SyncMessage');
         }

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -496,20 +496,20 @@ MessageReceiver.prototype.extend({
                     sentMessage.expirationStartTimestamp
             );
         } else if (syncMessage.contacts) {
-            this.handleContacts(envelope, syncMessage.contacts);
+            return this.handleContacts(envelope, syncMessage.contacts);
         } else if (syncMessage.groups) {
-            this.handleGroups(envelope, syncMessage.groups);
+            return this.handleGroups(envelope, syncMessage.groups);
         } else if (syncMessage.blocked) {
-            this.handleBlocked(envelope, syncMessage.blocked);
+            return this.handleBlocked(envelope, syncMessage.blocked);
         } else if (syncMessage.request) {
             console.log('Got SyncMessage Request');
-            this.removeFromCache(envelope);
+            return this.removeFromCache(envelope);
         } else if (syncMessage.read && syncMessage.read.length) {
             console.log('read messages',
                     'from', envelope.source + '.' + envelope.sourceDevice);
-            this.handleRead(envelope, syncMessage.read);
+            return this.handleRead(envelope, syncMessage.read);
         } else if (syncMessage.verified) {
-            this.handleVerified(envelope, syncMessage.verified);
+            return this.handleVerified(envelope, syncMessage.verified);
         } else {
             throw new Error('Got empty SyncMessage');
         }


### PR DESCRIPTION
Discovered yesterday a potential reason for high resource usage on startup: many duplicate calls to functions dealing with expired messages, leading to many concurrent DB requests for expiring messages, and therefore many duplicate deletions for the same message. So we `_.throttle()` these functions to once per second.

Also realized that the recent work to handle read receipts and delivery receipts within the overall incoming message queue (while loading screen is showing) wasn't quite working. Turns out that we weren't flowing promises back through `handleSyncMessage()` in `MessageReceiver`.

Finally, a quick change to make it easier to localize a confusing string.