### PR TITLE
Set received based on when we get message from websocket

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -233,14 +233,13 @@
     }
 
     function onSentMessage(ev) {
-        var now = new Date().getTime();
         var data = ev.data;
 
         var message = new Whisper.Message({
             source         : textsecure.storage.user.getNumber(),
             sourceDevice   : data.device,
             sent_at        : data.timestamp,
-            received_at    : now,
+            received_at    : data.receivedAt || Date.now(),
             conversationId : data.destination,
             type           : 'outgoing',
             sent           : true,

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38333,6 +38333,8 @@ MessageReceiver.prototype.extend({
             return;
         }
 
+        var receivedAt = Date.now();
+
         this.incoming.push(textsecure.crypto.decryptWebsocketMessage(request.body, this.signalingKey).then(function(plaintext) {
             var envelope = textsecure.protobuf.Envelope.decode(plaintext);
             // After this point, decoding errors are not the server's
@@ -38342,6 +38344,8 @@ MessageReceiver.prototype.extend({
             if (this.isBlocked(envelope.source)) {
                 return request.respond(200, 'OK');
             }
+
+            envelope.receivedAt = receivedAt;
 
             return this.addToCache(envelope, plaintext).then(function() {
                 request.respond(200, 'OK');
@@ -38663,6 +38667,7 @@ MessageReceiver.prototype.extend({
                     destination              : destination,
                     timestamp                : timestamp.toNumber(),
                     device                   : envelope.sourceDevice,
+                    receivedAt               : envelope.receivedAt,
                     message                  : message
                 };
                 if (expirationStartTimestamp) {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -82,6 +82,8 @@ MessageReceiver.prototype.extend({
             return;
         }
 
+        var receivedAt = Date.now();
+
         this.incoming.push(textsecure.crypto.decryptWebsocketMessage(request.body, this.signalingKey).then(function(plaintext) {
             var envelope = textsecure.protobuf.Envelope.decode(plaintext);
             // After this point, decoding errors are not the server's
@@ -91,6 +93,8 @@ MessageReceiver.prototype.extend({
             if (this.isBlocked(envelope.source)) {
                 return request.respond(200, 'OK');
             }
+
+            envelope.receivedAt = receivedAt;
 
             return this.addToCache(envelope, plaintext).then(function() {
                 request.respond(200, 'OK');
@@ -412,6 +416,7 @@ MessageReceiver.prototype.extend({
                     destination              : destination,
                     timestamp                : timestamp.toNumber(),
                     device                   : envelope.sourceDevice,
+                    receivedAt               : envelope.receivedAt,
                     message                  : message
                 };
                 if (expirationStartTimestamp) {


### PR DESCRIPTION
With [our better sorting (`received_at` then `sent_at`)](https://github.com/WhisperSystems/Signal-Desktop/commit/7e9ed1481b7cf3e7451f135438e0601925923e32#diff-fdb432d7888e10d18d02c7becd34c5e4R592) we can reintroduce this. It also has a fix to ensure that your sent messages from your other devices have the right `received_at`, a key missing element of the previous approach.

Previous take on this: https://github.com/WhisperSystems/Signal-Desktop/commit/620b71a649f020e54d876b40537f45fa264839ec
Emergency fix to prevent out-of-order groups: https://github.com/WhisperSystems/Signal-Desktop/commit/7e9ed1481b7cf3e7451f135438e0601925923e32