### PR TITLE
Copy emoji from components to images directory for asar creation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,9 @@ install:
 
 build_script:
   - yarn run icon-gen
+  - del /f images\emoji\apple
+  - mkdir images\emoji\apple
+  - xcopy components\emojidata\img-apple-64 images\emoji\apple
   - node_modules\.bin\grunt
   - node_modules\.bin\build --em.environment=%SIGNAL_ENV% --publish=never
 


### PR DESCRIPTION
Discovered another symlink causing problems on windows, this time all of our emoji images. When we build the ASAR on windows, those files weren't getting included. This change takes advantage of the fact that the appveyor build steps are unique to windows, and copies all of the emoji images from `components` to `images`.