### PR TITLE
Receipt messages

### DIFF
--- a/background.html
+++ b/background.html
@@ -792,6 +792,7 @@
   <script type='text/javascript' src='js/notifications.js'></script>
   <script type='text/javascript' src='js/delivery_receipts.js'></script>
   <script type='text/javascript' src='js/read_receipts.js'></script>
+  <script type='text/javascript' src='js/read_syncs.js'></script>
   <script type='text/javascript' src='js/libphonenumber-util.js'></script>
   <script type='text/javascript' src='js/models/messages.js'></script>
   <script type='text/javascript' src='js/models/conversations.js'></script>

--- a/background.html
+++ b/background.html
@@ -499,30 +499,37 @@
     {{ /message }}
   </script>
   <script type='text/x-tmpl-mustache' id='contact-detail'>
-      <div class='clearfix'>
-        {{> avatar }}
-        <div class='contact-details'>
-          {{ #errors }}
-              <div class='error-icon-container'>
-                {{ #showErrorButton }}
-                  <button class='error'>
-                    <span class='icon error'></span>
-                    {{ errorButtonLabel }}
-                  </button>
-                {{ /showErrorButton }}
-                {{ ^showErrorButton }}
-                  <span class='error-icon'></span>
-                {{ /showErrorButton }}
-              </div>
-          {{ /errors }}
-          <span class='name' dir='auto'>{{ name }}</span>
-          {{ #errors }}
-            {{ #message }}
-              <p class='error-message'>{{message}}</p>
-            {{ /message }}
-          {{ /errors }}
+    <div class='clearfix'>
+      {{> avatar }}
+      <div class='contact-details'>
+        {{ #errors }}
+          <div class='error-icon-container'>
+            {{ #showErrorButton }}
+              <button class='error'>
+                <span class='icon error'></span>
+                {{ errorButtonLabel }}
+              </button>
+            {{ /showErrorButton }}
+            {{ ^showErrorButton }}
+              <span class='error-icon'></span>
+            {{ /showErrorButton }}
+          </div>
+        {{ /errors }}
+
+        {{ ^errors }}
+        <div class='status-icon-container {{ status }}'>
+          <span class='status'></span>
         </div>
+        {{ /errors }}
+
+        <span class='name' dir='auto'>{{ name }}</span>
+        {{ #errors }}
+          {{ #message }}
+            <p class='error-message'>{{message}}</p>
+          {{ /message }}
+        {{ /errors }}
       </div>
+    </div>
   </script>
   <script type='text/x-tmpl-mustache' id='link_to_support'>
     <a href='http://support.whispersystems.org/hc/articles/213134107' target='_blank'>

--- a/background.html
+++ b/background.html
@@ -339,7 +339,7 @@
   </script>
   <script type='text/x-tmpl-mustache' id='contact'>
       {{> avatar }}
-      <div class='contact-details {{ #class }} {{ class }} {{ /class}}'> {{> contact_name_and_number }} </div>
+      <div class='contact-details {{ class }}'> {{> contact_name_and_number }} </div>
   </script>
   <script type='text/x-tmpl-mustache' id='new-contact'>
       {{> avatar }}

--- a/js/background.js
+++ b/js/background.js
@@ -191,6 +191,7 @@
         messageReceiver.addEventListener('group', onGroupReceived);
         messageReceiver.addEventListener('sent', onSentMessage);
         messageReceiver.addEventListener('readSync', onReadSync);
+        messageReceiver.addEventListener('read', onReadReceipt);
         messageReceiver.addEventListener('verified', onVerified);
         messageReceiver.addEventListener('error', onError);
         messageReceiver.addEventListener('empty', onEmpty);
@@ -527,6 +528,24 @@
         }
 
         throw error;
+    }
+
+    function onReadReceipt(ev) {
+        var read_at   = ev.timestamp;
+        var timestamp = ev.read.timestamp;
+        var reader    = ev.read.reader;
+        console.log('read receipt', reader, timestamp);
+
+        var receipt = Whisper.ReadReceipts.add({
+            reader    : reader,
+            timestamp : timestamp,
+            read_at   : read_at,
+        });
+
+        receipt.on('remove', ev.confirm);
+
+        // Calling this directly so we can wait for completion
+        return Whisper.ReadReceipts.onReceipt(receipt);
     }
 
     function onReadSync(ev) {

--- a/js/background.js
+++ b/js/background.js
@@ -190,7 +190,7 @@
         messageReceiver.addEventListener('contact', onContactReceived);
         messageReceiver.addEventListener('group', onGroupReceived);
         messageReceiver.addEventListener('sent', onSentMessage);
-        messageReceiver.addEventListener('read', onReadReceipt);
+        messageReceiver.addEventListener('readSync', onReadSync);
         messageReceiver.addEventListener('verified', onVerified);
         messageReceiver.addEventListener('error', onError);
         messageReceiver.addEventListener('empty', onEmpty);
@@ -529,7 +529,7 @@
         throw error;
     }
 
-    function onReadReceipt(ev) {
+    function onReadSync(ev) {
         var read_at   = ev.timestamp;
         var timestamp = ev.read.timestamp;
         var sender    = ev.read.sender;

--- a/js/background.js
+++ b/js/background.js
@@ -186,7 +186,7 @@
             SERVER_URL, USERNAME, PASSWORD, mySignalingKey, options
         );
         messageReceiver.addEventListener('message', onMessageReceived);
-        messageReceiver.addEventListener('receipt', onDeliveryReceipt);
+        messageReceiver.addEventListener('delivery', onDeliveryReceipt);
         messageReceiver.addEventListener('contact', onContactReceived);
         messageReceiver.addEventListener('group', onGroupReceived);
         messageReceiver.addEventListener('sent', onSentMessage);

--- a/js/background.js
+++ b/js/background.js
@@ -379,9 +379,17 @@
         var now = new Date().getTime();
         var data = ev.data;
 
+        var type, id;
+        if (data.message.group) {
+            type = 'group';
+            id = data.message.group.id;
+        } else {
+            type = 'private';
+            id = data.destination;
+        }
+
         if (data.message.flags & textsecure.protobuf.DataMessage.Flags.PROFILE_KEY_UPDATE) {
-            var id = data.message.group ? data.message.group.id : data.destination;
-            return ConversationController.getOrCreateAndWait(id, 'private').then(function(convo) {
+            return ConversationController.getOrCreateAndWait(id, type).then(function(convo) {
               return convo.save({profileSharing: true}).then(ev.confirm);
             });
         }
@@ -402,15 +410,6 @@
                 console.log('Received duplicate message', message.idForLogging());
                 ev.confirm();
                 return;
-            }
-
-            var type, id;
-            if (data.message.group) {
-                type = 'group';
-                id = data.message.group.id;
-            } else {
-                type = 'private';
-                id = data.destination;
             }
 
             return ConversationController.getOrCreateAndWait(id, type).then(function() {

--- a/js/background.js
+++ b/js/background.js
@@ -196,6 +196,7 @@
         messageReceiver.addEventListener('error', onError);
         messageReceiver.addEventListener('empty', onEmpty);
         messageReceiver.addEventListener('progress', onProgress);
+        messageReceiver.addEventListener('settings', onSettings);
 
         window.textsecure.messaging = new textsecure.MessageSender(
             SERVER_URL, USERNAME, PASSWORD, CDN_URL
@@ -251,6 +252,13 @@
         var view = window.owsDesktopApp.appView;
         if (view) {
             view.onProgress(count);
+        }
+    }
+    function onSettings(ev) {
+        if (ev.settings.readReceipts) {
+            storage.put('read-receipt-setting', true);
+        } else {
+            storage.put('read-receipt-setting', false);
         }
     }
 

--- a/js/background.js
+++ b/js/background.js
@@ -533,9 +533,9 @@
         var read_at   = ev.timestamp;
         var timestamp = ev.read.timestamp;
         var sender    = ev.read.sender;
-        console.log('read receipt', sender, timestamp);
+        console.log('read sync', sender, timestamp);
 
-        var receipt = Whisper.ReadReceipts.add({
+        var receipt = Whisper.ReadSyncs.add({
             sender    : sender,
             timestamp : timestamp,
             read_at   : read_at
@@ -544,7 +544,7 @@
         receipt.on('remove', ev.confirm);
 
         // Calling this directly so we can wait for completion
-        return Whisper.ReadReceipts.onReceipt(receipt);
+        return Whisper.ReadSyncs.onReceipt(receipt);
     }
 
     function onVerified(ev) {

--- a/js/background.js
+++ b/js/background.js
@@ -597,17 +597,16 @@
     }
 
     function onDeliveryReceipt(ev) {
-        var pushMessage = ev.proto;
-        var timestamp = pushMessage.timestamp.toNumber();
+        var deliveryReceipt = ev.deliveryReceipt;
         console.log(
             'delivery receipt from',
-            pushMessage.source + '.' + pushMessage.sourceDevice,
-            timestamp
+            deliveryReceipt.source + '.' + deliveryReceipt.sourceDevice,
+            deliveryReceipt.timestamp
         );
 
         var receipt = Whisper.DeliveryReceipts.add({
-            timestamp: timestamp,
-            source: pushMessage.source
+            timestamp: deliveryReceipt.timestamp,
+            source: deliveryReceipt.source
         });
 
         receipt.on('remove', ev.confirm);

--- a/js/background.js
+++ b/js/background.js
@@ -536,6 +536,10 @@
         var reader    = ev.read.reader;
         console.log('read receipt', reader, timestamp);
 
+        if (!storage.get('read-receipt-setting')) {
+          return ev.confirm();
+        }
+
         var receipt = Whisper.ReadReceipts.add({
             reader    : reader,
             timestamp : timestamp,

--- a/js/background.js
+++ b/js/background.js
@@ -214,6 +214,21 @@
             }
         }
 
+        // If we've just upgraded to read receipt support on desktop, kick off a
+        // one-time configuration sync request to get the read-receipt setting
+        // from the master device.
+        var readReceiptConfigurationSync = 'read-receipt-configuration-sync';
+        if (!storage.get(readReceiptConfigurationSync)) {
+
+            if (!firstRun && textsecure.storage.user.getDeviceId() != '1') {
+                textsecure.messaging.sendRequestConfigurationSyncMessage().then(function() {
+                    storage.put(readReceiptConfigurationSync, true);
+                }).catch(function(e) {
+                    console.log(e);
+                });
+            }
+        }
+
         if (firstRun === true && textsecure.storage.user.getDeviceId() != '1') {
             if (!storage.get('theme-setting') && textsecure.storage.get('userAgent') === 'OWI') {
                 storage.put('theme-setting', 'ios');
@@ -229,6 +244,12 @@
                 console.log('sync timed out');
                 Whisper.events.trigger('contactsync');
             });
+
+            if (Whisper.Import.isComplete()) {
+              textsecure.messaging.sendRequestConfigurationSyncMessage().catch(function(e) {
+                console.log(e);
+              });
+            }
         }
     }
 

--- a/js/delivery_receipts.js
+++ b/js/delivery_receipts.js
@@ -41,8 +41,10 @@
             }).then(function(message) {
                 if (message) {
                     var deliveries = message.get('delivered') || 0;
+                    var delivered_to = message.get('delivered_to') || [];
                     return new Promise(function(resolve, reject) {
                         message.save({
+                            delivered_to: _.union(delivered_to, receipt.get('source')),
                             delivered: deliveries + 1
                         }).then(function() {
                             // notify frontend listeners

--- a/js/delivery_receipts.js
+++ b/js/delivery_receipts.js
@@ -44,7 +44,7 @@
                     var delivered_to = message.get('delivered_to') || [];
                     return new Promise(function(resolve, reject) {
                         message.save({
-                            delivered_to: _.union(delivered_to, receipt.get('source')),
+                            delivered_to: _.union(delivered_to, [receipt.get('source')]),
                             delivered: deliveries + 1
                         }).then(function() {
                             // notify frontend listeners

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -39873,6 +39873,16 @@ MessageSender.prototype = {
 
         return Promise.resolve();
     },
+    sendReadReceipts: function(sender, timestamps) {
+        var receiptMessage = new textsecure.protobuf.ReceiptMessage();
+        receiptMessage.type = textsecure.protobuf.ReceiptMessage.Type.READ;
+        receiptMessage.timestamps = timestamps;
+
+        var contentMessage = new textsecure.protobuf.Content();
+        contentMessage.receiptMessage = receiptMessage;
+
+        return this.sendIndividualProto(sender, contentMessage, Date.now());
+    },
     syncReadMessages: function(reads) {
         var myNumber = textsecure.storage.user.getNumber();
         var myDevice = textsecure.storage.user.getDeviceId();
@@ -40180,6 +40190,7 @@ textsecure.MessageSender = function(url, username, password, cdn_url) {
     this.getAvatar                         = sender.getAvatar                        .bind(sender);
     this.syncReadMessages                  = sender.syncReadMessages                 .bind(sender);
     this.syncVerification                  = sender.syncVerification                 .bind(sender);
+    this.sendReadReceipts                  = sender.sendReadReceipts                 .bind(sender);
 };
 
 textsecure.MessageSender.prototype = {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38694,7 +38694,11 @@ MessageReceiver.prototype.extend({
         return new Promise(function(resolve, reject) {
             var ev = new Event('receipt');
             ev.confirm = this.removeFromCache.bind(this, envelope);
-            ev.proto = envelope;
+            ev.deliveryReceipt = {
+              timestamp    : envelope.timestamp.toNumber(),
+              source       : envelope.source,
+              sourceDevice : envelope.sourceDevice
+            };
             this.dispatchAndWait(ev).then(resolve, reject);
         }.bind(this));
     },

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38692,7 +38692,7 @@ MessageReceiver.prototype.extend({
     },
     onDeliveryReceipt: function (envelope) {
         return new Promise(function(resolve, reject) {
-            var ev = new Event('receipt');
+            var ev = new Event('delivery');
             ev.confirm = this.removeFromCache.bind(this, envelope);
             ev.deliveryReceipt = {
               timestamp    : envelope.timestamp.toNumber(),

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38927,7 +38927,7 @@ MessageReceiver.prototype.extend({
     handleRead: function(envelope, read) {
         var results = [];
         for (var i = 0; i < read.length; ++i) {
-            var ev = new Event('read');
+            var ev = new Event('readSync');
             ev.confirm = this.removeFromCache.bind(this, envelope);
             ev.timestamp = envelope.timestamp.toNumber();
             ev.read = {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38860,6 +38860,8 @@ MessageReceiver.prototype.extend({
             return this.handleNullMessage(envelope, content.nullMessage);
         } else if (content.callMessage) {
             return this.handleCallMessage(envelope, content.callMessage);
+        } else if (content.receiptMessage) {
+            return this.handleReceiptMessage(envelope, content.receiptMessage);
         } else {
             this.removeFromCache(envelope);
             throw new Error('Unsupported content message');
@@ -38868,6 +38870,33 @@ MessageReceiver.prototype.extend({
     handleCallMessage: function(envelope, nullMessage) {
         console.log('call message from', this.getEnvelopeId(envelope));
         this.removeFromCache(envelope);
+    },
+    handleReceiptMessage: function(envelope, receiptMessage) {
+        var results = [];
+        if (receiptMessage.type === textsecure.protobuf.ReceiptMessage.Type.DELIVERY) {
+            for (var i = 0; i < receiptMessage.timestamps.length; ++i) {
+                var ev = new Event('delivery');
+                ev.confirm = this.removeFromCache.bind(this, envelope);
+                ev.deliveryReceipt = {
+                  timestamp    : receiptMessage.timestamps[i].toNumber(),
+                  source       : envelope.source,
+                  sourceDevice : envelope.sourceDevice
+                };
+                results.push(this.dispatchAndWait(ev));
+            }
+        } else if (receiptMessage.type === textsecure.protobuf.ReceiptMessage.Type.READ) {
+            for (var i = 0; i < receiptMessage.timestamps.length; ++i) {
+                var ev = new Event('read');
+                ev.confirm = this.removeFromCache.bind(this, envelope);
+                ev.timestamp = envelope.timestamp.toNumber();
+                ev.read = {
+                    timestamp : receiptMessage.timestamps[i].toNumber(),
+                    reader    : envelope.source
+                }
+                results.push(this.dispatchAndWait(ev));
+            }
+        }
+        return Promise.all(results);
     },
     handleNullMessage: function(envelope, nullMessage) {
         console.log('null message from', this.getEnvelopeId(envelope));

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38147,7 +38147,8 @@ var TextSecureServer = (function() {
                                                 provisionMessage.identityKeyPair,
                                                 provisionMessage.profileKey,
                                                 deviceName,
-                                                provisionMessage.userAgent
+                                                provisionMessage.userAgent,
+                                                provisionMessage.readReceipts
                                             ).then(generateKeys).
                                               then(registerKeys).
                                               then(registrationDone);
@@ -38246,7 +38247,8 @@ var TextSecureServer = (function() {
                 });
             });
         },
-        createAccount: function(number, verificationCode, identityKeyPair, profileKey, deviceName, userAgent) {
+        createAccount: function(number, verificationCode, identityKeyPair,
+                           profileKey, deviceName, userAgent, readReceipts) {
             var signalingKey = libsignal.crypto.getRandomBytes(32 + 20);
             var password = btoa(getString(libsignal.crypto.getRandomBytes(16)));
             password = password.substring(0, password.length - 2);
@@ -38288,7 +38290,7 @@ var TextSecureServer = (function() {
                     if (userAgent) {
                         textsecure.storage.put('userAgent', userAgent);
                     }
-                    if (provisionMessage.readReceipts) {
+                    if (readReceipts) {
                         textsecure.storage.put('read-receipt-setting', true);
                     } else {
                         textsecure.storage.put('read-receipt-setting', false);

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -40212,25 +40212,26 @@ textsecure.MessageSender = function(url, username, password, cdn_url) {
     textsecure.replay.registerFunction(sender.sendMessage.bind(sender), textsecure.replay.Type.REBUILD_MESSAGE);
     textsecure.replay.registerFunction(sender.retrySendMessageProto.bind(sender), textsecure.replay.Type.RETRY_SEND_MESSAGE_PROTO);
 
-    this.sendExpirationTimerUpdateToNumber = sender.sendExpirationTimerUpdateToNumber.bind(sender);
-    this.sendExpirationTimerUpdateToGroup  = sender.sendExpirationTimerUpdateToGroup .bind(sender);
-    this.sendRequestGroupSyncMessage       = sender.sendRequestGroupSyncMessage      .bind(sender);
-    this.sendRequestContactSyncMessage     = sender.sendRequestContactSyncMessage    .bind(sender);
-    this.sendMessageToNumber               = sender.sendMessageToNumber              .bind(sender);
-    this.closeSession                      = sender.closeSession                     .bind(sender);
-    this.sendMessageToGroup                = sender.sendMessageToGroup               .bind(sender);
-    this.createGroup                       = sender.createGroup                      .bind(sender);
-    this.updateGroup                       = sender.updateGroup                      .bind(sender);
-    this.addNumberToGroup                  = sender.addNumberToGroup                 .bind(sender);
-    this.setGroupName                      = sender.setGroupName                     .bind(sender);
-    this.setGroupAvatar                    = sender.setGroupAvatar                   .bind(sender);
-    this.leaveGroup                        = sender.leaveGroup                       .bind(sender);
-    this.sendSyncMessage                   = sender.sendSyncMessage                  .bind(sender);
-    this.getProfile                        = sender.getProfile                       .bind(sender);
-    this.getAvatar                         = sender.getAvatar                        .bind(sender);
-    this.syncReadMessages                  = sender.syncReadMessages                 .bind(sender);
-    this.syncVerification                  = sender.syncVerification                 .bind(sender);
-    this.sendReadReceipts                  = sender.sendReadReceipts                 .bind(sender);
+    this.sendExpirationTimerUpdateToNumber   = sender.sendExpirationTimerUpdateToNumber.bind(sender);
+    this.sendExpirationTimerUpdateToGroup    = sender.sendExpirationTimerUpdateToGroup .bind(sender);
+    this.sendRequestGroupSyncMessage         = sender.sendRequestGroupSyncMessage      .bind(sender);
+    this.sendRequestContactSyncMessage       = sender.sendRequestContactSyncMessage    .bind(sender);
+    this.sendRequestConfigurationSyncMessage = sender.sendRequestConfigurationSyncMessage.bind(sender);
+    this.sendMessageToNumber                 = sender.sendMessageToNumber              .bind(sender);
+    this.closeSession                        = sender.closeSession                     .bind(sender);
+    this.sendMessageToGroup                  = sender.sendMessageToGroup               .bind(sender);
+    this.createGroup                         = sender.createGroup                      .bind(sender);
+    this.updateGroup                         = sender.updateGroup                      .bind(sender);
+    this.addNumberToGroup                    = sender.addNumberToGroup                 .bind(sender);
+    this.setGroupName                        = sender.setGroupName                     .bind(sender);
+    this.setGroupAvatar                      = sender.setGroupAvatar                   .bind(sender);
+    this.leaveGroup                          = sender.leaveGroup                       .bind(sender);
+    this.sendSyncMessage                     = sender.sendSyncMessage                  .bind(sender);
+    this.getProfile                          = sender.getProfile                       .bind(sender);
+    this.getAvatar                           = sender.getAvatar                        .bind(sender);
+    this.syncReadMessages                    = sender.syncReadMessages                 .bind(sender);
+    this.syncVerification                    = sender.syncVerification                 .bind(sender);
+    this.sendReadReceipts                    = sender.sendReadReceipts                 .bind(sender);
 };
 
 textsecure.MessageSender.prototype = {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37999,8 +37999,12 @@ var TextSecureServer = (function() {
                 return res;
             });
         },
-        sendMessages: function(destination, messageArray, timestamp) {
+        sendMessages: function(destination, messageArray, timestamp, silent) {
             var jsonData = { messages: messageArray, timestamp: timestamp};
+
+            if (silent) {
+              jsonData.silent = true;
+            }
 
             return this.ajax({
                 call                : 'messages',
@@ -39286,7 +39290,7 @@ textsecure.MessageReceiver.prototype = {
 /*
  * vim: ts=4:sw=4:expandtab
  */
-function OutgoingMessage(server, timestamp, numbers, message, callback) {
+function OutgoingMessage(server, timestamp, numbers, message, silent, callback) {
     if (message instanceof textsecure.protobuf.DataMessage) {
         var content = new textsecure.protobuf.Content();
         content.dataMessage = message;
@@ -39297,6 +39301,7 @@ function OutgoingMessage(server, timestamp, numbers, message, callback) {
     this.numbers = numbers;
     this.message = message; // ContentMessage proto
     this.callback = callback;
+    this.silent = silent;
 
     this.numbersCompleted = 0;
     this.errors = [];
@@ -39379,7 +39384,7 @@ OutgoingMessage.prototype = {
     },
 
     transmitMessage: function(number, jsonData, timestamp) {
-        return this.server.sendMessages(number, jsonData, timestamp).catch(function(e) {
+        return this.server.sendMessages(number, jsonData, timestamp, this.silent).catch(function(e) {
             if (e.name === 'HTTPError' && (e.code !== 409 && e.code !== 410)) {
                 // 409 and 410 should bubble and be handled by doSendMessage
                 // 404 should throw UnregisteredUserError
@@ -39775,13 +39780,13 @@ MessageSender.prototype = {
             }.bind(this));
         }.bind(this));
     },
-    sendMessageProto: function(timestamp, numbers, message, callback) {
+    sendMessageProto: function(timestamp, numbers, message, callback, silent) {
         var rejections = textsecure.storage.get('signedKeyRotationRejected', 0);
         if (rejections > 5) {
             throw new textsecure.SignedPreKeyRotationError(numbers, message.toArrayBuffer(), timestamp);
         }
 
-        var outgoing = new OutgoingMessage(this.server, timestamp, numbers, message, callback);
+        var outgoing = new OutgoingMessage(this.server, timestamp, numbers, message, silent, callback);
 
         numbers.forEach(function(number) {
             this.queueJobForNumber(number, function() {
@@ -39802,14 +39807,14 @@ MessageSender.prototype = {
         }.bind(this));
     },
 
-    sendIndividualProto: function(number, proto, timestamp) {
+    sendIndividualProto: function(number, proto, timestamp, silent) {
         return new Promise(function(resolve, reject) {
             this.sendMessageProto(timestamp, [number], proto, function(res) {
                 if (res.errors.length > 0)
                     reject(res);
                 else
                     resolve(res);
-            });
+            }, silent);
         }.bind(this));
     },
 
@@ -39898,7 +39903,7 @@ MessageSender.prototype = {
         var contentMessage = new textsecure.protobuf.Content();
         contentMessage.receiptMessage = receiptMessage;
 
-        return this.sendIndividualProto(sender, contentMessage, Date.now());
+        return this.sendIndividualProto(sender, contentMessage, Date.now(), true /*silent*/);
     },
     syncReadMessages: function(reads) {
         var myNumber = textsecure.storage.user.getNumber();

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -39864,6 +39864,22 @@ MessageSender.prototype = {
         return this.server.getAvatar(path);
     },
 
+    sendRequestConfigurationSyncMessage: function() {
+        var myNumber = textsecure.storage.user.getNumber();
+        var myDevice = textsecure.storage.user.getDeviceId();
+        if (myDevice != 1) {
+            var request = new textsecure.protobuf.SyncMessage.Request();
+            request.type = textsecure.protobuf.SyncMessage.Request.Type.CONFIGURATION;
+            var syncMessage = this.createSyncMessage();
+            syncMessage.request = request;
+            var contentMessage = new textsecure.protobuf.Content();
+            contentMessage.syncMessage = syncMessage;
+
+            return this.sendIndividualProto(myNumber, contentMessage, Date.now());
+        }
+
+        return Promise.resolve();
+    },
     sendRequestGroupSyncMessage: function() {
         var myNumber = textsecure.storage.user.getNumber();
         var myDevice = textsecure.storage.user.getDeviceId();

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -793,10 +793,13 @@
             if (read.length && options.sendReadReceipts) {
                 console.log('Sending', read.length, 'read receipts');
                 promises.push(textsecure.messaging.syncReadMessages(read));
-                _.each(_.groupBy(read, 'sender'), function(receipts, sender) {
-                    var timestamps = _.map(receipts, 'timestamp');
-                    promises.push(textsecure.messaging.sendReadReceipts(sender, timestamps));
-                });
+
+                if (storage.get('read-receipt-setting')) {
+                  _.each(_.groupBy(read, 'sender'), function(receipts, sender) {
+                      var timestamps = _.map(receipts, 'timestamp');
+                      promises.push(textsecure.messaging.sendReadReceipts(sender, timestamps));
+                  });
+                }
             }
 
             return Promise.all(promises);

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -487,15 +487,15 @@
 
         // We mark as read everything older than this message - to clean up old stuff
         //   still marked unread in the database. If the user generally doesn't read in
-        //   the desktop app, so the desktop app only gets read receipts, we can very
+        //   the desktop app, so the desktop app only gets read syncs, we can very
         //   easily end up with messages never marked as read (our previous early read
-        //   receipt handling, read receipts never sent because app was offline)
+        //   sync handling, read syncs never sent because app was offline)
 
-        // We queue it because we often get a whole lot of read receipts at once, and
+        // We queue it because we often get a whole lot of read syncs at once, and
         //   their markRead calls could very easily overlap given the async pull from DB.
 
-        // Lastly, we don't send read receipts for any message marked read due to a read
-        //   receipt. That's a notification explosion we don't need.
+        // Lastly, we don't send read syncs for any message marked read due to a read
+        //   sync. That's a notification explosion we don't need.
         return this.queueJob(function() {
             return this.markRead(message.get('received_at'), {sendReadReceipts: false});
         }.bind(this));

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -793,6 +793,10 @@
             if (read.length && options.sendReadReceipts) {
                 console.log('Sending', read.length, 'read receipts');
                 promises.push(textsecure.messaging.syncReadMessages(read));
+                _.each(_.groupBy(read, 'sender'), function(receipts, sender) {
+                    var timestamps = _.map(receipts, 'timestamp');
+                    promises.push(textsecure.messaging.sendReadReceipts(sender, timestamps));
+                });
             }
 
             return Promise.all(promises);

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -196,7 +196,12 @@
                 if (result.dataMessage) {
                     this.set({dataMessage: result.dataMessage});
                 }
-                this.save({sent: true, expirationStartTimestamp: now});
+                var sent_to = this.get('sent_to') || [];
+                this.save({
+                  sent_to: _.union(sent_to, result.successfulNumbers),
+                  sent: true,
+                  expirationStartTimestamp: now
+                });
                 this.sendSyncMessage();
             }.bind(this)).catch(function(result) {
                 var now = Date.now();
@@ -219,7 +224,12 @@
                 } else {
                     this.saveErrors(result.errors);
                     if (result.successfulNumbers.length > 0) {
-                        this.set({sent: true, expirationStartTimestamp: now});
+                        var sent_to = this.get('sent_to') || [];
+                        this.set({
+                          sent_to: _.union(sent_to, result.successfulNumbers),
+                          sent: true,
+                          expirationStartTimestamp: now
+                        });
                         promises.push(this.sendSyncMessage());
                     }
                     promises = promises.concat(_.map(result.errors, function(error) {

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -455,6 +455,8 @@
                                 read_by: _.union(message.get('read_by'), read_by)
                             });
                         }
+
+                        message.set({recipients: conversation.getRecipients()});
                     }
 
                     var conversation_timestamp = conversation.get('timestamp');

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -188,6 +188,21 @@
             return _.size(this.get('errors')) > 0;
         },
 
+        getStatus: function(number) {
+            var read_by = this.get('read_by') || [];
+            if (read_by.indexOf(number) >= 0) {
+              return 'read';
+            }
+            var delivered_to = this.get('delivered_to') || [];
+            if (delivered_to.indexOf(number) >= 0) {
+              return 'delivered';
+            }
+            var sent_to = this.get('sent_to') || [];
+            if (sent_to.indexOf(number) >= 0) {
+              return 'sent';
+            }
+        },
+
         send: function(promise) {
             this.trigger('pending');
             return promise.then(function(result) {

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -445,6 +445,18 @@
                         }
                     }
 
+                    if (type === 'outgoing') {
+                        var reads = Whisper.ReadReceipts.forMessage(conversation, message);
+                        if (reads.length) {
+                            var read_by = reads.map(function(receipt) {
+                                return receipt.get('reader');
+                            });
+                            message.set({
+                                read_by: _.union(message.get('read_by'), read_by)
+                            });
+                        }
+                    }
+
                     var conversation_timestamp = conversation.get('timestamp');
                     if (!conversation_timestamp || message.get('sent_at') > conversation_timestamp) {
                         conversation.set({

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -428,7 +428,7 @@
                         }
                     }
                     if (type === 'incoming') {
-                        var readReceipt = Whisper.ReadReceipts.forMessage(message);
+                        var readReceipt = Whisper.ReadSyncs.forMessage(message);
                         if (readReceipt) {
                             if (message.get('expireTimer') && !message.get('expirationStartTimestamp')) {
                                 message.set('expirationStartTimestamp', readReceipt.get('read_at'));
@@ -439,7 +439,7 @@
                             // This is primarily to allow the conversation to mark all older messages as
                             //   read, as is done when we receive a read receipt for a message we already
                             //   know about.
-                            Whisper.ReadReceipts.notifyConversation(message);
+                            Whisper.ReadSyncs.notifyConversation(message);
                         } else {
                             conversation.set('unreadCount', conversation.get('unreadCount') + 1);
                         }

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -428,16 +428,16 @@
                         }
                     }
                     if (type === 'incoming') {
-                        var readReceipt = Whisper.ReadSyncs.forMessage(message);
-                        if (readReceipt) {
+                        var readSync = Whisper.ReadSyncs.forMessage(message);
+                        if (readSync) {
                             if (message.get('expireTimer') && !message.get('expirationStartTimestamp')) {
-                                message.set('expirationStartTimestamp', readReceipt.get('read_at'));
+                                message.set('expirationStartTimestamp', readSync.get('read_at'));
                             }
                         }
-                        if (readReceipt || message.isExpirationTimerUpdate()) {
+                        if (readSync || message.isExpirationTimerUpdate()) {
                             message.unset('unread');
                             // This is primarily to allow the conversation to mark all older messages as
-                            //   read, as is done when we receive a read receipt for a message we already
+                            //   read, as is done when we receive a read sync for a message we already
                             //   know about.
                             Whisper.ReadSyncs.notifyConversation(message);
                         } else {

--- a/js/read_receipts.js
+++ b/js/read_receipts.js
@@ -46,4 +46,77 @@
             }
         },
     }))();
+
+    Whisper.ReadReceipts = new (Backbone.Collection.extend({
+        forMessage: function(conversation, message) {
+            if (!message.isOutgoing()) {
+                return [];
+            }
+            var ids = [];
+            if (conversation.isPrivate()) {
+                ids = [conversation.id];
+            } else {
+                ids = conversation.get('members');
+            }
+            var receipts = this.filter(function(receipt) {
+                return receipt.get('timestamp') === message.get('sent_at')
+                  &&  _.contains(ids, receipt.get('reader'));
+            });
+            if (receipts.length) {
+                console.log('Found early read receipts for message');
+                this.remove(receipts);
+            }
+            return receipts;
+        },
+        onReceipt: function(receipt) {
+            var messages  = new Whisper.MessageCollection();
+            return messages.fetchSentAt(receipt.get('timestamp')).then(function() {
+                if (messages.length === 0) { return; }
+                var message = messages.find(function(message) {
+                    return (message.isOutgoing() && receipt.get('reader') === message.get('conversationId'));
+                });
+                if (message) { return message; }
+
+                var groups = new Whisper.GroupCollection();
+                return groups.fetchGroups(receipt.get('reader')).then(function() {
+                    var ids = groups.pluck('id');
+                    ids.push(receipt.get('reader'));
+                    return messages.find(function(message) {
+                        return (message.isOutgoing() &&
+                                _.contains(ids, message.get('conversationId')));
+                    });
+                });
+            }).then(function(message) {
+                if (message) {
+                    var read_by = message.get('read_by') || [];
+                    read_by.push(receipt.get('reader'));
+                    return new Promise(function(resolve, reject) {
+                        message.save({ read_by: read_by }).then(function() {
+                            // notify frontend listeners
+                            var conversation = ConversationController.get(
+                                message.get('conversationId')
+                            );
+                            if (conversation) {
+                                conversation.trigger('read', message);
+                            }
+
+                            this.remove(receipt);
+                            resolve();
+                        }.bind(this), reject);
+                    }.bind(this));
+                } else {
+                    console.log(
+                        'No message for read receipt',
+                        receipt.get('reader'),
+                        receipt.get('timestamp')
+                    );
+                }
+            }.bind(this)).catch(function(error) {
+                console.log(
+                    'ReadReceipts.onReceipt error:',
+                    error && error.stack ? error.stack : error
+                );
+            });
+        },
+    }))();
 })();

--- a/js/read_receipts.js
+++ b/js/read_receipts.js
@@ -4,49 +4,6 @@
 ;(function() {
     'use strict';
     window.Whisper = window.Whisper || {};
-    Whisper.ReadSyncs = new (Backbone.Collection.extend({
-        forMessage: function(message) {
-            var receipt = this.findWhere({
-                sender: message.get('source'),
-                timestamp: message.get('sent_at')
-            });
-            if (receipt) {
-                console.log('Found early read sync for message');
-                this.remove(receipt);
-                return receipt;
-            }
-        },
-        onReceipt: function(receipt) {
-            var messages  = new Whisper.MessageCollection();
-            return messages.fetchSentAt(receipt.get('timestamp')).then(function() {
-                var message = messages.find(function(message) {
-                    return (message.isIncoming() && message.isUnread() &&
-                            message.get('source') === receipt.get('sender'));
-                });
-                if (message) {
-                    return message.markRead(receipt.get('read_at')).then(function() {
-                        this.notifyConversation(message);
-                        this.remove(receipt);
-                    }.bind(this));
-                } else {
-                    console.log(
-                        'No message for read sync',
-                        receipt.get('sender'), receipt.get('timestamp')
-                    );
-                }
-            }.bind(this));
-        },
-        notifyConversation: function(message) {
-            var conversation = ConversationController.get({
-                id: message.get('conversationId')
-            });
-
-            if (conversation) {
-                conversation.onReadMessage(message);
-            }
-        },
-    }))();
-
     Whisper.ReadReceipts = new (Backbone.Collection.extend({
         forMessage: function(conversation, message) {
             if (!message.isOutgoing()) {

--- a/js/read_receipts.js
+++ b/js/read_receipts.js
@@ -4,14 +4,14 @@
 ;(function() {
     'use strict';
     window.Whisper = window.Whisper || {};
-    Whisper.ReadReceipts = new (Backbone.Collection.extend({
+    Whisper.ReadSyncs = new (Backbone.Collection.extend({
         forMessage: function(message) {
             var receipt = this.findWhere({
                 sender: message.get('source'),
                 timestamp: message.get('sent_at')
             });
             if (receipt) {
-                console.log('Found early read receipt for message');
+                console.log('Found early read sync for message');
                 this.remove(receipt);
                 return receipt;
             }
@@ -30,7 +30,7 @@
                     }.bind(this));
                 } else {
                     console.log(
-                        'No message for read receipt',
+                        'No message for read sync',
                         receipt.get('sender'), receipt.get('timestamp')
                     );
                 }

--- a/js/read_syncs.js
+++ b/js/read_syncs.js
@@ -1,0 +1,49 @@
+/*
+ * vim: ts=4:sw=4:expandtab
+ */
+;(function() {
+    'use strict';
+    window.Whisper = window.Whisper || {};
+    Whisper.ReadSyncs = new (Backbone.Collection.extend({
+        forMessage: function(message) {
+            var receipt = this.findWhere({
+                sender: message.get('source'),
+                timestamp: message.get('sent_at')
+            });
+            if (receipt) {
+                console.log('Found early read sync for message');
+                this.remove(receipt);
+                return receipt;
+            }
+        },
+        onReceipt: function(receipt) {
+            var messages  = new Whisper.MessageCollection();
+            return messages.fetchSentAt(receipt.get('timestamp')).then(function() {
+                var message = messages.find(function(message) {
+                    return (message.isIncoming() && message.isUnread() &&
+                            message.get('source') === receipt.get('sender'));
+                });
+                if (message) {
+                    return message.markRead(receipt.get('read_at')).then(function() {
+                        this.notifyConversation(message);
+                        this.remove(receipt);
+                    }.bind(this));
+                } else {
+                    console.log(
+                        'No message for read sync',
+                        receipt.get('sender'), receipt.get('timestamp')
+                    );
+                }
+            }.bind(this));
+        },
+        notifyConversation: function(message) {
+            var conversation = ConversationController.get({
+                id: message.get('conversationId')
+            });
+
+            if (conversation) {
+                conversation.onReadMessage(message);
+            }
+        },
+    }))();
+})();

--- a/js/views/contact_list_view.js
+++ b/js/views/contact_list_view.js
@@ -23,7 +23,6 @@
             render_attributes: function() {
                 if (this.model.id === this.ourNumber) {
                     return {
-                        class: 'not-clickable',
                         title: i18n('me'),
                         number: this.model.getNumber(),
                         avatar: this.model.getAvatar()
@@ -31,6 +30,7 @@
                 }
 
                 return {
+                    class: 'clickable',
                     title: this.model.getTitle(),
                     number: this.model.getNumber(),
                     avatar: this.model.getAvatar(),

--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -109,6 +109,7 @@
             this.listenTo(this.model, 'change:avatar change:profileAvatar', this.updateAvatar);
             this.listenTo(this.model, 'newmessage', this.addMessage);
             this.listenTo(this.model, 'delivered', this.updateMessage);
+            this.listenTo(this.model, 'read', this.updateMessage);
             this.listenTo(this.model, 'opened', this.onOpened);
             this.listenTo(this.model, 'expired', this.onExpired);
             this.listenTo(this.model, 'prune', this.onPrune);

--- a/js/views/message_detail_view.js
+++ b/js/views/message_detail_view.js
@@ -67,6 +67,7 @@
             var showButton = Boolean(this.outgoingKeyError);
 
             return {
+                status           : this.message.getStatus(this.model.id),
                 name             : this.model.getTitle(),
                 avatar           : this.model.getAvatar(),
                 errors           : this.errors,

--- a/js/views/message_view.js
+++ b/js/views/message_view.js
@@ -175,6 +175,7 @@
             this.listenTo(this.model, 'change:errors', this.onErrorsChanged);
             this.listenTo(this.model, 'change:body', this.render);
             this.listenTo(this.model, 'change:delivered', this.renderDelivered);
+            this.listenTo(this.model, 'change:read_by', this.renderRead);
             this.listenTo(this.model, 'change:expirationStartTimestamp', this.renderExpiring);
             this.listenTo(this.model, 'change', this.renderSent);
             this.listenTo(this.model, 'change:flags change:group_update', this.renderControl);
@@ -271,6 +272,11 @@
         renderDelivered: function() {
             if (this.model.get('delivered')) { this.$el.addClass('delivered'); }
         },
+        renderRead: function() {
+            if (!_.isEmpty(this.model.get('read_by'))) {
+              this.$el.addClass('read');
+            }
+        },
         onErrorsChanged: function() {
             if (this.model.isIncoming()) {
                 this.render();
@@ -359,6 +365,7 @@
 
             this.renderSent();
             this.renderDelivered();
+            this.renderRead();
             this.renderErrors();
             this.renderExpiring();
 

--- a/libtextsecure/ProvisioningCipher.js
+++ b/libtextsecure/ProvisioningCipher.js
@@ -36,6 +36,7 @@ ProvisioningCipher.prototype = {
                     number           : provisionMessage.number,
                     provisioningCode : provisionMessage.provisioningCode,
                     userAgent        : provisionMessage.userAgent,
+                    readReceipts     : provisionMessage.readReceipts
                 };
                 if (provisionMessage.profileKey) {
                   ret.profileKey = provisionMessage.profileKey.toArrayBuffer();

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -204,6 +204,7 @@
                     textsecure.storage.remove('regionCode');
                     textsecure.storage.remove('userAgent');
                     textsecure.storage.remove('profileKey');
+                    textsecure.storage.remove('read-receipts-setting');
 
                     // update our own identity key, which may have changed
                     // if we're relinking after a reinstall on the master device
@@ -226,6 +227,12 @@
                     if (userAgent) {
                         textsecure.storage.put('userAgent', userAgent);
                     }
+                    if (provisionMessage.readReceipts) {
+                        textsecure.storage.put('read-receipt-setting', true);
+                    } else {
+                        textsecure.storage.put('read-receipt-setting', false);
+                    }
+
 
                     textsecure.storage.user.setNumberAndDeviceId(number, response.deviceId || 1, deviceName);
                     textsecure.storage.put('regionCode', libphonenumber.util.getRegionCodeForNumber(number));

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -86,7 +86,8 @@
                                                 provisionMessage.identityKeyPair,
                                                 provisionMessage.profileKey,
                                                 deviceName,
-                                                provisionMessage.userAgent
+                                                provisionMessage.userAgent,
+                                                provisionMessage.readReceipts
                                             ).then(generateKeys).
                                               then(registerKeys).
                                               then(registrationDone);
@@ -185,7 +186,8 @@
                 });
             });
         },
-        createAccount: function(number, verificationCode, identityKeyPair, profileKey, deviceName, userAgent) {
+        createAccount: function(number, verificationCode, identityKeyPair,
+                           profileKey, deviceName, userAgent, readReceipts) {
             var signalingKey = libsignal.crypto.getRandomBytes(32 + 20);
             var password = btoa(getString(libsignal.crypto.getRandomBytes(16)));
             password = password.substring(0, password.length - 2);
@@ -227,7 +229,7 @@
                     if (userAgent) {
                         textsecure.storage.put('userAgent', userAgent);
                     }
-                    if (provisionMessage.readReceipts) {
+                    if (readReceipts) {
                         textsecure.storage.put('read-receipt-setting', true);
                     } else {
                         textsecure.storage.put('read-receipt-setting', false);

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -357,8 +357,12 @@ var TextSecureServer = (function() {
                 return res;
             });
         },
-        sendMessages: function(destination, messageArray, timestamp) {
+        sendMessages: function(destination, messageArray, timestamp, silent) {
             var jsonData = { messages: messageArray, timestamp: timestamp};
+
+            if (silent) {
+              jsonData.silent = true;
+            }
 
             return this.ajax({
                 call                : 'messages',

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -340,7 +340,11 @@ MessageReceiver.prototype.extend({
         return new Promise(function(resolve, reject) {
             var ev = new Event('receipt');
             ev.confirm = this.removeFromCache.bind(this, envelope);
-            ev.proto = envelope;
+            ev.deliveryReceipt = {
+              timestamp    : envelope.timestamp.toNumber(),
+              source       : envelope.source,
+              sourceDevice : envelope.sourceDevice
+            };
             this.dispatchAndWait(ev).then(resolve, reject);
         }.bind(this));
     },

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -338,7 +338,7 @@ MessageReceiver.prototype.extend({
     },
     onDeliveryReceipt: function (envelope) {
         return new Promise(function(resolve, reject) {
-            var ev = new Event('receipt');
+            var ev = new Event('delivery');
             ev.confirm = this.removeFromCache.bind(this, envelope);
             ev.deliveryReceipt = {
               timestamp    : envelope.timestamp.toNumber(),

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -573,7 +573,7 @@ MessageReceiver.prototype.extend({
     handleRead: function(envelope, read) {
         var results = [];
         for (var i = 0; i < read.length; ++i) {
-            var ev = new Event('read');
+            var ev = new Event('readSync');
             ev.confirm = this.removeFromCache.bind(this, envelope);
             ev.timestamp = envelope.timestamp.toNumber();
             ev.read = {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -585,9 +585,19 @@ MessageReceiver.prototype.extend({
             return this.handleRead(envelope, syncMessage.read);
         } else if (syncMessage.verified) {
             return this.handleVerified(envelope, syncMessage.verified);
+        } else if (syncMessage.settings) {
+            return this.handleSettings(envelope, syncMessage.settings);
         } else {
             throw new Error('Got empty SyncMessage');
         }
+    },
+    handleSettings: function(envelope, settings) {
+        var ev = new Event('settings');
+        ev.confirm = this.removeFromCache.bind(this, envelope);
+        ev.settings = {
+            readReceipts: settings.readReceipts
+        };
+        return this.dispatchAndWait(ev);
     },
     handleVerified: function(envelope, verified) {
         var ev = new Event('verified');

--- a/libtextsecure/outgoing_message.js
+++ b/libtextsecure/outgoing_message.js
@@ -1,7 +1,7 @@
 /*
  * vim: ts=4:sw=4:expandtab
  */
-function OutgoingMessage(server, timestamp, numbers, message, callback) {
+function OutgoingMessage(server, timestamp, numbers, message, silent, callback) {
     if (message instanceof textsecure.protobuf.DataMessage) {
         var content = new textsecure.protobuf.Content();
         content.dataMessage = message;
@@ -12,6 +12,7 @@ function OutgoingMessage(server, timestamp, numbers, message, callback) {
     this.numbers = numbers;
     this.message = message; // ContentMessage proto
     this.callback = callback;
+    this.silent = silent;
 
     this.numbersCompleted = 0;
     this.errors = [];
@@ -94,7 +95,7 @@ OutgoingMessage.prototype = {
     },
 
     transmitMessage: function(number, jsonData, timestamp) {
-        return this.server.sendMessages(number, jsonData, timestamp).catch(function(e) {
+        return this.server.sendMessages(number, jsonData, timestamp, this.silent).catch(function(e) {
             if (e.name === 'HTTPError' && (e.code !== 409 && e.code !== 410)) {
                 // 409 and 410 should bubble and be handled by doSendMessage
                 // 404 should throw UnregisteredUserError

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -328,6 +328,22 @@ MessageSender.prototype = {
         return this.server.getAvatar(path);
     },
 
+    sendRequestConfigurationSyncMessage: function() {
+        var myNumber = textsecure.storage.user.getNumber();
+        var myDevice = textsecure.storage.user.getDeviceId();
+        if (myDevice != 1) {
+            var request = new textsecure.protobuf.SyncMessage.Request();
+            request.type = textsecure.protobuf.SyncMessage.Request.Type.CONFIGURATION;
+            var syncMessage = this.createSyncMessage();
+            syncMessage.request = request;
+            var contentMessage = new textsecure.protobuf.Content();
+            contentMessage.syncMessage = syncMessage;
+
+            return this.sendIndividualProto(myNumber, contentMessage, Date.now());
+        }
+
+        return Promise.resolve();
+    },
     sendRequestGroupSyncMessage: function() {
         var myNumber = textsecure.storage.user.getNumber();
         var myDevice = textsecure.storage.user.getDeviceId();

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -676,25 +676,26 @@ textsecure.MessageSender = function(url, username, password, cdn_url) {
     textsecure.replay.registerFunction(sender.sendMessage.bind(sender), textsecure.replay.Type.REBUILD_MESSAGE);
     textsecure.replay.registerFunction(sender.retrySendMessageProto.bind(sender), textsecure.replay.Type.RETRY_SEND_MESSAGE_PROTO);
 
-    this.sendExpirationTimerUpdateToNumber = sender.sendExpirationTimerUpdateToNumber.bind(sender);
-    this.sendExpirationTimerUpdateToGroup  = sender.sendExpirationTimerUpdateToGroup .bind(sender);
-    this.sendRequestGroupSyncMessage       = sender.sendRequestGroupSyncMessage      .bind(sender);
-    this.sendRequestContactSyncMessage     = sender.sendRequestContactSyncMessage    .bind(sender);
-    this.sendMessageToNumber               = sender.sendMessageToNumber              .bind(sender);
-    this.closeSession                      = sender.closeSession                     .bind(sender);
-    this.sendMessageToGroup                = sender.sendMessageToGroup               .bind(sender);
-    this.createGroup                       = sender.createGroup                      .bind(sender);
-    this.updateGroup                       = sender.updateGroup                      .bind(sender);
-    this.addNumberToGroup                  = sender.addNumberToGroup                 .bind(sender);
-    this.setGroupName                      = sender.setGroupName                     .bind(sender);
-    this.setGroupAvatar                    = sender.setGroupAvatar                   .bind(sender);
-    this.leaveGroup                        = sender.leaveGroup                       .bind(sender);
-    this.sendSyncMessage                   = sender.sendSyncMessage                  .bind(sender);
-    this.getProfile                        = sender.getProfile                       .bind(sender);
-    this.getAvatar                         = sender.getAvatar                        .bind(sender);
-    this.syncReadMessages                  = sender.syncReadMessages                 .bind(sender);
-    this.syncVerification                  = sender.syncVerification                 .bind(sender);
-    this.sendReadReceipts                  = sender.sendReadReceipts                 .bind(sender);
+    this.sendExpirationTimerUpdateToNumber   = sender.sendExpirationTimerUpdateToNumber.bind(sender);
+    this.sendExpirationTimerUpdateToGroup    = sender.sendExpirationTimerUpdateToGroup .bind(sender);
+    this.sendRequestGroupSyncMessage         = sender.sendRequestGroupSyncMessage      .bind(sender);
+    this.sendRequestContactSyncMessage       = sender.sendRequestContactSyncMessage    .bind(sender);
+    this.sendRequestConfigurationSyncMessage = sender.sendRequestConfigurationSyncMessage.bind(sender);
+    this.sendMessageToNumber                 = sender.sendMessageToNumber              .bind(sender);
+    this.closeSession                        = sender.closeSession                     .bind(sender);
+    this.sendMessageToGroup                  = sender.sendMessageToGroup               .bind(sender);
+    this.createGroup                         = sender.createGroup                      .bind(sender);
+    this.updateGroup                         = sender.updateGroup                      .bind(sender);
+    this.addNumberToGroup                    = sender.addNumberToGroup                 .bind(sender);
+    this.setGroupName                        = sender.setGroupName                     .bind(sender);
+    this.setGroupAvatar                      = sender.setGroupAvatar                   .bind(sender);
+    this.leaveGroup                          = sender.leaveGroup                       .bind(sender);
+    this.sendSyncMessage                     = sender.sendSyncMessage                  .bind(sender);
+    this.getProfile                          = sender.getProfile                       .bind(sender);
+    this.getAvatar                           = sender.getAvatar                        .bind(sender);
+    this.syncReadMessages                    = sender.syncReadMessages                 .bind(sender);
+    this.syncVerification                    = sender.syncVerification                 .bind(sender);
+    this.sendReadReceipts                    = sender.sendReadReceipts                 .bind(sender);
 };
 
 textsecure.MessageSender.prototype = {

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -246,13 +246,13 @@ MessageSender.prototype = {
             }.bind(this));
         }.bind(this));
     },
-    sendMessageProto: function(timestamp, numbers, message, callback) {
+    sendMessageProto: function(timestamp, numbers, message, callback, silent) {
         var rejections = textsecure.storage.get('signedKeyRotationRejected', 0);
         if (rejections > 5) {
             throw new textsecure.SignedPreKeyRotationError(numbers, message.toArrayBuffer(), timestamp);
         }
 
-        var outgoing = new OutgoingMessage(this.server, timestamp, numbers, message, callback);
+        var outgoing = new OutgoingMessage(this.server, timestamp, numbers, message, silent, callback);
 
         numbers.forEach(function(number) {
             this.queueJobForNumber(number, function() {
@@ -273,14 +273,14 @@ MessageSender.prototype = {
         }.bind(this));
     },
 
-    sendIndividualProto: function(number, proto, timestamp) {
+    sendIndividualProto: function(number, proto, timestamp, silent) {
         return new Promise(function(resolve, reject) {
             this.sendMessageProto(timestamp, [number], proto, function(res) {
                 if (res.errors.length > 0)
                     reject(res);
                 else
                     resolve(res);
-            });
+            }, silent);
         }.bind(this));
     },
 
@@ -369,7 +369,7 @@ MessageSender.prototype = {
         var contentMessage = new textsecure.protobuf.Content();
         contentMessage.receiptMessage = receiptMessage;
 
-        return this.sendIndividualProto(sender, contentMessage, Date.now());
+        return this.sendIndividualProto(sender, contentMessage, Date.now(), true /*silent*/);
     },
     syncReadMessages: function(reads) {
         var myNumber = textsecure.storage.user.getNumber();

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -361,6 +361,16 @@ MessageSender.prototype = {
 
         return Promise.resolve();
     },
+    sendReadReceipts: function(sender, timestamps) {
+        var receiptMessage = new textsecure.protobuf.ReceiptMessage();
+        receiptMessage.type = textsecure.protobuf.ReceiptMessage.Type.READ;
+        receiptMessage.timestamps = timestamps;
+
+        var contentMessage = new textsecure.protobuf.Content();
+        contentMessage.receiptMessage = receiptMessage;
+
+        return this.sendIndividualProto(sender, contentMessage, Date.now());
+    },
     syncReadMessages: function(reads) {
         var myNumber = textsecure.storage.user.getNumber();
         var myDevice = textsecure.storage.user.getDeviceId();
@@ -668,6 +678,7 @@ textsecure.MessageSender = function(url, username, password, cdn_url) {
     this.getAvatar                         = sender.getAvatar                        .bind(sender);
     this.syncReadMessages                  = sender.syncReadMessages                 .bind(sender);
     this.syncVerification                  = sender.syncVerification                 .bind(sender);
+    this.sendReadReceipts                  = sender.sendReadReceipts                 .bind(sender);
 };
 
 textsecure.MessageSender.prototype = {

--- a/protos/DeviceMessages.proto
+++ b/protos/DeviceMessages.proto
@@ -15,5 +15,6 @@ message ProvisionMessage {
   optional string number             = 3;
   optional string provisioningCode   = 4;
   optional string userAgent          = 5;
-  optional bytes profileKey         = 6;
+  optional bytes profileKey          = 6;
+  optional bool  readReceipts        = 7;
 }

--- a/protos/IncomingPushMessageSignal.proto
+++ b/protos/IncomingPushMessageSignal.proto
@@ -22,10 +22,21 @@ message Envelope {
 }
 
 message Content {
-  optional DataMessage dataMessage = 1;
-  optional SyncMessage syncMessage = 2;
-  optional CallMessage callMessage = 3;
-  optional NullMessage nullMessage = 4;
+  optional DataMessage dataMessage       = 1;
+  optional SyncMessage syncMessage       = 2;
+  optional CallMessage callMessage       = 3;
+  optional NullMessage nullMessage       = 4;
+  optional ReceiptMessage receiptMessage = 5;
+}
+
+message ReceiptMessage {
+  enum Type {
+    DELIVERY = 0;
+    READ     = 1;
+  }
+
+  optional Type   type        = 1;
+  repeated uint64 timestamps  = 2;
 }
 
 message NullMessage {

--- a/protos/IncomingPushMessageSignal.proto
+++ b/protos/IncomingPushMessageSignal.proto
@@ -128,10 +128,11 @@ message SyncMessage {
 
   message Request {
     enum Type {
-      UNKNOWN  = 0;
-      CONTACTS = 1;
-      GROUPS   = 2;
-      BLOCKED  = 3;
+      UNKNOWN       = 0;
+      CONTACTS      = 1;
+      GROUPS        = 2;
+      BLOCKED       = 3;
+      CONFIGURATION = 4;
     }
 
     optional Type type = 1;

--- a/protos/IncomingPushMessageSignal.proto
+++ b/protos/IncomingPushMessageSignal.proto
@@ -142,6 +142,10 @@ message SyncMessage {
     optional uint64 timestamp = 2;
   }
 
+  message Settings {
+    optional bool readReceipts = 1;
+  }
+
   optional Sent     sent     = 1;
   optional Contacts contacts = 2;
   optional Groups   groups   = 3;
@@ -150,6 +154,7 @@ message SyncMessage {
   optional Blocked  blocked  = 6;
   optional Verified verified = 7;
   optional bytes    padding  = 8;
+  optional Settings settings = 9;
 }
 
 message AttachmentPointer {

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -493,6 +493,10 @@ li.entry .error-icon-container {
     display: inline-block;
     @include color-svg('../images/double-check.svg', black);
   }
+  .read .status {
+    display: inline-block;
+    @include color-svg('../images/double-check.svg', $blue);
+  }
   .pending .status {
     display: inline-block;
     background: none;

--- a/stylesheets/_conversation.scss
+++ b/stylesheets/_conversation.scss
@@ -253,6 +253,7 @@
     padding: 0 36px;
     margin-bottom: 5px;
 
+    .status-icon-container,
     .error-icon-container {
       float: right;
     }
@@ -390,6 +391,28 @@ li.entry .error-icon-container {
   white-space: nowrap;
 }
 
+.status {
+  width: 18px;
+  height: 18px;
+}
+.sent .status {
+  display: inline-block;
+  @include color-svg('../images/check.svg', black);
+}
+.delivered .status {
+  display: inline-block;
+  @include color-svg('../images/double-check.svg', black);
+}
+.read .status {
+  display: inline-block;
+  @include color-svg('../images/double-check.svg', $blue);
+}
+.pending .status {
+  display: inline-block;
+  background: none;
+  &:before { content: '...'; }
+}
+
 .message-container,
 .message-list {
   list-style: none;
@@ -479,28 +502,6 @@ li.entry .error-icon-container {
         opacity: 1.0;
       }
     }
-  }
-
-  .status {
-    width: 18px;
-    height: 18px;
-  }
-  .sent .status {
-    display: inline-block;
-    @include color-svg('../images/check.svg', black);
-  }
-  .delivered .status {
-    display: inline-block;
-    @include color-svg('../images/double-check.svg', black);
-  }
-  .read .status {
-    display: inline-block;
-    @include color-svg('../images/double-check.svg', $blue);
-  }
-  .pending .status {
-    display: inline-block;
-    background: none;
-    &:before { content: '...'; }
   }
 
   .incoming {

--- a/stylesheets/_global.scss
+++ b/stylesheets/_global.scss
@@ -392,7 +392,6 @@ $avatar-size: 44px;
   margin: 0 0 0 $left-margin;
   width: calc(100% - #{$avatar-size} - #{$left-margin} - #{(4/14) + em});
   text-align: left;
-  cursor: pointer;
 
   p {
     overflow-x: hidden;
@@ -413,8 +412,8 @@ $avatar-size: 44px;
     font-size: $font-size-small;
   }
 
-  &.not-clickable {
-    cursor: default;
+  &.clickable {
+    cursor: pointer;
   }
 
   .verified-icon {

--- a/stylesheets/android-dark.scss
+++ b/stylesheets/android-dark.scss
@@ -133,6 +133,10 @@ $text-dark_l2: darken($text-dark, 30%);
     display: inline-block;
     @include color-svg('../images/double-check.svg', white);
   }
+  .read .status {
+    display: inline-block;
+    @include color-svg('../images/double-check.svg', $blue);
+  }
   .file-input .paperclip:before {
     content: '';
     display: inline-block;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1288,6 +1288,7 @@ input.search {
   .message-detail .contacts .contact-detail {
     padding: 0 36px;
     margin-bottom: 5px; }
+    .message-detail .contacts .contact-detail .status-icon-container,
     .message-detail .contacts .contact-detail .error-icon-container {
       float: right; }
     .message-detail .contacts .contact-detail button.error {
@@ -1392,6 +1393,34 @@ li.entry .error-icon-container {
   margin-right: 3px;
   white-space: nowrap; }
 
+.status {
+  width: 18px;
+  height: 18px; }
+
+.sent .status {
+  display: inline-block;
+  -webkit-mask: url("../images/check.svg") no-repeat center;
+  -webkit-mask-size: 100%;
+  background-color: black; }
+
+.delivered .status {
+  display: inline-block;
+  -webkit-mask: url("../images/double-check.svg") no-repeat center;
+  -webkit-mask-size: 100%;
+  background-color: black; }
+
+.read .status {
+  display: inline-block;
+  -webkit-mask: url("../images/double-check.svg") no-repeat center;
+  -webkit-mask-size: 100%;
+  background-color: #2090ea; }
+
+.pending .status {
+  display: inline-block;
+  background: none; }
+  .pending .status:before {
+    content: '...'; }
+
 .message-container,
 .message-list {
   list-style: none; }
@@ -1471,35 +1500,6 @@ li.entry .error-icon-container {
       .message-list .meta .timestamp:hover,
       .message-list .meta .status:hover {
         opacity: 1.0; }
-  .message-container .status,
-  .message-list .status {
-    width: 18px;
-    height: 18px; }
-  .message-container .sent .status,
-  .message-list .sent .status {
-    display: inline-block;
-    -webkit-mask: url("../images/check.svg") no-repeat center;
-    -webkit-mask-size: 100%;
-    background-color: black; }
-  .message-container .delivered .status,
-  .message-list .delivered .status {
-    display: inline-block;
-    -webkit-mask: url("../images/double-check.svg") no-repeat center;
-    -webkit-mask-size: 100%;
-    background-color: black; }
-  .message-container .read .status,
-  .message-list .read .status {
-    display: inline-block;
-    -webkit-mask: url("../images/double-check.svg") no-repeat center;
-    -webkit-mask-size: 100%;
-    background-color: #2090ea; }
-  .message-container .pending .status,
-  .message-list .pending .status {
-    display: inline-block;
-    background: none; }
-    .message-container .pending .status:before,
-    .message-list .pending .status:before {
-      content: '...'; }
   .message-container .incoming .avatar, .message-container .incoming .bubble,
   .message-list .incoming .avatar,
   .message-list .incoming .bubble {

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -1488,6 +1488,12 @@ li.entry .error-icon-container {
     -webkit-mask: url("../images/double-check.svg") no-repeat center;
     -webkit-mask-size: 100%;
     background-color: black; }
+  .message-container .read .status,
+  .message-list .read .status {
+    display: inline-block;
+    -webkit-mask: url("../images/double-check.svg") no-repeat center;
+    -webkit-mask-size: 100%;
+    background-color: #2090ea; }
   .message-container .pending .status,
   .message-list .pending .status {
     display: inline-block;
@@ -2352,6 +2358,11 @@ li.entry .error-icon-container {
     -webkit-mask: url("../images/double-check.svg") no-repeat center;
     -webkit-mask-size: 100%;
     background-color: white; }
+  .android-dark .read .status {
+    display: inline-block;
+    -webkit-mask: url("../images/double-check.svg") no-repeat center;
+    -webkit-mask-size: 100%;
+    background-color: #2090ea; }
   .android-dark .file-input .paperclip:before {
     content: '';
     display: inline-block;

--- a/stylesheets/manifest.css
+++ b/stylesheets/manifest.css
@@ -376,8 +376,7 @@ button.hamburger {
   display: inline-block;
   margin: 0 0 0 8px;
   width: calc(100% - 44px - 8px - 0.2857142857em);
-  text-align: left;
-  cursor: pointer; }
+  text-align: left; }
   .contact-details p {
     overflow-x: hidden;
     text-overflow: ellipsis; }
@@ -391,8 +390,8 @@ button.hamburger {
   .contact-details .number {
     color: #616161;
     font-size: 0.9285714286em; }
-  .contact-details.not-clickable {
-    cursor: default; }
+  .contact-details.clickable {
+    cursor: pointer; }
   .contact-details .verified-icon {
     -webkit-mask: url("../images/verified-check.svg") no-repeat center;
     -webkit-mask-size: 100%;


### PR DESCRIPTION
First pass at send/receive receipt messages...

Note some internal terminology have been changed. The messages/models formerly known as "read receipts" are now called "read syncs". These messages are exchanged only between linked devices and indicate that an incoming message was read on a linked master or sibling device.

The term "read receipts" now refers to ReceiptMessages of type READ. These messages are received from other Signal users and indicate that an outgoing message was read by that user.

ReceiptMessages can alternately be of type DELIVERY for encrypted delivery receipts. The delivery receipt event has been renamed and refactored slightly to handle them.

~TODO: Global opt-in/opt-out setting (or sync this from the phone?)~