### PR TITLE
Log call messages

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38837,10 +38837,16 @@ MessageReceiver.prototype.extend({
             return this.handleDataMessage(envelope, content.dataMessage);
         } else if (content.nullMessage) {
             return this.handleNullMessage(envelope, content.nullMessage);
+        } else if (content.callMessage) {
+            return this.handleCallMessage(envelope, content.callMessage);
         } else {
             this.removeFromCache(envelope);
             throw new Error('Unsupported content message');
         }
+    },
+    handleCallMessage: function(envelope, nullMessage) {
+        console.log('call message from', this.getEnvelopeId(envelope));
+        this.removeFromCache(envelope);
     },
     handleNullMessage: function(envelope, nullMessage) {
         console.log('null message from', this.getEnvelopeId(envelope));

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -483,10 +483,16 @@ MessageReceiver.prototype.extend({
             return this.handleDataMessage(envelope, content.dataMessage);
         } else if (content.nullMessage) {
             return this.handleNullMessage(envelope, content.nullMessage);
+        } else if (content.callMessage) {
+            return this.handleCallMessage(envelope, content.callMessage);
         } else {
             this.removeFromCache(envelope);
             throw new Error('Unsupported content message');
         }
+    },
+    handleCallMessage: function(envelope, nullMessage) {
+        console.log('call message from', this.getEnvelopeId(envelope));
+        this.removeFromCache(envelope);
     },
     handleNullMessage: function(envelope, nullMessage) {
         console.log('null message from', this.getEnvelopeId(envelope));


### PR DESCRIPTION
Rather than throw an error, just log call messages and drop them. This way we distinguish them from incorrectly encoded content messages, and don't insert unnecessary red flags and stacktraces in debug logs, as seen in https://github.com/WhisperSystems/Signal-Desktop/issues/520#issuecomment-331697317
