### PR TITLE
	Don't show notifications for verified state change with yourself

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -429,6 +429,7 @@
         _.defaults(options, {local: true});
 
         if (this.isMe()) {
+            console.log('refusing to add verified change advisory for our own number');
             return;
         }
 

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -428,6 +428,10 @@
         options = options || {};
         _.defaults(options, {local: true});
 
+        if (this.isMe()) {
+            return;
+        }
+
         var lastMessage = this.get('timestamp') || Date.now();
 
         console.log('adding verified change advisory for', this.id, id, lastMessage);


### PR DESCRIPTION
Though it is possible to verify yourself in Android and iOS, it's confusing to users and it really doesn't mean anything anyway.

Fixes https://github.com/WhisperSystems/Signal-Desktop/issues/1451