### PR TITLE
Wait 5s after socket interruption before showing 'disconnected'

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,7 +105,9 @@ module.exports = function(grunt) {
         '!js/signal_protocol_store.js',
         '_locales/**/*'
       ],
-      options: { jshintrc: '.jshintrc' },
+      options: {
+        jshintrc: '.jshintrc'
+      },
     },
     dist: {
       src: [

--- a/js/background.js
+++ b/js/background.js
@@ -117,7 +117,7 @@
             appView.inboxView.networkStatusView.update();
         });
         Whisper.events.on('reconnectTimer', function() {
-            appView.inboxView.networkStatusView.setSocketReconnectInterval(60000);
+            appView.inboxView.networkStatusView.onReconnectTimer();
         });
         Whisper.events.on('contactsync', function() {
           if (appView.installView) {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37370,7 +37370,6 @@ Internal.SessionLock.queueJobForNumber = function queueJobForNumber(number, runJ
             clearTimeout(this.keepAliveTimer);
             clearTimeout(this.disconnectTimer);
             this.keepAliveTimer = setTimeout(function() {
-                console.log('Sending a keepalive message');
                 this.wsr.sendRequest({
                     verb: 'GET',
                     path: this.path,

--- a/js/views/network_status_view.js
+++ b/js/views/network_status_view.js
@@ -78,14 +78,13 @@
                     instructions = i18n('checkNetworkConnection');
                     hasInterruption = true;
                 break;
+                /* jshint -W086 */
                 case WebSocket.CLOSED:
+                default:
                     this.setOffline();
                     message = i18n('disconnected');
                     instructions = i18n('checkNetworkConnection');
                     hasInterruption = true;
-                break;
-                default:
-                    this.setOffline();
                 break;
             }
 

--- a/libtextsecure/websocket-resources.js
+++ b/libtextsecure/websocket-resources.js
@@ -182,7 +182,6 @@
             clearTimeout(this.keepAliveTimer);
             clearTimeout(this.disconnectTimer);
             this.keepAliveTimer = setTimeout(function() {
-                console.log('Sending a keepalive message');
                 this.wsr.sendRequest({
                     verb: 'GET',
                     path: this.path,

--- a/test/index.html
+++ b/test/index.html
@@ -583,7 +583,6 @@
   <script type="text/javascript" src="../js/storage.js" data-cover></script>
   <script type="text/javascript" src="../js/signal_protocol_store.js" data-cover></script>
   <script type="text/javascript" src="../js/libtextsecure.js" data-cover></script>
-  <script type="text/javascript" src="../js/backup.js" data-cover></script>
 
   <script type="text/javascript" src="../js/libphonenumber-util.js"></script>
   <script type="text/javascript" src="../js/models/messages.js" data-cover></script>
@@ -621,7 +620,7 @@
   <script type='text/javascript' src='../js/views/conversation_search_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/hint_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/inbox_view.js' data-cover></script>
-  <script type='text/javascript' src='../js/views/network_status_view.js'></script>
+  <script type='text/javascript' src='../js/views/network_status_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/confirmation_dialog_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/identicon_svg_view.js' data-cover></script>
   <script type='text/javascript' src='../js/views/settings_view.js' data-cover></script>


### PR DESCRIPTION
We're getting logs showing socket interruptions with near-immediate reconnects. We're not sure exactly what is causing the disconnects themselves, but because the involved downtime is so short, we think that we can hide the 'disconnected' status in these cases. 

A few theories on why disconnects are happening more often:
- Chrome Apps are shut down when they've been idle for a while, which keeps sockets relatively fresh.
- Electron more aggressively slows down the event loop on idle, which causes normal socket maintenance to be missed periodically.
- The Node.js library we now use for WebSockets is a little bit less reliable than Chrome naturally was, at least when used within the world of Electron.

You might be wondering why we're still using the new Node.js websocket implementation, given some of these theories. Well, with it we can connect to servers with self-signed certificates, as well as do our own certificate pinning. All without changing the OS. So we're gonna try to stick with this implementation for as long as we can.