### PR TITLE
Handle rejections from protocol layer (due to missing records)

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -875,7 +875,12 @@
                 }
 
                 this.showSendConfirmationDialog(e, contacts);
-            }.bind(this));
+            }.bind(this)).catch(function(error) {
+                console.log(
+                    'checkUnverifiedSendMessage error:',
+                    error && error.stack ? error.stack : error
+                );
+            });
         },
 
         checkUntrustedSendMessage: function(e, options) {
@@ -883,7 +888,6 @@
             _.defaults(options, {force: false});
 
             this.model.getUntrusted().then(function(contacts) {
-
                 if (!contacts.length) {
                     return this.sendMessage(e);
                 }
@@ -895,7 +899,12 @@
                 }
 
                 this.showSendConfirmationDialog(e, contacts);
-            }.bind(this));
+            }.bind(this)).catch(function(error) {
+                console.log(
+                    'checkUntrustedSendMessage error:',
+                    error && error.stack ? error.stack : error
+                );
+            });
         },
 
         sendMessage: function(e) {


### PR DESCRIPTION
The `Conversation` model's `isVerified` and `isUntrusted` both went to the protocol layer, but were not prepared for rejected promises resulting from missing records. This prevented send in large groups where there has never been a message exchanged with one of the members.

Originally reported here: https://github.com/WhisperSystems/Signal-Desktop/issues/1349#issuecomment-321497611
