### PR TITLE
createTaskWithTimeout: Don't log expiration if task threw

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -40272,7 +40272,13 @@ libsignal.ProvisioningCipher = function() {
                     return reject(error);
                 };
 
-                var promise = task();
+                var promise;
+                try {
+                    promise = task();
+                } catch(error) {
+                    clearTimer();
+                    throw error;
+                }
                 if (!promise || !promise.then) {
                     clearTimer();
                     complete = true;

--- a/libtextsecure/task_with_timeout.js
+++ b/libtextsecure/task_with_timeout.js
@@ -51,7 +51,13 @@
                     return reject(error);
                 };
 
-                var promise = task();
+                var promise;
+                try {
+                    promise = task();
+                } catch(error) {
+                    clearTimer();
+                    throw error;
+                }
                 if (!promise || !promise.then) {
                     clearTimer();
                     complete = true;

--- a/libtextsecure/test/task_with_timeout_test.js
+++ b/libtextsecure/test/task_with_timeout_test.js
@@ -22,13 +22,13 @@ describe('createTaskWithTimeout', function() {
             assert.strictEqual(error, flowedError);
         });
     });
-    it('rejects if promise takes too long', function() {
+    it('rejects if promise takes too long (this one logs error to console)', function() {
         var error = new Error('original');
         var complete = false;
         var task = function() {
             return new Promise(function(resolve) {
                 setTimeout(function() {
-                    completed = true;
+                    complete = true;
                     resolve();
                 }, 3000);
             });
@@ -55,6 +55,20 @@ describe('createTaskWithTimeout', function() {
         var taskWithTimeout = textsecure.createTaskWithTimeout(task);
         return taskWithTimeout().then(function(result) {
             assert.strictEqual(result, 'hi!')
+        });
+    });
+    it('rejects if task throws (and does not log about taking too long)', function() {
+        var error = new Error('Task is throwing!');
+        var task = function() {
+            throw error;
+        };
+        var taskWithTimeout = textsecure.createTaskWithTimeout(task, this.name, {
+            timeout: 10
+        });
+        return taskWithTimeout().then(function(result) {
+            throw new Error('Overall task should reject!')
+        }, function(flowedError) {
+            assert.strictEqual(flowedError, error);
         });
     });
 });


### PR DESCRIPTION
Some log analysis today uncovered a bug in `createTaskWithTImeout` - it was claiming that a task hadn't completed in time when that task threw.

With this fix, we now catch anything thrown by the task, call `clearTimer()`, then re-throw.