### PR TITLE
Export: Limit path lengths of attachments, add tests

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -267,8 +267,35 @@
     });
   }
 
+  function trimFileName(filename) {
+    var components = filename.split('.');
+    if (components.length <= 1) {
+      return filename.slice(0, 30);
+    }
+
+    var extension = components[components.length - 1];
+    var name = components.slice(0, components.length - 1);
+    if (extension.length > 5) {
+      return filename.slice(0, 30);
+    }
+
+    return name.join('.').slice(0, 24) + '.' + extension;
+  }
+
+
   function getAttachmentFileName(attachment) {
-    return attachment.fileName || (attachment.id + '.' + attachment.contentType.split('/')[1]);
+    if (attachment.fileName) {
+      return trimFileName(attachment.fileName);
+    }
+
+    var name = attachment.id;
+
+    if (attachment.contentType) {
+      var components = attachment.contentType.split('/');
+      name += '.' + (components.length > 1 ? components[1] : attachment.contentType);
+    }
+
+    return name;
   }
 
   function readAttachment(parent, message, attachment) {
@@ -407,11 +434,10 @@
   function getConversationDirName(conversation) {
     var name = conversation.active_at || 'never';
     if (conversation.name) {
-      return ' (' + conversation.name.slice(0, 30) + ' ' + conversation.id + ')';
+      return name + ' (' + conversation.name.slice(0, 30) + ' ' + conversation.id + ')';
     } else {
-      return ' (' + conversation.id + ')';
+      return name + ' (' + conversation.id + ')';
     }
-    return name;
   }
 
   // Goals for logging names:
@@ -673,7 +699,13 @@
         );
         return Promise.reject(error);
       });
-    }
+    },
+    // for testing
+    sanitizeFileName: sanitizeFileName,
+    trimFileName: trimFileName,
+    getAttachmentFileName: getAttachmentFileName,
+    getConversationDirName: getConversationDirName,
+    getConversationLoggingName: getConversationLoggingName
   };
 
 }());

