### PR TITLE
Only show notifications when done with sync

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -179,6 +179,8 @@
             retryCached: connectCount === 1,
         };
 
+        Whisper.Notifications.disable(); // avoid notification flood until empty
+
         // initialize the socket and start listening for messages
         messageReceiver = new textsecure.MessageReceiver(
             SERVER_URL, USERNAME, PASSWORD, mySignalingKey, options
@@ -239,6 +241,8 @@
                 view.onEmpty();
             }
         }, 500);
+
+        Whisper.Notifications.enable();
     }
     function onProgress(ev) {
         var count = ev.count;
@@ -509,9 +513,7 @@
                     }
 
                     conversation.trigger('newmessage', message);
-                    if (initialLoadComplete) {
-                        conversation.notify(message);
-                    }
+                    conversation.notify(message);
 
                     if (ev.confirm) {
                         ev.confirm();

--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -1073,14 +1073,9 @@
         if (!message.isIncoming()) {
             return Promise.resolve();
         }
-        if (window.isFocused()) {
-            return Promise.resolve();
-        }
-
-        window.drawAttention();
         var conversationId = this.id;
 
-        ConversationController.getOrCreateAndWait(message.get('source'), 'private')
+        return ConversationController.getOrCreateAndWait(message.get('source'), 'private')
             .then(function(sender) {
                 return sender.getNotificationIcon().then(function(iconUrl) {
                     console.log('adding notification');

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -326,10 +326,7 @@
                 this.send(promise);
             }
         },
-        handleDataMessage: function(dataMessage, confirm, options) {
-            options = options || {};
-            _.defaults(options, {initialLoadComplete: true});
-
+        handleDataMessage: function(dataMessage, confirm) {
             // This function is called from the background script in a few scenarios:
             //   1. on an incoming message
             //   2. on a sent message sync'd from another device
@@ -496,7 +493,7 @@
                                         //   because we need to start expiration timers, etc.
                                         message.markRead();
                                     }
-                                    if (message.get('unread') && options.initialLoadComplete) {
+                                    if (message.get('unread')) {
                                         conversation.notify(message);
                                     }
 

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -12,25 +12,37 @@
         MESSAGE : 'message'
     };
 
+    var enabled = false;
+
     Whisper.Notifications = new (Backbone.Collection.extend({
         initialize: function() {
             this.on('add', this.update);
             this.on('remove', this.onRemove);
         },
-        onclick: function() {
-            var conversation;
-            var last = this.last();
-            if (last) {
-                conversation = ConversationController.get(last.get('conversationId'));
-            }
+        onClick: function(conversationId) {
+            var conversation = ConversationController.get(conversationId);
             this.trigger('click', conversation);
-            this.clear();
         },
         update: function() {
-            console.log('updating notifications', this.length);
+            console.log(
+                'updating notifications - count:', this.length,
+                'focused:', window.isFocused(),
+                'enabled:', enabled
+            );
+            if (!enabled) {
+                return; // wait til we are re-enabled
+            }
             if (this.length === 0) {
                 return;
             }
+            if (window.isFocused()) {
+                // The window is focused. Consider yourself notified.
+                this.clear();
+                return;
+            }
+
+            window.drawAttention();
+
             var audioNotification = storage.get('audio-notification') || false;
 
             var setting = storage.get('notification-setting') || 'message';
@@ -59,7 +71,11 @@
                 iconUrl = last.get('iconUrl');
                 break;
               case SETTINGS.MESSAGE:
-                title = last.get('title');
+                if (this.length === 1) {
+                  title = last.get('title');
+                } else {
+                  title = newMessageCount;
+                }
                 message = last.get('message');
                 iconUrl = last.get('iconUrl');
                 break;
@@ -70,26 +86,32 @@
                 tag    : 'signal',
                 silent : !audioNotification
             });
-            notification.onclick = this.onclick.bind(this);
+
+            notification.onclick = this.onClick.bind(this, last.get('conversationId'));
+
+            // We don't want to notify the user about these same messages again
+            this.clear();
         },
         getSetting: function() {
-            return storage.get('notification-setting') || 'message';
-        },
-        showMessage: function() {
-            return this.getSetting() === SETTINGS.MESSAGE;
-        },
-        showSender: function() {
-            var setting = this.getSetting();
-            return (setting === SETTINGS.MESSAGE || setting === SETTINGS.NAME);
+            return storage.get('notification-setting') || SETTINGS.MESSAGE;
         },
         onRemove: function() {
             console.log('remove notification');
-            if (this.length === 0) {
-                return;
-            }
         },
         clear: function() {
+            console.log('remove all notifications');
             this.reset([]);
-        }
+        },
+        enable: function() {
+            var update = !enabled;
+            enabled = true;
+            if (update) {
+              this.update();
+            }
+        },
+        disable: function() {
+            enabled = false;
+        },
+
     }))();
 })();


### PR DESCRIPTION
Instead of adding OS notifications immediately when we find out about a new unread message, we wait until we get the 'empty' event from `MessageReceiver`. This tells us that our queue is empty.

This then prevents the parade of notifications if a machine wakes up from sleep. Basically covers situations that the loading screen doesn't already.