### PR TITLE
Fix loading screen hang when unlinked, fix error dialog on startup

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -157,7 +157,7 @@
     function connect(firstRun) {
         window.removeEventListener('online', connect);
 
-        if (!Whisper.Registration.isDone()) { return; }
+        if (!Whisper.Registration.everDone()) { return; }
         if (Whisper.Import.isIncomplete()) { return; }
 
         if (messageReceiver) { messageReceiver.close(); }

--- a/main.js
+++ b/main.js
@@ -201,10 +201,10 @@ app.on('window-all-closed', function () {
 app.on('activate', function () {
   // On OS X it's common to re-create a window in the app when the
   // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) {
-    createWindow();
-  } else {
+  if (mainWindow) {
     mainWindow.show();
+  } else {
+    createWindow();
   }
 })
 


### PR DESCRIPTION
We got a report that, when unlinked, Electron shows the loading screen forever. This is because we don't get the 'unauthorized' event, because we never even try to connect to the websocket. This change attempts to connect to the websocket if `Registration.everDone()`, instead of just `.isDone()`.

Also, we got a report of this, an error dialog on startup, now fixed:

<img width="624" alt="screen_shot_2017-09-05_at_9 28 16_am" src="https://user-images.githubusercontent.com/443005/30131029-1931ff34-9300-11e7-9359-fb3aa126aece.png">

