### PR TITLE
Decrypt any IncomingIdentityKeyError still sticking around

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -288,13 +288,11 @@
     }
 
     function initIncomingMessage(data) {
-        var now = new Date().getTime();
-
         var message = new Whisper.Message({
             source         : data.source,
             sourceDevice   : data.sourceDevice,
             sent_at        : data.timestamp,
-            received_at    : now,
+            received_at    : data.receivedAt || Date.now(),
             conversationId : data.source,
             type           : 'incoming',
             unread         : 1

--- a/libtextsecure/errors.js
+++ b/libtextsecure/errors.js
@@ -30,7 +30,9 @@
     ReplayableError.prototype.constructor = ReplayableError;
 
     ReplayableError.prototype.replay = function() {
-        return registeredFunctions[this.functionCode].apply(window, this.args);
+        var argumentsAsArray = Array.prototype.slice.call(arguments, 0);
+        var args = this.args.concat(argumentsAsArray);
+        return registeredFunctions[this.functionCode].apply(window, args);
     };
 
     function IncomingIdentityKeyError(number, message, key) {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -646,11 +646,36 @@ MessageReceiver.prototype.extend({
             .then(decryptAttachment)
             .then(updateAttachment);
     },
-    tryMessageAgain: function(from, ciphertext) {
+    validateRetryContentMessage: function(content) {
+        // Today this is only called for incoming identity key errors. So it can't be a sync message.
+        if (content.syncMessage) {
+            return false;
+        }
+
+        // We want at least one field set, but not more than one
+        var count = 0;
+        count += content.dataMessage ? 1 : 0;
+        count += content.callMessage ? 1 : 0;
+        count += content.nullMessage ? 1 : 0;
+        if (count !== 1) {
+            return false;
+        }
+
+        // It's most likely that dataMessage will be populated, so we look at it in detail
+        var data = content.dataMessage;
+        if (data && !data.attachments.length && !data.body && !data.expireTimer && !data.flags && !data.group) {
+            return false;
+        }
+
+        return true;
+    },
+    tryMessageAgain: function(from, ciphertext, message) {
         var address = libsignal.SignalProtocolAddress.fromString(from);
+        var sentAt = message.sent_at || Date.now();
 
         var ourNumber = textsecure.storage.user.getNumber();
-        var number = address.toString().split('.')[0];
+        var number = address.getName();
+        var device = address.getDeviceId();
         var options = {};
 
         // No limit on message keys if we're communicating with our other devices
@@ -661,19 +686,42 @@ MessageReceiver.prototype.extend({
         var sessionCipher = new libsignal.SessionCipher(textsecure.storage.protocol, address, options);
         console.log('retrying prekey whisper message');
         return this.decryptPreKeyWhisperMessage(ciphertext, sessionCipher, address).then(function(plaintext) {
-            var finalMessage = textsecure.protobuf.DataMessage.decode(plaintext);
+            var envelope = {
+                source: number,
+                sourceDevice: device,
+                timestamp: {
+                    toNumber: function() {
+                        return sentAt;
+                    }
+                }
+            };
 
-            var p = Promise.resolve();
-            if ((finalMessage.flags & textsecure.protobuf.DataMessage.Flags.END_SESSION)
-                    == textsecure.protobuf.DataMessage.Flags.END_SESSION &&
-                    finalMessage.sync !== null) {
-                    var number = address.getName();
-                    p = this.handleEndSession(number);
+            // Before June, all incoming messages were still DataMessage:
+            //   - iOS: Michael Kirk says that they were sending Legacy messages until June
+            //   - Desktop: https://github.com/WhisperSystems/Signal-Desktop/commit/e8548879db405d9bcd78b82a456ad8d655592c0f
+            //   - Android: https://github.com/WhisperSystems/libsignal-service-java/commit/61a75d023fba950ff9b4c75a249d1a3408e12958
+            //
+            // var d = new Date('2017-06-01T07:00:00.000Z');
+            // d.getTime();
+            var startOfJune = 1496300400000;
+            if (sentAt < startOfJune) {
+                return this.innerHandleLegacyMessage(envelope, plaintext);
             }
 
-            return p.then(function() {
-                return this.processDecrypted(finalMessage);
-            }.bind(this));
+            // This is ugly. But we don't know what kind of proto we need to decode...
+            try {
+                // Simply decoding as a Content message may throw
+                var content = textsecure.protobuf.Content.decode(plaintext);
+
+                // But it might also result in an invalid object, so we try to detect that
+                if (this.validateRetryContentMessage(content)) {
+                    return this.innerHandleContentMessage(envelope, plaintext);
+                }
+            } catch(e) {
+                return this.innerHandleLegacyMessage(envelope, plaintext);
+            }
+
+            return this.innerHandleLegacyMessage(envelope, plaintext);
         }.bind(this));
     },
     handleEndSession: function(number) {


### PR DESCRIPTION
I discovered an issue that Signal Desktop users who had enabled the 'Require approval for safety number changes' option may run into after they've installed `0.42.1`. Here's the scenario:

- Alice, on `0.41.x`, has a conversation with Bob
- Bob reinstalls and sends some messages
- Alice sees some "Safety number changed" errors from Bob because of the safety number change
- Alice upgrades to `0.42.1`, released this week, which always shows incoming messages even with safety number changes
- Bob sends another message
- Alice sees it is immediately decrypted
- Unfortunately, at this point Bob's old messages are still showing as "Error handling incoming message", and there's no way to recover them.

This is because there was no code put in place to 'bring forward' these old messages when we switched methods. This pull request introduces that code - when a conversation is opened, its loaded messages (the most recent 100) are scanned for `IncomingIdentityKeyError` errors along with an identity key which matches what we currently have on file for that user.

For each of these messages, we attempt to replay the message. Once we're done, we mark the conversation as having completed this operation and remove the loading screen. We won't go through this process more than once per conversation. We log but continue past any errors which may arise, since there's no guarantee that the decrypt will succeed.
