### PR TITLE
Spell check: support for multiple errors, languages, and platforms

### DIFF
--- a/js/spell_check.js
+++ b/js/spell_check.js
@@ -1,0 +1,134 @@
+(function () {
+  var electron = require('electron');
+  var remote = electron.remote;
+  var app = remote.app;
+  var webFrame = electron.webFrame;
+  var path = require('path');
+
+  var osLocale = require('os-locale');
+  var os = require('os');
+  var semver = require('semver');
+  var spellchecker = require('spellchecker');
+
+  // `remote.require` since `Menu` is a main-process module.
+  var buildEditorContextMenu = remote.require('electron-editor-context-menu');
+
+  var EN_VARIANT = /^en/;
+
+  // Prevent the spellchecker from showing contractions as errors.
+  var ENGLISH_SKIP_WORDS = [
+    'ain',
+    'couldn',
+    'didn',
+    'doesn',
+    'hadn',
+    'hasn',
+    'mightn',
+    'mustn',
+    'needn',
+    'oughtn',
+    'shan',
+    'shouldn',
+    'wasn',
+    'weren',
+    'wouldn'
+  ];
+
+  function setupLinux(locale) {
+    if (process.env.HUNSPELL_DICTIONARIES || locale !== 'en_US') {
+      // apt-get install hunspell-<locale> can be run for easy access to other dictionaries
+      var location = process.env.HUNSPELL_DICTIONARIES || '/usr/share/hunspell';
+
+      console.log('Detected Linux. Setting up spell check with locale', locale, 'and dictionary location', location);
+      spellchecker.setDictionary(locale, location);
+    } else {
+      console.log('Detected Linux. Using default en_US spell check dictionary');
+    }
+  }
+
+  function setupWin7AndEarlier(locale) {
+    if (process.env.HUNSPELL_DICTIONARIES || locale !== 'en_US') {
+      var location = process.env.HUNSPELL_DICTIONARIES;
+
+      console.log('Detected Windows 7 or below. Setting up spell-check with locale', locale, 'and dictionary location', location);
+      spellchecker.setDictionary(locale, location);
+    } else {
+      console.log('Detected Windows 7 or below. Using default en_US spell check dictionary');
+    }
+  }
+
+  var locale = osLocale.sync().replace('-', '_');
+
+  // The LANG environment variable is how node spellchecker finds its default language:
+  //   https://github.com/atom/node-spellchecker/blob/59d2d5eee5785c4b34e9669cd5d987181d17c098/lib/spellchecker.js#L29
+  if (!process.env.LANG) {
+    process.env.LANG = locale;
+  }
+
+  if (process.platform === 'linux') {
+    setupLinux(locale);
+  } else if (process.platform === 'windows' && semver.lt(os.release(), '8.0.0')) {
+    setupWin7AndEarlier(locale);
+  } else {
+    // OSX and Windows 8+ have OS-level spellcheck APIs
+    console.log('Using OS-level spell check API with locale', process.env.LANG);
+  }
+
+  var simpleChecker = window.spellChecker = {
+    spellCheck: function(text) {
+      return !this.isMisspelled(text);
+    },
+    isMisspelled: function(text) {
+      var misspelled = spellchecker.isMisspelled(text);
+
+      // The idea is to make this as fast as possible. For the many, many calls which
+      //   don't result in the red squiggly, we minimize the number of checks.
+      if (!misspelled) {
+        return false;
+      }
+
+      // Only if we think we've found an error do we check the locale and skip list.
+      if (locale.match(EN_VARIANT) && _.contains(ENGLISH_SKIP_WORDS, text)) {
+        return false;
+      }
+
+      return true;
+    },
+    getSuggestions: function(text) {
+      return spellchecker.getCorrectionsForMisspelling(text);
+    },
+    add: function(text) {
+      spellchecker.add(text);
+    }
+  };
+
+  webFrame.setSpellCheckProvider(
+    'en-US',
+    // Not sure what this parameter (`autoCorrectWord`) does: https://github.com/atom/electron/issues/4371
+    // The documentation for `webFrame.setSpellCheckProvider` passes `true` so we do too.
+    true,
+    simpleChecker
+  );
+
+  window.addEventListener('contextmenu', function(e) {
+    // Only show the context menu in text editors.
+    if (!e.target.closest('textarea, input, [contenteditable="true"]')) {
+      return;
+    }
+
+    var selectedText = window.getSelection().toString();
+    var isMisspelled = selectedText && simpleChecker.isMisspelled(selectedText);
+    var spellingSuggestions = isMisspelled && simpleChecker.getSuggestions(selectedText).slice(0, 5);
+    var menu = buildEditorContextMenu({
+      isMisspelled: isMisspelled,
+      spellingSuggestions: spellingSuggestions,
+    });
+
+    // The 'contextmenu' event is emitted after 'selectionchange' has fired but possibly before the
+    // visible selection has changed. Try to wait to show the menu until after that, otherwise the
+    // visible selection will update after the menu dismisses and look weird.
+    setTimeout(function() {
+      menu.popup(remote.getCurrentWindow());
+    }, 30);
+  });
+})();

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
       "images/**",
       "fonts/*",
       "node_modules/**",
