### PR TITLE
Automatically focus "send message" when the user is typing

### DIFF
--- a/js/chromium.js
+++ b/js/chromium.js
@@ -11,4 +11,14 @@
             window.addEventListener('beforeunload', callback);
         }
     };
+
+    window.addEventListener('keypress', function(e) {
+        var isInput = ['INPUT', 'TEXTAREA'].includes(document.activeElement.tagName);
+        var isModalOpen = document.querySelector('body > div > .modal');
+        var sendMessageElement = document.querySelector('textarea.send-message');
+
+        if (!isInput && !isModalOpen && sendMessageElement) {
+            sendMessageElement.focus();
+        }
+    });
 }());


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
- [x] I have tested my contribution on these platforms:
 * Ubuntu 17.04, Chromium 60.0.3112.78
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
~Clicking on the _discussion container_ (highlighted in red in the screenshot) now focus on the message box.~
I've added an *event listener* for `keydown` events that focuses the message box if nothing else has focus. Why? Because I don't have always the patience to go to the message box and click there :smiley:.

PS: I have tried to sign the [Contributor Licence Agreement](https://whispersystems.org/cla/) but it doesn't work.
