### PR TITLE
Give initIncomingMessage envelope in background.js error handling

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -337,7 +337,7 @@
                 return;
             }
             var envelope = ev.proto;
-            var message = initIncomingMessage(envelope.source, envelope.timestamp.toNumber());
+            var message = initIncomingMessage(envelope);
 
             return message.saveErrors(e).then(function() {
                 var id = message.get('conversationId');


### PR DESCRIPTION
This causes hangs in the incoming processing queue whenever we run into an error on decryption. Bad news!