### PR TITLE
Additional logging to help track down socket disconnect problems

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37370,6 +37370,7 @@ Internal.SessionLock.queueJobForNumber = function queueJobForNumber(number, runJ
             clearTimeout(this.keepAliveTimer);
             clearTimeout(this.disconnectTimer);
             this.keepAliveTimer = setTimeout(function() {
+                console.log('Sending a keepalive message');
                 this.wsr.sendRequest({
                     verb: 'GET',
                     path: this.path,

--- a/libtextsecure/websocket-resources.js
+++ b/libtextsecure/websocket-resources.js
@@ -182,6 +182,7 @@
             clearTimeout(this.keepAliveTimer);
             clearTimeout(this.disconnectTimer);
             this.keepAliveTimer = setTimeout(function() {
+                console.log('Sending a keepalive message');
                 this.wsr.sendRequest({
                     verb: 'GET',
                     path: this.path,


### PR DESCRIPTION
Users have been running into difficulties with spurious socket disconnects, even with the application in focus. And there seem to be mysterious ~90-second gaps in the log before each of these socket timeout messages: https://github.com/WhisperSystems/Signal-Desktop/issues/1075

This additional logging will help us determine when we sent the original keepalive message, what kind of delays we're seeing between the two. It should only be a one second of delay, but I'm guessing that it is being extended out to ~90 seconds.