### PR TITLE
Additional logging when we get delivery receipt for unknown message

### DIFF
--- a/js/delivery_receipts.js
+++ b/js/delivery_receipts.js
@@ -59,8 +59,19 @@
                     }.bind(this));
                     // TODO: consider keeping a list of numbers we've
                     // successfully delivered to?
+                } else {
+                    console.log(
+                        'No message for delivery receipt',
+                        receipt.get('source'),
+                        receipt.get('timestamp')
+                    );
                 }
-            }.bind(this));
+            }.bind(this)).catch(function(error) {
+                console.log(
+                    'DeliveryReceipts.onReceipt error:',
+                    error && error.stack ? error.stack : error
+                );
+            });
         }
     }))();
 })();


### PR DESCRIPTION
I've noticed that delivery receipts often hang out in my queue, retried on every restart. Where are they coming from? Why are they hanging around? This logging will help us track down the underlying issue.