### PR TITLE
Update our release scripts to match changes in electron-builder

### DIFF
--- a/fix_broken_perms.sh
+++ b/fix_broken_perms.sh
@@ -1,6 +1,6 @@
 set -e
-find release/linux-unpacked -type d | xargs chmod 755
-find release/linux-unpacked -type f | xargs chmod 644
-find release/win-unpacked -type d | xargs chmod 755
-find release/win-unpacked -type f | xargs chmod 644
-chmod +x release/linux-unpacked/signal-desktop
+find release/linux -type d | xargs chmod 755
+find release/linux -type f | xargs chmod 644
+find release/windows -type d | xargs chmod 755
+find release/windows -type f | xargs chmod 644
+chmod +x release/linux/signal-desktop

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "prep-mac-release": "npm run build-release -- -m --dir",
     "prep-release": "npm run generate && grunt prep-release && npm run build-release && npm run build-mas-release && grunt test-release",
     "release-mac": "npm run build-release -- -m --prepackaged release/mac/Signal.app --publish=always",
-    "release-win": "npm run build-release -- -w --prepackaged release/win-unpacked --publish=always",
-    "release-lin": "npm run build-release -- -l --prepackaged release/linux-unpacked && VERSION=$npm_package_version ./aptly.sh",
+    "release-win": "npm run build-release -- -w --prepackaged release/windows --publish=always",
+    "release-lin": "npm run build-release -- -l --prepackaged release/linux && VERSION=$npm_package_version ./aptly.sh",
     "release": "npm run release-mac && npm run release-win && npm run release-lin"
   },
   "build": {


### PR DESCRIPTION
No more `win-unpacked`/`linux-unpacked`, so we need to extract downloaded zips into their own folders manually.