### PR TITLE
Only retry messages on startup, not every sockect reconnect

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -157,6 +157,7 @@
       }
     });
 
+    var connectCount = 0;
     function connect(firstRun) {
         window.removeEventListener('online', connect);
 
@@ -169,9 +170,14 @@
         var PASSWORD = storage.get('password');
         var mySignalingKey = storage.get('signaling_key');
 
+        connectCount += 1;
+        var options = {
+            retryCached: connectCount === 1,
+        };
+
         // initialize the socket and start listening for messages
         messageReceiver = new textsecure.MessageReceiver(
-            SERVER_URL, USERNAME, PASSWORD, mySignalingKey
+            SERVER_URL, USERNAME, PASSWORD, mySignalingKey, options
         );
         messageReceiver.addEventListener('message', onMessageReceived);
         messageReceiver.addEventListener('receipt', onDeliveryReceipt);

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38356,7 +38356,9 @@ var TextSecureServer = (function() {
  * vim: ts=4:sw=4:expandtab
  */
 
-function MessageReceiver(url, username, password, signalingKey) {
+function MessageReceiver(url, username, password, signalingKey, options) {
+    options = options || {};
+
     this.count = 0;
 
     this.url = url;
@@ -38368,6 +38370,12 @@ function MessageReceiver(url, username, password, signalingKey) {
     var address = libsignal.SignalProtocolAddress.fromString(username);
     this.number = address.getName();
     this.deviceId = address.getDeviceId();
+
+    this.pending = Promise.resolve();
+
+    if (options.retryCached) {
+        this.pending = this.queueAllCached();
+    }
 }
 
 MessageReceiver.prototype = new textsecure.EventTarget();
@@ -38386,8 +38394,6 @@ MessageReceiver.prototype.extend({
             handleRequest: this.handleRequest.bind(this),
             keepalive: { path: '/v1/keepalive', disconnect: true }
         });
-
-        this.pending = this.queueAllCached();
 
         // Ensures that an immediate 'empty' event from the websocket will fire only after
         //   all cached envelopes are processed.
@@ -39200,8 +39206,8 @@ MessageReceiver.prototype.extend({
 
 window.textsecure = window.textsecure || {};
 
-textsecure.MessageReceiver = function(url, username, password, signalingKey) {
-    var messageReceiver = new MessageReceiver(url, username, password, signalingKey);
+textsecure.MessageReceiver = function(url, username, password, signalingKey, options) {
+    var messageReceiver = new MessageReceiver(url, username, password, signalingKey, options);
     this.addEventListener    = messageReceiver.addEventListener.bind(messageReceiver);
     this.removeEventListener = messageReceiver.removeEventListener.bind(messageReceiver);
     this.getStatus           = messageReceiver.getStatus.bind(messageReceiver);


### PR DESCRIPTION
Pretty simple, really. It's a little more involved than you might expect, since multiple `MessageReceiver` instances may be created over the lifetime of the process.

