### PR TITLE
Import: Wait until all db writes resolve before saying we're done

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -29,7 +29,9 @@
                 console.log('Called storage.put before storage is ready. key:', key);
             }
             var item = items.add({id: key, value: value}, {merge: true});
-            item.save();
+            return new Promise(function(resolve, reject) {
+                item.save().then(resolve, reject);
+            });
         },
 
         get: function(key, defaultValue) {
@@ -44,8 +46,11 @@
             var item = items.get("" + key);
             if (item) {
                 items.remove(item);
-                item.destroy();
+                return new Promise(function(resolve, reject) {
+                    item.destroy().then(resolve, reject);
+                });
             }
+            return Promise.resolve();
         },
 
         onready: function(callback) {


### PR DESCRIPTION
This morning we received a report that Electron import seemed to finish successfully, but restart of the app resulted in a 'import was incomplete' screen: https://github.com/WhisperSystems/Signal-Desktop/issues/1399

This tries to solve that by waiting for all six final database writes before declaring that the import is complete. My theory here is that all the database activity causes `console.log()` statements (which go to the database) to fall behind, which creates a backlog with these six final writes at the end.

And that user, in two different attempts, clicked Restart fast enough that the backlog hadn't been processed.