### PR TITLE
MessageReceiver cache: Don't convert to string for save

### DIFF
--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -167,12 +167,21 @@ MessageReceiver.prototype.extend({
     },
     queueCached: function(item) {
         try {
-            var envelopePlaintext = this.stringToArrayBuffer(item.envelope);
+            var envelopePlaintext = item.envelope;
+
+            // Up until 0.42.6 we stored envelope and decrypted as strings in IndexedDB,
+            //   so we need to be ready for them.
+            if (typeof envelopePlaintext === 'string') {
+              envelopePlaintext = this.stringToArrayBuffer(envelopePlaintext);
+            }
             var envelope = textsecure.protobuf.Envelope.decode(envelopePlaintext);
 
             var decrypted = item.decrypted;
             if (decrypted) {
-                var payloadPlaintext = this.stringToArrayBuffer(decrypted);
+                var payloadPlaintext = decrypted;
+                if (typeof payloadPlaintext === 'string') {
+                    payloadPlaintext = this.stringToArrayBuffer(payloadPlaintext);
+                }
                 this.queueDecryptedEnvelope(envelope, payloadPlaintext);
             } else {
                 this.queueEnvelope(envelope);
@@ -184,9 +193,6 @@ MessageReceiver.prototype.extend({
     },
     getEnvelopeId: function(envelope) {
         return envelope.source + '.' + envelope.sourceDevice + ' ' + envelope.timestamp.toNumber();
-    },
-    arrayBufferToString: function(arrayBuffer) {
-        return new dcodeIO.ByteBuffer.wrap(arrayBuffer).toString('binary');
     },
     stringToArrayBuffer: function(string) {
         return new dcodeIO.ByteBuffer.wrap(string, 'binary').toArrayBuffer();
@@ -218,10 +224,9 @@ MessageReceiver.prototype.extend({
     addToCache: function(envelope, plaintext) {
         var id = this.getEnvelopeId(envelope);
         console.log('addToCache', id);
-        var string = this.arrayBufferToString(plaintext);
         var data = {
             id: id,
-            envelope: string,
+            envelope: plaintext,
             timestamp: Date.now(),
             attempts: 1
         };
@@ -230,9 +235,8 @@ MessageReceiver.prototype.extend({
     updateCache: function(envelope, plaintext) {
         var id = this.getEnvelopeId(envelope);
         console.log('updateCache', id);
-        var string = this.arrayBufferToString(plaintext);
         var data = {
-            decrypted: string
+            decrypted: plaintext
         };
         return textsecure.storage.unprocessed.update(id, data);
     },


### PR DESCRIPTION
I noticed, looking through the logs [submitted here](https://github.com/WhisperSystems/Signal-Desktop/issues/1364), that a common log entry right before a long delay is `addToCache`. Here's a delay of almost nine seconds:

```
2017-08-21T17:26:35.671Z addToCache +[REDACTED]109.1 1503336393444
2017-08-21T17:26:44.135Z queueing envelope +[REDACTED]109.1 1503336393444
```
 
And what does `addToCache` do? It converts an `ArrayBuffer` to a `string` so that the `envelope` can be stored in the cache. But because IndexedDB supports `ArrayBuffer` natively, this is unnecessary anyway.

This might just speed things up a bit!