### PR TITLE
i18n: Failover to english when language is missing a string

### DIFF
--- a/app/auto_update.js
+++ b/app/auto_update.js
@@ -18,8 +18,18 @@ function checkForUpdates() {
   autoUpdater.checkForUpdates();
 }
 
+function i18n(key, messages, failover) {
+  var string = messages[key];
+
+  if (!string) {
+    string = failover[key];
+  }
+
+  return string.message;
+}
+
 var showingDialog = false;
-function showUpdateDialog(messages) {
+function showUpdateDialog(messages, failover) {
   if (showingDialog) {
     return;
   }
@@ -28,12 +38,12 @@ function showUpdateDialog(messages) {
   const options = {
     type: 'info',
     buttons: [
-      messages.autoUpdateRestartButtonLabel.message,
-      messages.autoUpdateLaterButtonLabel.message
+      i18n('autoUpdateRestartButtonLabel', messages, failover),
+      i18n('autoUpdateLaterButtonLabel', messages, failover),
     ],
-    title: messages.autoUpdateNewVersionTitle.message,
-    message: messages.autoUpdateNewVersionMessage.message,
-    detail: messages.autoUpdateNewVersionInstructions.message,
+    title: i18n('autoUpdateNewVersionTitle', messages, failover),
+    message: i18n('autoUpdateNewVersionMessage', messages, failover),
+    detail: i18n('autoUpdateNewVersionInstructions', messages, failover),
     defaultId: RESTART_BUTTON,
     cancelId: LATER_BUTTON
   }
@@ -52,8 +62,8 @@ function onError(error) {
   console.log("Got an error while updating: ", error.stack);
 }
 
-function initialize(messages) {
-  if (!messages) {
+function initialize(messages, failover) {
+  if (!messages || !failover) {
     throw new Error('auto-update initialize needs localized messages');
   }
 
@@ -62,7 +72,7 @@ function initialize(messages) {
   }
 
   autoUpdater.addListener('update-downloaded', function() {
-    showUpdateDialog(messages);
+    showUpdateDialog(messages, failover);
   });
   autoUpdater.addListener('error', onError);
 

--- a/app/locale.js
+++ b/app/locale.js
@@ -25,11 +25,12 @@ function getLocaleMessages(locale) {
 }
 
 function load() {
-  // Load locale - if we can't load messages for the current locale, we
-  // default to 'en'
-  //
-  // possible locales:
-  // https://github.com/electron/electron/blob/master/docs/api/locales.md
+  // We always load 'en' because it will serve as our failover in case the primary
+  //   language is missing a string.
+  const failover = getLocaleMessages('en');
+
+  // Possible locales returned by app.getLocale():
+  //   https://github.com/electron/electron/blob/master/docs/api/locales.md
   let localeName = normalizeLocaleName(app.getLocale());
   let messages;
 
@@ -40,12 +41,13 @@ function load() {
     console.log('Falling back to en locale');
 
     localeName = 'en';
-    messages = getLocaleMessages(localeName);
+    messages = failover;
   }
 
   return {
     name: localeName,
-    messages
+    messages: messages,
+    failover: failover
   };
 }
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -6,13 +6,14 @@
 
     // preload.js loads this, pulling it from main.js (where it was loaded from disk)
     var messages = window.config.localeMessages;
+    var failover = window.config.localeFailover;
     var locale = window.config.locale;
 
-    window.i18n = function (message, substitutions) {
-      if (!messages[message]) {
+    function loadString(message, substitutions, strings) {
+      if (!strings[message]) {
         return;
       }
-      var s = messages[message].message;
+      var s = strings[message].message;
       if (substitutions instanceof Array) {
         substitutions.forEach(function(sub) {
           s = s.replace(/\$.+?\$/, sub);
@@ -21,6 +22,18 @@
         s = s.replace(/\$.+?\$/, substitutions);
       }
       return s;
+    }
+
+    window.i18n = function (message, substitutions) {
+      var result = loadString(message, substitutions, messages);
+
+      if (result) {
+        return result;
+      }
+      console.log('Missing string', message, 'for locale', locale);
+
+      // If a language doesn't include a given string, we use our failover strings
+      return loadString(message, substitutions, failover);
     };
 
     i18n.getLocale = function() {

--- a/js/spell_check.js
+++ b/js/spell_check.js
@@ -57,6 +57,8 @@
     }
   }
 
+  // We load locale this way and not via app.getLocale() because this call returns
+  //   'es_ES' and not just 'es.' And hunspell requires the fully-qualified locale.
   var locale = osLocale.sync().replace('-', '_');
 
   // The LANG environment variable is how node spellchecker finds its default language:

--- a/main.js
+++ b/main.js
@@ -85,7 +85,7 @@ function createWindow () {
 
   // Ingested in preload.js via a sendSync call
   ipc.on('locale-data', function(event, arg) {
-    event.returnValue = locale.messages;
+    event.returnValue = locale;
   });
 
   function prepareURL(pathSegments) {
@@ -165,7 +165,7 @@ app.on('ready', function() {
     locale = loadLocale();
   }
 
-  autoUpdate.initialize(locale.messages);
+  autoUpdate.initialize(locale.messages, locale.failover);
 
   createWindow();
 

--- a/preload.js
+++ b/preload.js
@@ -8,7 +8,9 @@
   window.config = require('url').parse(window.location.toString(), true).query;
 
   const ipc = electron.ipcRenderer
-  window.config.localeMessages = ipc.sendSync('locale-data');
+  const localeData = ipc.sendSync('locale-data');
+  window.config.localeMessages = localeData.messages;
+  window.config.localeFailover = localeData.failover;
 
   window.setBadgeCount = function(count) {
     ipc.send('set-badge-count', count);


### PR DESCRIPTION
I ran Electron in Spanish to test out spell check, and discovered that a bunch of UI was missing strings. A key feature of i18n in Chrome Apps that we hadn't yet reimplemented.

This required quite a bit more change than expected because we have two techniques of dealing with i18n in the app - 1) in Node.js code we access strings directly (`auto_update.js`), and 2) in the main application we use `window.i18n()`
