### PR TITLE
Fix handling of sync message with blocked numbers

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38888,7 +38888,7 @@ MessageReceiver.prototype.extend({
             }.bind(this));
         }.bind(this));
     },
-    handleBlocked: function(blocked) {
+    handleBlocked: function(envelope, blocked) {
         textsecure.storage.put('blocked', blocked.numbers);
     },
     isBlocked: function(number) {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -637,7 +637,7 @@ MessageReceiver.prototype.extend({
             }.bind(this));
         }.bind(this));
     },
-    handleBlocked: function(blocked) {
+    handleBlocked: function(envelope, blocked) {
         textsecure.storage.put('blocked', blocked.numbers);
     },
     isBlocked: function(number) {


### PR DESCRIPTION
Previously we were crashing whenever we got a sync message with blocked messages.