### PR TITLE
Trigger empty event on keepalive timeout

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38392,6 +38392,9 @@ MessageReceiver.prototype.extend({
         if (ev.code === 3000) {
             return;
         }
+        if (ev.code === 3001) {
+            this.onEmpty();
+        }
         // possible 403 or network issue. Make an request to confirm
         return this.server.getDevices(this.number)
             .then(this.connect.bind(this)) // No HTTP error? Reconnect

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -57,6 +57,9 @@ MessageReceiver.prototype.extend({
         if (ev.code === 3000) {
             return;
         }
+        if (ev.code === 3001) {
+            this.onEmpty();
+        }
         // possible 403 or network issue. Make an request to confirm
         return this.server.getDevices(this.number)
             .then(this.connect.bind(this)) // No HTTP error? Reconnect


### PR DESCRIPTION
Resolve extremely long loading screen time when dealing with repeated redeliveries and socket timeouts, as seen in #1426.