### PR TITLE
Further workaround to try to push node.js event loop forward

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -39,5 +39,10 @@
   window.nodeXMLHttpRequest = require("./js/XMLHttpRequest").XMLHttpRequest;
   window.nodeWebSocket = require("websocket").w3cwebsocket;
 
+  // Linux seems to periodically let the event loop stop, so this is a global workaround
+  setInterval(function() {
+    setImmediate(function() {});
+  }, 1000);
+
   window.EmojiConvertor = require('emoji-js');
 })();


### PR DESCRIPTION
We're still having problems with the Node.js websocket in Electron, tracked here: https://github.com/WhisperSystems/Signal-Desktop/issues/1075

This takes our workaround and amps it up. Instead of calling `setImmediate` after making a web request, we do it every second. I'm hoping that this extreme approach solves the problem, and then we can do the work to pare back as necessary.