### PR TITLE
Fetch all conversations on startup of app, not on inbox load

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -72,6 +72,8 @@
 
     storage.fetch();
     storage.onready(function() {
+        ConversationController.load();
+
         window.dispatchEvent(new Event('storage_ready'));
         setUnreadCount(storage.get("unreadCount", 0));
 
@@ -518,7 +520,7 @@
         getAppView: function(destWindow) {
             var self = this;
 
-            return ConversationController.updateInbox().then(function() {
+            return ConversationController.loadPromise().then(function() {
                 try {
                     if (self.inboxView) { self.inboxView.remove(); }
                     self.inboxView = new Whisper.InboxView({

--- a/js/expiring_messages.js
+++ b/js/expiring_messages.js
@@ -11,7 +11,10 @@
         var expired = new Whisper.MessageCollection();
         expired.on('add', function(message) {
             console.log('message', message.get('sent_at'), 'expired');
-            message.getConversation().trigger('expired', message);
+            var conversation = message.getConversation();
+            if (conversation) {
+                conversation.trigger('expired', message);
+            }
 
             // We delete after the trigger to allow the conversation time to process
             //   the expiration before the message is removed from the database.

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -147,7 +147,10 @@
             return this.imageUrl;
         },
         getConversation: function() {
-            return ConversationController.get(this.get('conversationId'));
+            // This needs to be an unsafe call, because this method is called during
+            //   initial module setup. We may be in the middle of the initial fetch to
+            //   the database.
+            return ConversationController.getUnsafe(this.get('conversationId'));
         },
         getExpirationTimerUpdateSource: function() {
             if (this.isExpirationTimerUpdate()) {
@@ -235,7 +238,7 @@
 
         someRecipientsFailed: function() {
             var c = this.getConversation();
-            if (c.isPrivate()) {
+            if (!c || c.isPrivate()) {
                 return false;
             }
 

--- a/test/fixtures_test.js
+++ b/test/fixtures_test.js
@@ -11,7 +11,7 @@ describe("Fixtures", function() {
   });
 
   it('renders', function(done) {
-    ConversationController.updateInbox().then(function() {
+    ConversationController.load().then(function() {
       var view = new Whisper.InboxView({window: window});
       view.onEmpty();
       view.$el.prependTo($('#render-android'));

--- a/test/fixtures_test.js
+++ b/test/fixtures_test.js
@@ -11,7 +11,7 @@ describe("Fixtures", function() {
   });
 
   it('renders', function(done) {
-    ConversationController.load().then(function() {
+    ConversationController.loadPromise().then(function() {
       var view = new Whisper.InboxView({window: window});
       view.onEmpty();
       view.$el.prependTo($('#render-android'));

--- a/test/models/messages_test.js
+++ b/test/models/messages_test.js
@@ -4,11 +4,13 @@
 (function () {
     'use strict';
 
-    function clear(done) {
-        var messages = new Whisper.MessageCollection();
-        return messages.fetch().then(function() {
-            messages.destroyAll();
-            done();
+    function deleteAllMessages() {
+        return new Promise(function(resolve, reject) {
+            var messages = new Whisper.MessageCollection();
+            return messages.fetch().then(function() {
+                messages.destroyAll();
+                resolve();
+            }, reject);
         });
     }
 
@@ -21,9 +23,18 @@
     var attachment = { data: 'datasaurus',
                        contentType: 'plain/text' };
 
+    var source = '+14155555555';
+
     describe('MessageCollection', function() {
-        before(clear);
-        after(clear);
+        before(function() {
+            return Promise.all([
+                deleteAllMessages(),
+                ConversationController.load()
+            ]);
+        });
+        after(function() {
+            return deleteAllMessages();
+        });
 
         it('has no image url', function() {
             var messages = new Whisper.MessageCollection();
@@ -49,7 +60,10 @@
 
         it('gets incoming contact', function() {
             var messages = new Whisper.MessageCollection();
-            var message = messages.add({ type: 'incoming' });
+            var message = messages.add({
+                type: 'incoming',
+                source: source
+            });
             message.getContact();
         });
 


### PR DESCRIPTION
A recent change to fetch conversations less didn't take into account all that can happen in the app without the inbox loaded. Inbox load happens when the window is shown, but messages can come in with the app in the background. In that case, the conversation wouldn't have been loaded from the database, but would be saved to the database with partial data anyway, losing data.

This change fetches all conversations as soon as the the data store is ready for a fetch. It also introduces failsafe throws to ensure that synchronous `ConversationController` accesses don't happen until the initial fetch is complete. A new `getUnsafe()` method was required to account for some of the model setup that happens _during_ that initial conversation fetch.

Fixes #1428