### PR TITLE
Chrome export fixes: too-long names, redact group ids

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -412,7 +412,11 @@
 
   function getConversationLoggingName(conversation) {
     var name = conversation.active_at || 'never';
-    name += ' (' + conversation.id + ')';
+    if (conversation.type === 'private') {
+      name += ' (' + conversation.id + ')';
+    } else {
+      name += ' ([REDACTED_GROUP]' + conversation.id.slice(-3) + ')';
+    }
     return name;
   }
 

--- a/js/backup.js
+++ b/js/backup.js
@@ -543,7 +543,7 @@
               'Done importing',
               messages.length,
               'messages for conversation',
-              conversationId
+              '[REDACTED]' + conversationId.slice(-3)
             );
             resolve();
           }

--- a/js/backup.js
+++ b/js/backup.js
@@ -403,9 +403,9 @@
   function getConversationDirName(conversation) {
     var name = conversation.active_at || 'never';
     if (conversation.type === 'private') {
-      name += ' (' + (conversation.name || conversation.id) + ')';
+      name += ' (' + (conversation.name || conversation.id).slice(0, 30) + ')';
     } else {
-      name += ' (' + conversation.name + ')';
+      name += ' (' + conversation.name.slice(0, 30) + ')';
     }
     return name;
   }

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -150,8 +150,10 @@
                 banner.$el.prependTo(this.$el);
                 this.$el.addClass('expired');
             } else if (Whisper.Migration.inProgress()) {
-                this.appLoadingScreen.remove();
-                this.appLoadingScreen = null;
+                if (this.appLoadingScreen) {
+                    this.appLoadingScreen.remove();
+                    this.appLoadingScreen = null;
+                }
                 this.showMigrationScreen();
             } else if (storage.get('migrationEnabled')) {
                 var migrationBanner = new Whisper.MigrationAlertBanner().render();


### PR DESCRIPTION
This user reported a failing export: https://github.com/WhisperSystems/Signal-Desktop/issues/1398

Ultimately we discovered that it was due to an extremely long group name. So now we limit group and contact names to 30 characters when we go to the filesystem.

But in the process we realized that the group id is not something we wanted in clear-text. So, as with phone numbers, we only log the last three characters of the group id.