+      "!node_modules/spellchecker/vendor/hunspell/**/*",
       "!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme,test,__tests__,tests,powered-test,example,examples,*.d.ts}",
       "!**/node_modules/.bin",
       "!**/node_modules/*/build/**",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "electron-config": "^1.0.0",
     "electron-editor-context-menu": "^1.1.1",
     "electron-updater": "^2.1.2",
+    "os-locale": "^2.1.0",
     "semver": "^5.4.1",
     "spellchecker": "^3.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
       "images/**",
       "fonts/*",
       "node_modules/**",
-      "!node_modules/spellchecker/vendor/hunspell/**/*",
       "!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme,test,__tests__,tests,powered-test,example,examples,*.d.ts}",
       "!**/node_modules/.bin",
       "!**/node_modules/*/build/**",
@@ -130,7 +129,8 @@
     "config": "^1.25.1",
     "electron-config": "^1.0.0",
     "electron-editor-context-menu": "^1.1.1",
-    "electron-spell-check-provider": "^1.1.0",
-    "electron-updater": "^2.1.2"
+    "electron-updater": "^2.1.2",
+    "semver": "^5.4.1",
+    "spellchecker": "^3.4.1"
   }
 }

--- a/preload.js
+++ b/preload.js
@@ -2,7 +2,7 @@
   'use strict';
 
   console.log('preload');
-  const electron = require('electron')
+  const electron = require('electron');
 
   window.PROTO_ROOT = 'protos';
   window.config = require('url').parse(window.location.toString(), true).query;
@@ -28,68 +28,10 @@
   ipc.on('debug-log', function() {
     Whisper.events.trigger('showDebugLog');
   });
-  /**
-  * Enables spell-checking and the right-click context menu in text editors.
-  * Electron (`webFrame.setSpellCheckProvider`) only underlines misspelled words;
-  * we must manage the menu ourselves.
-  *
-  * Run this in the renderer process.
-  */
-  var remote = electron.remote;
-  var webFrame = electron.webFrame;
-  var SpellCheckProvider = require('electron-spell-check-provider');
-  // `remote.require` since `Menu` is a main-process module.
-  var buildEditorContextMenu = remote.require('electron-editor-context-menu');
 
-  var selection;
-  function resetSelection() {
-    selection = {
-      isMisspelled: false,
-      spellingSuggestions: []
-    };
-  }
-  resetSelection();
+  // We pull these dependencies in now, from here, because they have Node.js dependencies
 
-  window.spellChecker = new SpellCheckProvider(window.config.locale).on('misspelling', function(suggestions) {
-      // Prime the context menu with spelling suggestions _if_ the user has selected text. Electron
-      // may sometimes re-run the spell-check provider for an outdated selection e.g. if the user
-      // right-clicks some misspelled text and then an image.
-      if (window.getSelection().toString()) {
-        selection.isMisspelled = true;
-        // Take the first three suggestions if any.
-        selection.spellingSuggestions = suggestions.slice(0, 3);
-      }
-  });
-
-  // Reset the selection when clicking around, before the spell-checker runs and the context menu shows.
-  window.addEventListener('mousedown', resetSelection);
-
-  // The spell-checker runs when the user clicks on text and before the 'contextmenu' event fires.
-  // Thus, we may retrieve spell-checking suggestions to put in the menu just before it shows.
-
-  webFrame.setSpellCheckProvider(
-    'en-US',
-    // Not sure what this parameter (`autoCorrectWord`) does: https://github.com/atom/electron/issues/4371
-    // The documentation for `webFrame.setSpellCheckProvider` passes `true` so we do too.
-    true,
-    spellChecker
-  );
-
-  window.addEventListener('contextmenu', function(e) {
-    // Only show the context menu in text editors.
-    if (!e.target.closest('textarea, input, [contenteditable="true"]')) return;
-
-    var menu = buildEditorContextMenu(selection);
-
-    // The 'contextmenu' event is emitted after 'selectionchange' has fired but possibly before the
-    // visible selection has changed. Try to wait to show the menu until after that, otherwise the
-    // visible selection will update after the menu dismisses and look weird.
-    setTimeout(function() {
-      menu.popup(remote.getCurrentWindow());
-    }, 30);
-  });
-
-  // we have to pull this in this way because it references node APIs
+  require('./js/spell_check');
   require('./js/backup');
 
 })();

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,6 +659,14 @@ cross-spawn@^4.0.0:
     lru-cache "^4.0.1"
     which "^1.2.9"
 
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cryptiles@2.x.x:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
@@ -1192,6 +1200,18 @@ execa@^0.5.0:
   dependencies:
     cross-spawn "^4.0.0"
     get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"
