### PR TITLE
Fix race handling contact sync with verified info

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -202,6 +202,18 @@
                         color: details.color,
                         active_at: conversation.get('active_at') || Date.now(),
                     }).then(resolve, reject);
+                }).then(function() {
+                    if (details.verified) {
+                        var verified = details.verified;
+                        var ev = new Event('verified');
+                        ev.verified = {
+                            state: verified.state,
+                            destination: verified.destination,
+                            identityKey: verified.identityKey.toArrayBuffer(),
+                        };
+                        ev.viaContactSync = true;
+                        return onVerified(ev);
+                    }
                 });
             })
             .then(ev.confirm)

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38784,10 +38784,7 @@ MessageReceiver.prototype.extend({
             throw new Error('Got empty SyncMessage');
         }
     },
-    handleVerified: function(envelope, verified, options) {
-        options = options || {};
-        _.defaults(options, {viaContactSync: false});
-
+    handleVerified: function(envelope, verified) {
         var ev = new Event('verified');
         ev.confirm = this.removeFromCache.bind(this, envelope);
         ev.verified = {
@@ -38795,7 +38792,6 @@ MessageReceiver.prototype.extend({
             destination: verified.destination,
             identityKey: verified.identityKey.toArrayBuffer()
         };
-        ev.viaContactSync = options.viaContactSync;
         return this.dispatchAndWait(ev);
     },
     handleRead: function(envelope, read) {
@@ -38824,14 +38820,6 @@ MessageReceiver.prototype.extend({
                 ev.confirm = this.removeFromCache.bind(this, envelope);
                 ev.contactDetails = contactDetails;
                 results.push(this.dispatchAndWait(ev));
-
-                if (contactDetails.verified) {
-                    results.push(this.handleVerified(
-                        envelope,
-                        contactDetails.verified,
-                        {viaContactSync: true}
-                    ));
-                }
 
                 contactDetails = contactBuffer.next();
             }

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -533,10 +533,7 @@ MessageReceiver.prototype.extend({
             throw new Error('Got empty SyncMessage');
         }
     },
-    handleVerified: function(envelope, verified, options) {
-        options = options || {};
-        _.defaults(options, {viaContactSync: false});
-
+    handleVerified: function(envelope, verified) {
         var ev = new Event('verified');
         ev.confirm = this.removeFromCache.bind(this, envelope);
         ev.verified = {
@@ -544,7 +541,6 @@ MessageReceiver.prototype.extend({
             destination: verified.destination,
             identityKey: verified.identityKey.toArrayBuffer()
         };
-        ev.viaContactSync = options.viaContactSync;
         return this.dispatchAndWait(ev);
     },
     handleRead: function(envelope, read) {
@@ -573,14 +569,6 @@ MessageReceiver.prototype.extend({
                 ev.confirm = this.removeFromCache.bind(this, envelope);
                 ev.contactDetails = contactDetails;
                 results.push(this.dispatchAndWait(ev));
-
-                if (contactDetails.verified) {
-                    results.push(this.handleVerified(
-                        envelope,
-                        contactDetails.verified,
-                        {viaContactSync: true}
-                    ));
-                }
 
                 contactDetails = contactBuffer.next();
             }


### PR DESCRIPTION
When processing a contact sync with embedded identity key verification info, we
were running overlapping async fetch/save operations on the same conversation
model, causing a race that tends to clobber updates to the contact info.

In this change we extend the application-level contact info handler to block on
a subsequent call to the verification handler, which effectively serializes the
fetch/save calls, and relieves the need for the message receiver to trigger a
seperate event concerning the verification info on contact sync messages.

Fixes #1408