### PR TITLE
Disconnect from socket faster on complete loss of network access

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -149,9 +149,9 @@
     Whisper.events.on('start-shutdown', function() {
       if (messageReceiver) {
         messageReceiver.close().then(function() {
-          messageReceiver = null;
           Whisper.events.trigger('shutdown-complete');
         });
+        messageReceiver = null;
       } else {
         Whisper.events.trigger('shutdown-complete');
       }
@@ -164,7 +164,10 @@
         if (!Whisper.Registration.everDone()) { return; }
         if (Whisper.Import.isIncomplete()) { return; }
 
-        if (messageReceiver) { messageReceiver.close(); }
+        if (messageReceiver) {
+            messageReceiver.close();
+            messageReceiver = null;
+        }
 
         var USERNAME = storage.get('number_id');
         var PASSWORD = storage.get('password');

--- a/js/background.js
+++ b/js/background.js
@@ -159,6 +159,7 @@
 
     function connect(firstRun) {
         window.removeEventListener('online', connect);
+        window.addEventListener('offline', disconnect);
 
         if (!Whisper.Registration.everDone()) { return; }
         if (Whisper.Import.isIncomplete()) { return; }
@@ -439,6 +440,17 @@
         return message;
     }
 
+    function disconnect() {
+        window.removeEventListener('offline', disconnect);
+        window.addEventListener('online', connect);
+
+        console.log('offline');
+        if (messageReceiver) {
+            messageReceiver.close();
+            messageReceiver = null;
+        }
+    }
+
     function onError(ev) {
         var error = ev.error;
         console.log(error);
@@ -457,10 +469,6 @@
                 setTimeout(connect, 60000);
 
                 Whisper.events.trigger('reconnectTimer');
-            } else {
-                console.log('offline');
-                if (messageReceiver) { messageReceiver.close(); }
-                window.addEventListener('online', connect);
             }
             return;
         }

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38394,6 +38394,7 @@ MessageReceiver.prototype.extend({
         this.incoming = [this.pending];
     },
     close: function() {
+        this.calledClose = true;
         this.socket.close(3000, 'called close');
         return this.drain();
     },
@@ -38407,7 +38408,17 @@ MessageReceiver.prototype.extend({
         return Promise.all(this.dispatchEvent(event));
     },
     onclose: function(ev) {
-        console.log('websocket closed', ev.code, ev.reason || '');
+        console.log(
+            'websocket closed',
+            ev.code,
+            ev.reason || '',
+            'calledClose:',
+            this.calledClose
+        );
+
+        if (this.calledClose) {
+            return;
+        }
         if (ev.code === 3000) {
             return;
         }

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -40,6 +40,7 @@ MessageReceiver.prototype.extend({
         this.incoming = [this.pending];
     },
     close: function() {
+        this.calledClose = true;
         this.socket.close(3000, 'called close');
         return this.drain();
     },
@@ -53,7 +54,17 @@ MessageReceiver.prototype.extend({
         return Promise.all(this.dispatchEvent(event));
     },
     onclose: function(ev) {
-        console.log('websocket closed', ev.code, ev.reason || '');
+        console.log(
+            'websocket closed',
+            ev.code,
+            ev.reason || '',
+            'calledClose:',
+            this.calledClose
+        );
+
+        if (this.calledClose) {
+            return;
+        }
         if (ev.code === 3000) {
             return;
         }


### PR DESCRIPTION
Today we wait for a keepalive request to fail, but those only happen every 55 seconds. This change immediately forces a disconnect in the case that the browser tells us that we're offline.