### PR TITLE
Travis doesn't respect the repo/organization email so turning off

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,5 @@ env:
     - secure: LeXDynRSyeHXR9KdmhYuP/zsc8uFsnYoOWI3fqg8x5SLOilfDyQ766idkT9NTRrdSR8WY7wP4DPs3hrBWGmcVq7BhytI9Q34YSgGS/Sds0jlm5AzSpYfAHpSQ+9ufQXNKN6lgxTkupdsWlc2Em20wUd5EfluDSOoeWVMlqHmKrw=
     - secure: WzXjaiy6BmEyKI3uXeanjbAlmzadlwIWxJbC7Mff2duIl/nsaOTK6ElYu23IfeBCvK1DxXV8DVUfTIZXkeFeqHKPtgq2t3HcS12YiNnb7ToGpgOpzElYY4wAOPxRbqPE/ZcthbSxo1x/thgDeWNWxqK1X4XJ3qEIRoE+tPsGKG8=
 sudo: false
+notifications:
+  email: false


### PR DESCRIPTION
This turns off TravisCI email notifications. Github does a fine job telling us about the things we care about, otherwise we can always go there and see the results.