### PR TITLE
Don't revoke convo avatar URL on unload - we will need it again

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -256,7 +256,6 @@
                 model.trigger('unload');
             });
             this.model.messageCollection.reset([]);
-            this.model.revokeAvatarUrl();
         },
 
         trim: function() {


### PR DESCRIPTION
We were being too aggressive on unload of a conversation, removing something from memory which was a property of the long-lived `Conversation` model. What we need to get rid of is anything associated with _viewing_ that model.

Fixes #1370 