### PR TITLE
Fetch conversations once, clean up ConversationController API

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -193,7 +193,7 @@
             return;
         }
 
-        return ConversationController.findOrCreateById(id, 'private')
+        return ConversationController.getOrCreateAndWait(id, 'private')
             .then(function(conversation) {
                 return new Promise(function(resolve, reject) {
                     conversation.save({
@@ -217,7 +217,7 @@
         var details = ev.groupDetails;
         var id = details.id;
 
-        return ConversationController.findOrCreateById(id, 'group').then(function(conversation) {
+        return ConversationController.getOrCreateAndWait(id, 'group').then(function(conversation) {
             var updates = {
                 name: details.name,
                 members: details.members,
@@ -362,7 +362,7 @@
 
             return message.saveErrors(error).then(function() {
                 var id = message.get('conversationId');
-                return ConversationController.findOrCreateById(id, 'private').then(function(conversation) {
+                return ConversationController.getOrCreateAndWait(id, 'private').then(function(conversation) {
                     conversation.set({
                         active_at: Date.now(),
                         unreadCount: conversation.get('unreadCount') + 1
@@ -443,7 +443,7 @@
         console.log('got verified sync for', number, state,
             ev.viaContactSync ? 'via contact sync' : '');
 
-        return ConversationController.findOrCreateById(number, 'private').then(function(contact) {
+        return ConversationController.getOrCreateAndWait(number, 'private').then(function(contact) {
             var options = {
                 viaSyncMessage: true,
                 viaContactSync: ev.viaContactSync,

--- a/js/background.js
+++ b/js/background.js
@@ -246,8 +246,19 @@
                 return;
             }
 
-            return message.handleDataMessage(data.message, ev.confirm, {
-                initialLoadComplete: initialLoadComplete
+            var type, id;
+            if (data.message.group) {
+                type = 'group';
+                id = data.message.group.id;
+            } else {
+                type = 'private';
+                id = data.source;
+            }
+
+            return ConversationController.getOrCreateAndWait(id, type).then(function() {
+                return message.handleDataMessage(data.message, ev.confirm, {
+                    initialLoadComplete: initialLoadComplete
+                });
             });
         });
     }
@@ -274,8 +285,19 @@
                 return;
             }
 
-            return message.handleDataMessage(data.message, ev.confirm, {
-                initialLoadComplete: initialLoadComplete
+            var type, id;
+            if (data.message.group) {
+                type = 'group';
+                id = data.message.group.id;
+            } else {
+                type = 'private';
+                id = data.destination;
+            }
+
+            return ConversationController.getOrCreateAndWait(id, type).then(function() {
+                return message.handleDataMessage(data.message, ev.confirm, {
+                    initialLoadComplete: initialLoadComplete
+                });
             });
         });
     }

--- a/js/keychange_listener.js
+++ b/js/keychange_listener.js
@@ -13,13 +13,13 @@
         }
 
         signalProtocolStore.on('keychange', function(id) {
-          var conversation = ConversationController.add({id: id});
-          conversation.fetch().then(function() {
+          ConversationController.getOrCreateAndWait(id, 'private').then(function(conversation) {
             conversation.addKeyChange(id);
-          });
-          ConversationController.getAllGroupsInvolvingId(id).then(function(groups) {
-            _.forEach(groups, function(group) {
-              group.addKeyChange(id);
+
+            ConversationController.getAllGroupsInvolvingId(id).then(function(groups) {
+              _.forEach(groups, function(group) {
+                group.addKeyChange(id);
+              });
             });
           });
         });

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -147,19 +147,12 @@
             return this.imageUrl;
         },
         getConversation: function() {
-            return ConversationController.add({
-                id: this.get('conversationId')
-            });
+            return ConversationController.get(this.get('conversationId'));
         },
         getExpirationTimerUpdateSource: function() {
             if (this.isExpirationTimerUpdate()) {
               var conversationId = this.get('expirationTimerUpdate').source;
-              var c = ConversationController.get(conversationId);
-              if (!c) {
-                  c = ConversationController.create({id: conversationId, type: 'private'});
-                  c.fetch();
-              }
-              return c;
+              return ConversationController.getOrCreate(conversationId, 'private');
             }
         },
         getContact: function() {
@@ -167,21 +160,12 @@
             if (!this.isIncoming()) {
                 conversationId = textsecure.storage.user.getNumber();
             }
-            var c = ConversationController.get(conversationId);
-            if (!c) {
-                c = ConversationController.create({id: conversationId, type: 'private'});
-                c.fetch();
-            }
-            return c;
+            return ConversationController.getOrCreate(conversationId, 'private');
         },
         getModelForKeyChange: function() {
             var id = this.get('key_changed');
             if (!this.modelForKeyChange) {
-              var c = ConversationController.get(id);
-              if (!c) {
-                  c = ConversationController.create({ id: id, type: 'private' });
-                  c.fetch();
-              }
+              var c = ConversationController.getOrCreate(id, 'private');
               this.modelForKeyChange = c;
             }
             return this.modelForKeyChange;
@@ -189,11 +173,7 @@
         getModelForVerifiedChange: function() {
             var id = this.get('verifiedChanged');
             if (!this.modelForVerifiedChange) {
-              var c = ConversationController.get(id);
-              if (!c) {
-                  c = ConversationController.create({ id: id, type: 'private' });
-                  c.fetch();
-              }
+              var c = ConversationController.getOrCreate(id, 'private');
               this.modelForVerifiedChange = c;
             }
             return this.modelForVerifiedChange;

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -25,9 +25,7 @@
                 openInbox();
                 return;
             }
-            var conversation = ConversationController.create({
-                id: last.get('conversationId')
-            });
+            var conversation = ConversationController.get(last.get('conversationId'));
             openConversation(conversation);
             this.clear();
         },

--- a/js/views/conversation_search_view.js
+++ b/js/views/conversation_search_view.js
@@ -88,7 +88,7 @@
             // Creates a view to display a new contact
             this.new_contact_view = new Whisper.NewContactView({
                 el: this.$new_contact,
-                model: ConversationController.create({
+                model: ConversationController.createTemporary({
                     type: 'private'
                 })
             }).render();
@@ -97,7 +97,7 @@
         createConversation: function() {
             var conversation = this.new_contact_view.model;
             if (this.new_contact_view.model.isValid()) {
-                ConversationController.findOrCreateById(
+                ConversationController.getOrCreateAndWait(
                     this.new_contact_view.model.id,
                     'private'
                 ).then(function(conversation) {

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -261,9 +261,11 @@
         },
         openConversation: function(e, conversation) {
             this.searchView.hideHints();
-            conversation = ConversationController.create(conversation);
-            this.conversation_stack.open(conversation);
-            this.focusConversation();
+            if (conversation) {
+                conversation = ConversationController.get(conversation.id);
+                this.conversation_stack.open(conversation);
+                this.focusConversation();
+            }
         },
         toggleMenu: function() {
             this.$('.global-menu .menu-list').toggle();

--- a/test/keychange_listener_test.js
+++ b/test/keychange_listener_test.js
@@ -26,7 +26,7 @@ describe('KeyChangeListener', function() {
   describe('When we have a conversation with this contact', function() {
     var convo = new Whisper.Conversation({ id: phoneNumberWithKeyChange, type: 'private'});
     before(function() {
-      ConversationController.add(convo);
+      ConversationController.createTemporary(convo);
       return convo.save();
     });
 
@@ -51,7 +51,7 @@ describe('KeyChangeListener', function() {
   describe('When we have a group with this contact', function() {
     var convo = new Whisper.Conversation({ id: 'groupId', type: 'group', members: [phoneNumberWithKeyChange] });
     before(function() {
-      ConversationController.add(convo);
+      ConversationController.createTemporary(convo);
       return convo.save();
     });
     after(function() {

--- a/test/views/message_view_test.js
+++ b/test/views/message_view_test.js
@@ -3,7 +3,7 @@ describe('MessageView', function() {
     return storage.put('number_id', '+18088888888.1');
   });
 
-  var convo = ConversationController.addTemporary({id: 'foo'});
+  var convo = ConversationController.createTemporary({id: 'foo'});
   var message = convo.messageCollection.add({
     conversationId: convo.id,
     body: 'hello world',

--- a/test/views/message_view_test.js
+++ b/test/views/message_view_test.js
@@ -1,11 +1,9 @@
 describe('MessageView', function() {
-  var conversations = new Whisper.ConversationCollection();
-  before(function(done) {
-    conversations.fetch().then(done);
-    storage.put('number_id', '+18088888888.1');
+  before(function() {
+    return storage.put('number_id', '+18088888888.1');
   });
 
-  var convo = conversations.add({id: 'foo'});
+  var convo = ConversationController.addTemporary({id: 'foo'});
   var message = convo.messageCollection.add({
     conversationId: convo.id,
     body: 'hello world',


### PR DESCRIPTION
Race conditions around re-fetching have caused some problems recently, so this removes the need to re-fetch conversations. They are fetched once or saved initially, and that is it. All interaction goes through the `ConversationController`, which is the central source of truth.

We now have two rules for Conversations:

1. If a conversation is in the `ConversationController` it doesn't need to be fetched, but its initial fetch/save might be in progress. You can wait for that fetch/save with `conversation.initialPromise`.
2. If a conversation is not already in the `ConversationController`, it's not yet in the database. It needs to be added to the `ConversationController` and saved to the database.

Note: These invariants will only hold once `ConversationController.updateInbox()` has resolved, with that initial database load.