### PR TITLE
Add certificate name for windows code-signing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,7 @@ build_script:
   - yarn run icon-gen
   - node build\grunt.js
   - node_modules\.bin\build --em.environment=%SIGNAL_ENV% --publish=never
+  - type package.json | findstr /v certificateSubjectName > package.json
 
 test_script:
   - node build\grunt.js test-release:win

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,8 @@ install:
 build_script:
   - yarn run icon-gen
   - node build\grunt.js
-  - type package.json | findstr /v certificateSubjectName > package.json
+  - type package.json | findstr /v certificateSubjectName > temp.json
+  - move temp.json package.json
   - node_modules\.bin\build --em.environment=%SIGNAL_ENV% --publish=never
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ install:
 build_script:
   - yarn run icon-gen
   - node build\grunt.js
-  - node_modules\.bin\build --em.environment=%SIGNAL_ENV% --publish=never
   - type package.json | findstr /v certificateSubjectName > package.json
+  - node_modules\.bin\build --em.environment=%SIGNAL_ENV% --publish=never
 
 test_script:
   - node build\grunt.js test-release:win

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "win": {
       "asarUnpack": "node_modules/spellchecker/vendor/hunspell_dictionaries",
       "artifactName": "${productName}-Setup_${version}.${ext}",
+      "certificateSubjectName": "Signal",
       "icon": "build/icons/win/icon.ico",
       "publish": {
         "provider": "s3",


### PR DESCRIPTION
Woo! It's here!

`electron-builder` supports our extended validation code-signing cert, but only on windows. Our release process must now include a signing step on windows.

Also: Moving to signed windows builds will require that all of our windows users reinstall from scratch, because auto-update will very likely reject the new builds with a different signature.