### PR TITLE
More logging, small message composition bug-fix

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -230,7 +230,7 @@
         if (this.get('decryptedOldIncomingKeyErrors')) {
             return Promise.resolve();
         }
-        console.log('decryptOldIncomingKeyErrors start');
+        console.log('decryptOldIncomingKeyErrors start for', this.id);
 
         var messages = this.messageCollection.filter(function(message) {
             var errors = message.get('errors');
@@ -245,7 +245,7 @@
         });
 
         var markComplete = function() {
-            console.log('decryptOldIncomingKeyErrors complete');
+            console.log('decryptOldIncomingKeyErrors complete for', this.id);
             return new Promise(function(resolve) {
                 this.save({decryptedOldIncomingKeyErrors: true}).always(resolve);
             }.bind(this));
@@ -559,6 +559,7 @@
     sendMessage: function(body, attachments) {
         this.queueJob(function() {
             var now = Date.now();
+            console.log('Sending message to conversation', this.id, 'with timestamp', now);
             var message = this.messageCollection.add({
                 body           : body,
                 conversationId : this.id,

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -961,6 +961,8 @@
                     console.log('Error pulling attached files before send');
                     this.focusMessageField();
                 }.bind(this));
+            } else {
+                this.focusMessageField();
             }
         },
 

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -419,12 +419,15 @@
         onLoaded: function () {
             var view = this.loadingScreen;
             if (view) {
+                var openDelta = Date.now() - this.openStart;
+                console.log('Conversation', this.model.id, 'took', openDelta, 'milliseconds to load');
                 this.loadingScreen = null;
                 view.remove();
             }
         },
 
         onOpened: function() {
+            this.openStart = Date.now();
             this.lastActivity = Date.now();
 
             this.statusFetch = this.throttledGetProfiles().then(function() {
@@ -866,6 +869,7 @@
 
         checkUnverifiedSendMessage: function(e, options) {
             e.preventDefault();
+            this.sendStart = Date.now();
             this.$messageField.prop('disabled', true);
 
             options = options || {};
@@ -946,6 +950,8 @@
 
             if (message.length > 0 || this.fileInput.hasFiles()) {
                 this.fileInput.getFiles().then(function(attachments) {
+                    var sendDelta = Date.now() - this.sendStart;
+                    console.log('Send pre-checks took', sendDelta, 'milliseconds');
                     this.model.sendMessage(message, attachments);
                     input.val("");
                     this.focusMessageField();


### PR DESCRIPTION
Logging changes for four scenarios:

- How long it takes to get a message through the pre-send checks
- How long it takes to open a conversation for the first time
- The timestamp of any message we send to correlate with logs from other devices
- Add conversation ID to 'decrypt old identity key errors' start/end

Note, there's one more interesting metric that we'll be able to capture with these changes - the space in the log between the 'pre-send checks' log entry and the 'message timestamp' entry. That will tell us how long we are hanging out in the Conversation's queue before moving forward with the message send.

Lastly, we now re-enable the message composition text box if the user presses enter with no text provided. Previously the message would stay disabled until the user clicked with
the mouse.