### PR TITLE
Add a max setTimout for expiring messages (over max == immediate)

### DIFF
--- a/js/expiring_messages.js
+++ b/js/expiring_messages.js
@@ -31,7 +31,12 @@
             console.log('next message expires', new Date(expires_at).toISOString());
 
             var wait = expires_at - Date.now();
+
+            // In the past
             if (wait < 0) { wait = 0; }
+
+            // Too far in the future, since it's limited to a 32-bit value
+            if (wait > 2147483647) { wait = 2147483647; }
 
             clearTimeout(timeout);
             timeout = setTimeout(destroyExpiredMessages, wait);


### PR DESCRIPTION
Discovered a [user log where expiring message checks were happening constantly](https://gist.github.com/cd7bf6292b6368b3da0c52309fadeddf). This ensures that a very large timeout doesn't roll over into immediate callbacks.