### PR TITLE
Fix RangeError on non-file drag/drop events

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -208,6 +208,9 @@
             'dragleave': 'sendToFileInput'
         },
         sendToFileInput: function(e) {
+            if (e.originalEvent.dataTransfer.types[0] != 'Files') {
+                return;
+            }
             this.fileInput.$el.trigger(e);
         },
 


### PR DESCRIPTION
Just noticed some spurious "RangeError: Maximum call stack size exceeded" statements in the console. Investigation reveals they can be repro'd by selecting text in a message, and then dragging the text around.

<img width="1074" alt="schermafbeelding 2017-09-22 om 3 09 08 pm" src="https://user-images.githubusercontent.com/1039940/30745894-1f363fb2-9fa8-11e7-8ca8-2ab83d99249e.png">
