### PR TITLE
setTimeout/setImmediate workaround for linux hangs

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37666,8 +37666,22 @@ var TextSecureServer = (function() {
         return true;
     }
 
+    // On Linux/Electron multiple quick web requests can result in the Node.js event
+    //   loop getting wedged. Bug: https://github.com/electron/electron/issues/10570
+    //   This forces the event loop to move.
+    function scheduleHangWorkaround() {
+        setTimeout(function() {
+            setImmediate(function() {
+                // noop
+            });
+        }, 1000);
+    }
+
     function createSocket(url) {
       var requestOptions = { ca: window.config.certificateAuthorities };
+
+      scheduleHangWorkaround();
+
       return new nodeWebSocket(url, null, null, null, requestOptions);
     }
 
@@ -37728,6 +37742,8 @@ var TextSecureServer = (function() {
                 reject(HTTPError(xhr.status, xhr.statusText, options.stack));
             };
             xhr.send( options.data || null );
+
+            scheduleHangWorkaround();
         });
     }
 

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -24,8 +24,22 @@ var TextSecureServer = (function() {
         return true;
     }
 
+    // On Linux/Electron multiple quick web requests can result in the Node.js event
+    //   loop getting wedged. Bug: https://github.com/electron/electron/issues/10570
+    //   This forces the event loop to move.
+    function scheduleHangWorkaround() {
+        setTimeout(function() {
+            setImmediate(function() {
+                // noop
+            });
+        }, 1000);
+    }
+
     function createSocket(url) {
       var requestOptions = { ca: window.config.certificateAuthorities };
+
+      scheduleHangWorkaround();
+
       return new nodeWebSocket(url, null, null, null, requestOptions);
     }
 
@@ -86,6 +100,8 @@ var TextSecureServer = (function() {
                 reject(HTTPError(xhr.status, xhr.statusText, options.stack));
             };
             xhr.send( options.data || null );
+
+            scheduleHangWorkaround();
         });
     }
 

--- a/test/index.html
+++ b/test/index.html
@@ -583,7 +583,6 @@
   <script type="text/javascript" src="../js/storage.js" data-cover></script>
   <script type="text/javascript" src="../js/signal_protocol_store.js" data-cover></script>
   <script type="text/javascript" src="../js/libtextsecure.js" data-cover></script>
-  <script type="text/javascript" src="../js/backup.js" data-cover></script>
 
   <script type="text/javascript" src="../js/libphonenumber-util.js"></script>
   <script type="text/javascript" src="../js/models/messages.js" data-cover></script>


### PR DESCRIPTION
This week we discovered an unfortunate Electron bug leading to hangs in our web request calls. When we make two requests right in a row, the second very frequently doesn't return - on Linux only: https://github.com/electron/electron/issues/10570

It turns out that any async call can get that Node.js event loop running again, so in this workaround we call `setImmediate()` - after we try to open a websocket (signing up, receiving messages), and after we make a standalone web request (sending a message). The good news is that these events aren't extremely frequent, the call is very low overhead.

I've verified that this does indeed fix the problematic behavior on Linux.

Also, a little bonus - `backup.js` fails when directly referenced from `test.html` because it pulls in Node.js dependencies. Removed!