### PR TITLE
scroll only when needed

### DIFF
--- a/js/views/message_list_view.js
+++ b/js/views/message_list_view.js
@@ -48,7 +48,7 @@
             this.$el.scrollTop(this.scrollPosition - this.$el.outerHeight());
         },
         scrollToBottomIfNeeded: function() {
-            if (this.atBottom()) {
+            if (!this.atBottom()) {
                 this.scrollToBottom();
             }
         },


### PR DESCRIPTION
I believe this is typo.

I peaked at the profiler and found this:

## before

<img width="698" alt="before-scroll-only-when-needed" src="https://user-images.githubusercontent.com/217057/30139954-1cfc6d54-933f-11e7-9ae7-89a35eb0badd.png">

## after

<img width="682" alt="after-scroll-only-when-needed" src="https://user-images.githubusercontent.com/217057/30139956-20fa8030-933f-11e7-8710-7bab3c79a0f2.png">

This change doesn't actually seem to improve the situation much. It mostly just shuffles time spent from `scrollToBottomIfNeeded` ->`measureScrollPosition`.

Throttling `measureScrollPosition` does effectively solve this particular hotspot, but I'm not sure it guarantees proper behavior - e.g. with respect to the scroll indicator. Maybe those more in the know have an idea for a next step?