### PR TITLE
MessageView: Handle change of color to null, call getColor()

### DIFF
--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -365,15 +365,18 @@
 
             return this;
         },
-        updateColor: function(model, color) {
+        updateColor: function() {
             var bubble = this.$('.bubble');
-            bubble.removeClass(Whisper.Conversation.COLORS);
+
+            // this.contact is known to be non-null if we're registered for color changes
+            var color = this.contact.getColor();
             if (color) {
+                bubble.removeClass(Whisper.Conversation.COLORS);
                 bubble.addClass(color);
             }
             this.avatarView = new (Whisper.View.extend({
                 templateName: 'avatar',
-                render_attributes: { avatar: model.getAvatar() }
+                render_attributes: { avatar: this.model.getAvatar() }
             }))();
             this.$('.avatar').replaceWith(this.avatarView.render().$('.avatar'));
         },


### PR DESCRIPTION
When we relied on the actual value of the color property to be supplied to the `updateColor()` change event listener, sometimes it would be `null`. Then the conversation bubbles would have no color at all, making the text hard to read.

This happens for iOS users who have been communicating with a phone number, then add a contact for that user. (Because iOS does not supply a color in its contact sync data)