--- a/test/backup_test.js
+++ b/test/backup_test.js
@@ -1,0 +1,134 @@
+'use strict';
+
+describe('Backup', function() {
+  describe('sanitizeFileName', function() {
+    it('leaves a basic string alone', function() {
+      var initial = 'Hello, how are you #5 (\'fine\' + great).jpg';
+      var expected = initial;
+      assert.strictEqual(Whisper.Backup.sanitizeFileName(initial), expected);
+    });
+
+    it('replaces all unknown characters', function() {
+      var initial = '!@$%^&*=';
+      var expected = '________';
+      assert.strictEqual(Whisper.Backup.sanitizeFileName(initial), expected);
+    });
+  });
+
+  describe('trimFileName', function() {
+    it('handles a file with no extension', function() {
+      var initial = '0123456789012345678901234567890123456789';
+      var expected = '012345678901234567890123456789';
+      assert.strictEqual(Whisper.Backup.trimFileName(initial), expected);
+    });
+
+    it('handles a file with a long extension', function() {
+      var initial = '0123456789012345678901234567890123456789.01234567890123456789';
+      var expected = '012345678901234567890123456789';
+      assert.strictEqual(Whisper.Backup.trimFileName(initial), expected);
+    });
+
+    it('handles a file with a normal extension', function() {
+      var initial = '01234567890123456789012345678901234567890123456789.jpg';
+      var expected = '012345678901234567890123.jpg';
+      assert.strictEqual(Whisper.Backup.trimFileName(initial), expected);
+    });
+  });
+
+  describe('getAttachmentFileName', function() {
+    it('uses original filename if attachment has one', function() {
+      var attachment = {
+        fileName: 'blah.jpg'
+      };
+      var expected = 'blah.jpg';
+      assert.strictEqual(Whisper.Backup.getAttachmentFileName(attachment), expected);
+    });
+
+    it('uses attachment id if no filename', function() {
+      var attachment = {
+        id: '123'
+      };
+      var expected = '123';
+      assert.strictEqual(Whisper.Backup.getAttachmentFileName(attachment), expected);
+    });
+
+    it('uses filename and contentType if available', function() {
+      var attachment = {
+        id: '123',
+        contentType: 'image/jpeg'
+      };
+      var expected = '123.jpeg';
+      assert.strictEqual(Whisper.Backup.getAttachmentFileName(attachment), expected);
+    });
+
+    it('handles strange contentType', function() {
+      var attachment = {
+        id: '123',
+        contentType: 'something'
+      };
+      var expected = '123.something';
+      assert.strictEqual(Whisper.Backup.getAttachmentFileName(attachment), expected);
+    });
+  });
+
+  describe('getConversationDirName', function() {
+    it('uses name if available', function() {
+      var conversation = {
+        active_at: 123,
+        name: '0123456789012345678901234567890123456789',
+        id: 'id'
+      };
+      var expected = '123 (012345678901234567890123456789 id)';
+      assert.strictEqual(Whisper.Backup.getConversationDirName(conversation), expected);
+    });
+
+    it('uses just id if name is not available', function() {
+      var conversation = {
+        active_at: 123,
+        id: 'id'
+      };
+      var expected = '123 (id)';
+      assert.strictEqual(Whisper.Backup.getConversationDirName(conversation), expected);
+    });
+
+    it('uses never for missing active_at', function() {
+      var conversation = {
+        name: 'name',
+        id: 'id'
+      };
+      var expected = 'never (name id)';
+      assert.strictEqual(Whisper.Backup.getConversationDirName(conversation), expected);
+    });
+  });
+
+  describe('getConversationLoggingName', function() {
+    it('uses plain id if conversation is private', function() {
+      var conversation = {
+        active_at: 123,
+        id: 'id',
+        type: 'private'
+      };
+      var expected = '123 (id)';
+      assert.strictEqual(Whisper.Backup.getConversationLoggingName(conversation), expected);
+    });
+
+    it('uses just id if name is not available', function() {
+      var conversation = {
+        active_at: 123,
+        id: 'groupId',
+        type: 'group'
+      };
+      var expected = '123 ([REDACTED_GROUP]pId)';
+      assert.strictEqual(Whisper.Backup.getConversationLoggingName(conversation), expected);
+    });
+
+    it('uses never for missing active_at', function() {
+      var conversation = {
+        id: 'id',
+        type: 'private'
+      };
+      var expected = 'never (id)';
+      assert.strictEqual(Whisper.Backup.getConversationLoggingName(conversation), expected);
+    });
+  });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -580,6 +580,7 @@
   <script type="text/javascript" src="../js/storage.js" data-cover></script>
   <script type="text/javascript" src="../js/signal_protocol_store.js" data-cover></script>
   <script type="text/javascript" src="../js/libtextsecure.js" data-cover></script>
+  <script type="text/javascript" src="../js/backup.js" data-cover></script>
 
   <script type="text/javascript" src="../js/libphonenumber-util.js"></script>
   <script type="text/javascript" src="../js/models/messages.js" data-cover></script>
@@ -648,6 +649,7 @@
   <script type="text/javascript" src="keychange_listener_test.js"></script>
   <script type="text/javascript" src="emoji_util_test.js"></script>
   <script type="text/javascript" src="reliable_trigger_test.js"></script>
+  <script type="text/javascript" src="backup_test.js"></script>
 
   <script type="text/javascript" src="fixtures.js"></script>
   <script type="text/javascript" src="fixtures_test.js"></script>

--- a/test/views/message_view_test.js
+++ b/test/views/message_view_test.js
@@ -1,15 +1,17 @@
 describe('MessageView', function() {
-  before(function() {
-    return storage.put('number_id', '+18088888888.1');
-  });
+  var convo, message;
 
-  var convo = ConversationController.createTemporary({id: 'foo'});
-  var message = convo.messageCollection.add({
-    conversationId: convo.id,
-    body: 'hello world',
-    type: 'outgoing',
-    source: '+14158675309',
-    received_at: Date.now()
+  before(function() {
+    convo = ConversationController.createTemporary({id: 'foo'});
+    message = convo.messageCollection.add({
+      conversationId: convo.id,
+      body: 'hello world',
+      type: 'outgoing',
+      source: '+14158675309',
+      received_at: Date.now()
+    });
+
+    return storage.put('number_id', '+18088888888.1');
   });
 
   it('should display the message text', function() {


### PR DESCRIPTION
Three changes:
 1. Limit attachment names to 30 chars
 2. Reintroduce last contact date in conversation dir name
 3. Add tests for most `backup.js` helper functions

This should make it more likely that we'll succeed on Windows, which has a path length limit.

Bonus: Fix `MessageView` tests, which were failing during code coverage runs

_Note: This is an export format breaking change, since it changes how attachment filenames are generated. Any attachment filename longer than 30 characters will cause a failure on import if using an older build that doesn't trim filenames._