### PR TITLE
Set receivedAt to post-encrypt time, not actual received time

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -589,7 +589,13 @@
         model      : Message,
         database   : Whisper.Database,
         storeName  : 'messages',
-        comparator : 'received_at',
+        comparator : function(left, right) {
+            if (left.get('received_at') === right.get('received_at')) {
+                return (left.get('sent_at') || 0) - (right.get('sent_at') || 0);
+            }
+
+            return (left.get('received_at') || 0) - (right.get('received_at') || 0);
+        },
         initialize : function(models, options) {
             if (options) {
                 this.conversation = options.conversation;

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -81,7 +81,6 @@ MessageReceiver.prototype.extend({
             }
             return;
         }
-        var receivedAt = Date.now();
 
         this.incoming.push(textsecure.crypto.decryptWebsocketMessage(request.body, this.signalingKey).then(function(plaintext) {
             var envelope = textsecure.protobuf.Envelope.decode(plaintext);
@@ -92,8 +91,6 @@ MessageReceiver.prototype.extend({
             if (this.isBlocked(envelope.source)) {
                 return request.respond(200, 'OK');
             }
-
-            envelope.receivedAt = receivedAt;
 
             return this.addToCache(envelope, plaintext).then(function() {
                 request.respond(200, 'OK');


### PR DESCRIPTION
It turns out setting our `received_at` date immediately after receiving from the websocket is causing problems for situations when the application downloads a lot of content at once. So, we both remove that set of `received_at` and improve our sorting, so we sort by `received_at`, then `sent_at`.