### PR TITLE
Deprecated: Remove check for banner, now always show

### DIFF
--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -155,7 +155,7 @@
                     this.appLoadingScreen = null;
                 }
                 this.showMigrationScreen();
-            } else if (storage.get('migrationEnabled')) {
+            } else {
                 var migrationBanner = new Whisper.MigrationAlertBanner().render();
                 migrationBanner.$el.prependTo(this.$el);
             }


### PR DESCRIPTION
This turns on the deprecation banner for everyone. We'll merge it when we're ready to move everyone over to Electron.