### PR TITLE
focus() visible window on show-window instead of show()

### DIFF
--- a/main.js
+++ b/main.js
@@ -146,7 +146,15 @@ function createWindow () {
   });
 
   ipc.on('show-window', function() {
-    mainWindow.show();
+    // Using focus() instead of show() seems to be important on Windows when our window
+    //   has been docked using Aero Snap/Snap Assist. A full .show() call here will cause
+    //   the window to reposition:
+    //   https://github.com/WhisperSystems/Signal-Desktop/issues/1429
+    if (mainWindow.isVisible()) {
+      mainWindow.focus();
+    } else {
+      mainWindow.show();
+    }
   });
 }
 


### PR DESCRIPTION
When clicking on a notification in Windows when a window had been stuck to one side of the screen using Snap, the window would be repositioned. We now use a less-aggressive technique for calling attention to ourselves.

Fixes #1429 (thanks for the correction, Lilia)