### PR TITLE
Log entry max to 2k, remove logging in hot codepaths

### DIFF
--- a/js/debugLog.js
+++ b/js/debugLog.js
@@ -40,7 +40,7 @@
         }
     });
 
-    var MAX_MESSAGES = 5000;
+    var MAX_MESSAGES = 2000;
     var PHONE_REGEX = /\+\d{7,12}(\d{3})/g;
     var log = new DebugLog();
     if (window.console) {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38487,7 +38487,6 @@ MessageReceiver.prototype.extend({
     },
     addToCache: function(envelope, plaintext) {
         var id = this.getEnvelopeId(envelope);
-        console.log('addToCache', id);
         var data = {
             id: id,
             envelope: plaintext,
@@ -38498,7 +38497,6 @@ MessageReceiver.prototype.extend({
     },
     updateCache: function(envelope, plaintext) {
         var id = this.getEnvelopeId(envelope);
-        console.log('updateCache', id);
         var data = {
             decrypted: plaintext
         };
@@ -38506,7 +38504,6 @@ MessageReceiver.prototype.extend({
     },
     removeFromCache: function(envelope) {
         var id = this.getEnvelopeId(envelope);
-        console.log('removeFromCache', id);
         return textsecure.storage.unprocessed.remove(id);
     },
     queueDecryptedEnvelope: function(envelope, plaintext) {

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -343,13 +343,10 @@
             if (dataMessage.group) {
                 conversationId = dataMessage.group.id;
             }
-            console.log('queuing handleDataMessage', message.idForLogging());
 
             var conversation = ConversationController.get(conversationId);
             return conversation.queueJob(function() {
                 return new Promise(function(resolve) {
-                    console.log('starting handleDataMessage', message.idForLogging());
-
                     var now = new Date().getTime();
                     var attributes = { type: 'private' };
                     if (dataMessage.group) {
@@ -459,8 +456,6 @@
                         });
                     }
 
-                    console.log('beginning saves in handleDataMessage', message.idForLogging());
-
                     var handleError = function(error) {
                         error = error && error.stack ? error.stack : error;
                         console.log('handleDataMessage', message.idForLogging(), 'error:', error);
@@ -491,8 +486,6 @@
                                     if (message.get('unread') && options.initialLoadComplete) {
                                         conversation.notify(message);
                                     }
-
-                                    console.log('done with handleDataMessage', message.idForLogging());
 
                                     confirm();
                                     return resolve();

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -236,7 +236,6 @@ MessageReceiver.prototype.extend({
     },
     addToCache: function(envelope, plaintext) {
         var id = this.getEnvelopeId(envelope);
-        console.log('addToCache', id);
         var data = {
             id: id,
             envelope: plaintext,
@@ -247,7 +246,6 @@ MessageReceiver.prototype.extend({
     },
     updateCache: function(envelope, plaintext) {
         var id = this.getEnvelopeId(envelope);
-        console.log('updateCache', id);
         var data = {
             decrypted: plaintext
         };
@@ -255,7 +253,6 @@ MessageReceiver.prototype.extend({
     },
     removeFromCache: function(envelope) {
         var id = this.getEnvelopeId(envelope);
-        console.log('removeFromCache', id);
         return textsecure.storage.unprocessed.remove(id);
     },
     queueDecryptedEnvelope: function(envelope, plaintext) {


### PR DESCRIPTION
On a recent trip through a CPU profile taken while Signal Desktop churned through a large backlog of messages (inspired by #1457), it was clear that console.log was a major source of time spent, primarily the sort operation required after every new entry is added to the Backbone collection. So, three different techniques to combat this:

1. Reduce the maximum number of entries in the collection from 5k to 2k
2. No more logging of add/update/remove queue in MessageReceiver
3. No more log entries in Message.handleDataMessage main codepath