### PR TITLE
i18n: Failover to english when language is missing a string

### DIFF
--- a/app/locale.js
+++ b/app/locale.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const fs = require('fs');
 const app = require('electron').app;
+const _ = require('lodash');
 
 function normalizeLocaleName(locale) {
   if (/^en-/.test(locale)) {
@@ -25,6 +26,8 @@ function getLocaleMessages(locale) {
 }
 
 function load() {
+  var english = getLocaleMessages('en');
+
   // Load locale - if we can't load messages for the current locale, we
   // default to 'en'
   //
@@ -35,12 +38,15 @@ function load() {
 
   try {
     messages = getLocaleMessages(localeName);
+
+    // We start with english, then overwrite that with anything present in locale
+    messages = _.merge(english, messages);
   } catch (e) {
     console.log('Problem loading messages for locale ', localeName, e.stack);
     console.log('Falling back to en locale');
 
     localeName = 'en';
-    messages = getLocaleMessages(localeName);
+    messages = english;
   }
 
   return {

--- a/js/spell_check.js
+++ b/js/spell_check.js
@@ -57,6 +57,8 @@
     }
   }
 
+  // We load locale this way and not via app.getLocale() because this call returns
+  //   'es_ES' and not just 'es.' And hunspell requires the fully-qualified locale.
   var locale = osLocale.sync().replace('-', '_');
 
   // The LANG environment variable is how node spellchecker finds its default language:

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "electron-config": "^1.0.0",
     "electron-editor-context-menu": "^1.1.1",
     "electron-updater": "^2.1.2",
+    "lodash": "^4.17.4",
     "os-locale": "^2.1.0",
     "semver": "^5.4.1",
     "spellchecker": "^3.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2337,6 +2337,10 @@ lodash@^4.14.0, lodash@^4.3.0, lodash@^4.8.0, lodash@~4.16.4:
   version "4.16.6"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
+lodash@^4.17.4:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
 lodash@~4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.3.0.tgz#efd9c4a6ec53f3b05412429915c3e4824e4d25a4"


### PR DESCRIPTION
I ran Electron in Spanish to test out spell check, and discovered that a bunch of UI was missing strings. A key feature of i18n in Chrome Apps that we hadn't yet reimplemented.

This is a simpler change than https://github.com/WhisperSystems/Signal-Desktop/pull/1379, so it's probably the better solution.