@@ -2698,6 +2718,14 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
+os-locale@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/os-locale/-/os-locale-2.1.0.tgz#42bc2900a6b5b8bd17376c8e882b65afccf24bf2"
+  dependencies:
+    execa "^0.7.0"
+    lcid "^1.0.0"
+    mem "^1.1.0"
+
 os-tmpdir@^1.0.0, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -3318,6 +3346,16 @@ setprototypeof@1.0.2:
 setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@0.3.x:
   version "0.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -88,6 +88,10 @@ ansi-styles@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
+any-promise@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+
 aproba@^1.0.3:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.1.tgz#95d3600f07710aa0e9298c726ad5ecf2eacbabab"
@@ -1081,13 +1085,6 @@ electron-publisher-s3@^19.0.1:
     electron-publish "~19.0.1"
     fs-extra-p "^4.3.0"
     mime "^1.3.6"
-
-electron-spell-check-provider@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/electron-spell-check-provider/-/electron-spell-check-provider-1.1.0.tgz#d1410b6ff2ffcba197db30bf886e37e0e39aec2e"
-  dependencies:
-    spellchecker "^3.2.1"
-    underscore "^1.8.3"
 
 electron-updater@^2.1.2:
   version "2.1.2"
@@ -3259,6 +3256,10 @@ semver-diff@^2.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
+semver@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
+
 semver@~5.0.1:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.0.3.tgz#77466de589cd5d3c95f138aa78bc569a3cb5d27a"
@@ -3405,10 +3406,11 @@ speedometer@~0.1.2:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/speedometer/-/speedometer-0.1.4.tgz#9876dbd2a169d3115402d48e6ea6329c8816a50d"
 
-spellchecker@^3.2.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/spellchecker/-/spellchecker-3.3.1.tgz#fc0ed2b6d7c78daf22c05548211171331420da06"
+spellchecker@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/spellchecker/-/spellchecker-3.4.1.tgz#0caedceff314baef0123051bc597ba28e89c2ac3"
   dependencies:
+    any-promise "^1.3.0"
     nan "^2.0.0"
 
 split@^1.0.0:
@@ -3717,10 +3719,6 @@ underscore.string@~2.3.3:
 underscore.string@~3.2.3:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.2.3.tgz#806992633665d5e5fcb4db1fb3a862eb68e9e6da"
-
-underscore@^1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 underscore@~1.6.0:
   version "1.6.0"


### PR DESCRIPTION
These changes enable a number of scenarios:

- Context menu behavior with multiple spelling errors - previously the context menu would show only the last error in the target text.
- Non-`en-US` support on Linux. You can use `apt-get install hunspell-en-ca` (for example) to install additional hunspell dictionaries (we check `/usr/share/hunspell` for anything other than `en-US`). As long as the `os-locale` module is able to detect that you want the `en-ca` locale, it should just work.
- The `HUNSPELL_DICTIONARIES` environment variable can be set on Linux to override our default search location.

Note: 
 
- The story for Windows 7 and earlier is worse than Linux. You get the `en-US` dictionary by default, but you'll need to do two things to enable other locales: 1) download the appropriate hunspell dictionary for your locale and 2) set the `HUNSPELL_DICTIONARIES` environment variable so we can find it.
- Seems that my previous difficulty getting spell-check to work on my Ubuntu was because it was set up with the default locale, `en-GB`
- I decided against any kind of failover, because we don't want to show `en-US` spell check for someone trying to type in Spanish