### PR TITLE
Scroll to bottom when adding a new message (on send, receive, etc.)

### DIFF
--- a/js/views/message_list_view.js
+++ b/js/views/message_list_view.js
@@ -48,7 +48,12 @@
             this.$el.scrollTop(this.scrollPosition - this.$el.outerHeight());
         },
         scrollToBottomIfNeeded: function() {
-            if (!this.atBottom()) {
+            // This is counter-intuitive. Our current bottomOffset is reflective of what
+            //   we last measured, not necessarily the current state. And this is called
+            //   after we just made a change to the DOM: inserting a message, or an image
+            //   finished loading. So if we were near the bottom before, we _need_ to be
+            //   at the bottom again. So we scroll to the bottom.
+            if (this.atBottom()) {
                 this.scrollToBottom();
             }
         },


### PR DESCRIPTION
It turns out that this pull request did actually break expected behavior: https://github.com/WhisperSystems/Signal-Desktop/pull/1441

When you send a message, for example, it doesn't look like it sent because we don't scroll the window down. With this small change, we scroll down once more.

It's true, though, the code is very uninituitive. The name of the method is 'IfNeeded' and then inside the method we say that we should scroll to bottom if we're at the bottom already. So, I added a comment to try to make this easier to understand as you read it.