### PR TITLE
Update strings for fa, no, pt_BR, pt_PT, ro, zh_CN, zh_TW

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -54,7 +54,7 @@
       "description": "Title of the popup window used to select data previously exported"
     },
     "importError": {
-      "message": "Unfortunately, something went wrong during the import. <p>First, double-check your target directory. It should start with 'Signal Export.'</p><p>Next, try with a new export of your data from the Chrome App.</p>If that still fails, please <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/215188737-How-do-I-submit-a-debug-log-from-the-Desktop-'>submit a debug log</a> so we can help you get migrated!",
+      "message": "Unfortunately, something went wrong during the import. <p>First, double-check your target directory. It should start with 'Signal Export.'</p><p>Next, try with a new export of your data from the Chrome App.</p>If that still fails, please <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/215188737'>submit a debug log</a> so we can help you get migrated!",
       "description": "Message shown if the import went wrong."
     },
     "tryAgain": {

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -12,11 +12,11 @@
         "description": "Label for a selectable option in the message expiration timer menu"
     },
     "view": {
-        "message": "View",
+        "message": "نمایش",
         "description": "Used as a label on a button allowing user to see more information"
     },
     "upgradingDatabase": {
-        "message": "Upgrading database. This may take some time...",
+        "message": "در حال به‌روزرسانی پابگاه داده. ممکن است کمی طول بکشد...",
         "description": "Message shown on the loading screen when we're changing database structure on first run of a new version"
     },
     "lastSynced": {
@@ -178,7 +178,7 @@
         "description": ""
     },
     "delete": {
-        "message": "Delete",
+        "message": "پاک کن",
         "description": ""
     },
     "verified": {
@@ -312,7 +312,7 @@
         "description": "Placeholder text in the search input"
     },
     "someRecipientsFailed": {
-        "message": "Some recipients failed.",
+        "message": "برخی دریافت‌ها با مشکل مواجه شد.",
         "description": "When you send to multiple recipients via a group, and the message went to some recipients but not others."
     },
     "noNameOrMessage": {
@@ -398,7 +398,7 @@
         "description": "Very short format indicating current timer setting in the conversation header"
     },
     "loadingMessages": {
-        "message": "Loading messages. $count$ so far...",
+        "message": "در حال بارگذاری پیام‌ها. تاکنون $count$ ...",
         "description": "Message shown on the loading screen when we're catching up on the backlog of messages",
         "placeholders": {
             "count": {
@@ -554,7 +554,7 @@
         "description": "Placeholder text in the message entry field"
     },
     "me": {
-        "message": "Me",
+        "message": "من",
         "description": "The label for yourself when shown in a group member list"
     },
     "mediaMessage": {
@@ -574,7 +574,7 @@
         "description": ""
     },
     "deleteMessage": {
-        "message": "Delete this message",
+        "message": "پاک کردن این پیام",
         "description": ""
     },
     "autoUpdateNewVersionInstructions": {
@@ -656,7 +656,7 @@
         "description": "Hover text for attachment filenames"
     },
     "sendAnyway": {
-        "message": "Send Anyway",
+        "message": "به هر حال بفرست",
         "description": "Used on a warning dialog to make it clear that it might be risky to send the message."
     },
     "youMarkedAsVerified": {
@@ -694,7 +694,7 @@
         "description": "Label for a selectable option in the message expiration timer menu"
     },
     "showMembers": {
-        "message": "Show members",
+        "message": "نمایش اعضا",
         "description": ""
     },
     "youMarkedAsNotVerifiedOtherDevice": {
@@ -722,11 +722,11 @@
         "description": "Text displayed before the phone number that the user is in the process of linking with"
     },
     "groupMembers": {
-        "message": "Group members",
+        "message": "اعضای گروه",
         "description": ""
     },
     "loading": {
-        "message": "Loading...",
+        "message": "در حال بارگذاری...",
         "description": "Message shown on the loading screen before we've loaded any messages"
     },
     "newMessages": {
@@ -870,7 +870,7 @@
         "description": "Header for notification settings"
     },
     "tryAgain": {
-        "message": "Try again",
+        "message": "تلاش دوباره",
         "description": "Button shown if the user runs into an error during import, allowing them to start over"
     },
     "resend": {

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -12,7 +12,7 @@
         "description": "Label for a selectable option in the message expiration timer menu"
     },
     "view": {
-        "message": "View",
+        "message": "Se",
         "description": "Used as a label on a button allowing user to see more information"
     },
     "upgradingDatabase": {
@@ -178,7 +178,7 @@
         "description": ""
     },
     "delete": {
-        "message": "Delete",
+        "message": "Slett",
         "description": ""
     },
     "verified": {
@@ -554,7 +554,7 @@
         "description": "Placeholder text in the message entry field"
     },
     "me": {
-        "message": "Me",
+        "message": "Meg",
         "description": "The label for yourself when shown in a group member list"
     },
     "mediaMessage": {
@@ -574,7 +574,7 @@
         "description": ""
     },
     "deleteMessage": {
-        "message": "Delete this message",
+        "message": "Slett denne meldingen",
         "description": ""
     },
     "autoUpdateNewVersionInstructions": {
@@ -656,7 +656,7 @@
         "description": "Hover text for attachment filenames"
     },
     "sendAnyway": {
-        "message": "Send Anyway",
+        "message": "Send allikevel",
         "description": "Used on a warning dialog to make it clear that it might be risky to send the message."
     },
     "youMarkedAsVerified": {
@@ -694,7 +694,7 @@
         "description": "Label for a selectable option in the message expiration timer menu"
     },
     "showMembers": {
-        "message": "Show members",
+        "message": "Vis medlemmer",
         "description": ""
     },
     "youMarkedAsNotVerifiedOtherDevice": {
@@ -722,11 +722,11 @@
         "description": "Text displayed before the phone number that the user is in the process of linking with"
     },
     "groupMembers": {
-        "message": "Group members",
+        "message": "Gruppemedlemmer",
         "description": ""
     },
     "loading": {
-        "message": "Loading...",
+        "message": "Laster...",
         "description": "Message shown on the loading screen before we've loaded any messages"
     },
     "newMessages": {

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -4,7 +4,7 @@
         "description": "Alt text for button to take user down to bottom of conversation, shown when user scrolls up"
     },
     "importChooserTitle": {
-        "message": "Choose directory with exported data",
+        "message": "Escolha o diretório com os dados exportados",
         "description": "Title of the popup window used to select data previously exported"
     },
     "timerOption_10_seconds": {
@@ -34,7 +34,7 @@
         }
     },
     "importInstructions": {
-        "message": "The first step is to tell us where you previously exported your Signal data. It will be a directory whose name starts with 'Signal Export.'",
+        "message": "O primeiro passo é informar onde foi realizada a exportação de dados anteriormente. O diretório começa com 'Signal Export'.",
         "description": "Description of the export process"
     },
     "unsupportedAttachment": {
@@ -92,7 +92,7 @@
         "description": "Displays the details of a key change"
     },
     "verifyHelp": {
-        "message": "Se você desejar verificar a segurança da sua criptografia ponta-a-ponta com $name$, compare os números acima com os números no aparelho desse contato.",
+        "message": "Se você desejar verificar a segurança da sua criptografia ponta-a-ponta com $name$, compare os números acima com os números no aparelho dessa pessoa.",
         "description": "",
         "placeholders": {
             "name": {
@@ -146,7 +146,7 @@
         "description": "Obvious instructions for when a user's computer loses its network connection"
     },
     "notificationSettingsDialog": {
-        "message": "Quando a mensagem chegar, exibir notificações que mostrem:",
+        "message": "Quando mensagens chegarem, exibir notificações que mostrem:",
         "description": "Explain the purpose of the notification settings"
     },
     "timestamp_h": {
@@ -270,7 +270,7 @@
         "description": "Label for setting notifications to display sender name only"
     },
     "autoUpdateLaterButtonLabel": {
-        "message": "Later",
+        "message": "Mais tarde",
         "description": ""
     },
     "from": {
@@ -282,7 +282,7 @@
         "description": "Confirmation dialog text that asks the user if they really wish to delete the conversation. Answer buttons use the strings 'ok' and 'cancel'. The deletion is permanent, i.e. it cannot be undone."
     },
     "installImport": {
-        "message": "Set up with Chrome App export",
+        "message": "Configurar com dados exportados do aplicativo Chrome",
         "description": "One of two choices presented on the screen shown on first launch"
     },
     "unlinkedWarning": {
@@ -312,7 +312,7 @@
         "description": "Placeholder text in the search input"
     },
     "someRecipientsFailed": {
-        "message": "Houve falha para alguns destinatários.",
+        "message": "Falha em alguns envios.",
         "description": "When you send to multiple recipients via a group, and the message went to some recipients but not others."
     },
     "noNameOrMessage": {
@@ -346,11 +346,11 @@
         "description": "Text that links to a support article on verifying safety numbers"
     },
     "installNew": {
-        "message": "Set up as new install",
+        "message": "Configurar como nova instalação",
         "description": "One of two choices presented on the screen shown on first launch"
     },
     "importing": {
-        "message": "Please wait while we import your data...",
+        "message": "Por favor, aguarde enquanto importamos seus dados...",
         "description": "Shown as we are loading the user's data from disk"
     },
     "unreadMessages": {
@@ -502,11 +502,11 @@
         "description": "Very short format indicating current timer setting in the conversation header"
     },
     "autoUpdateRestartButtonLabel": {
-        "message": "Restart",
+        "message": "Reiniciar",
         "description": ""
     },
     "importButton": {
-        "message": "Import",
+        "message": "Importar",
         "description": ""
     },
     "sync": {
@@ -578,7 +578,7 @@
         "description": ""
     },
     "autoUpdateNewVersionInstructions": {
-        "message": "Press Restart to apply the updates.",
+        "message": "Por favor, reinicie o aplicativo para aplicar as atualizações.",
         "description": ""
     },
     "timerOption_0_seconds": {
@@ -586,7 +586,7 @@
         "description": "Label for option to turn off message expiration in the timer menu"
     },
     "importError": {
-        "message": "Unfortunately, something went wrong during the import. <p>First, double-check your target directory. It should start with 'Signal Export.'</p><p>Next, try with a new export of your data from the Chrome App.</p>If that still fails, please <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/215188737-How-do-I-submit-a-debug-log-from-the-Desktop-'>submit a debug log</a> so we can help you get migrated!",
+        "message": "Infelizmente ocorreu um erro durante a importação. <p>Primeiro, confira seu diretório de destino. Ele deve começar com 'Signal Export'.</p><p>Em seguida, tente novamente, usando o aplicativo Chrome para exportar seus dados.</p>Se o erro persistir <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/215188737-How-do-I-submit-a-debug-log-from-the-Desktop-'>envie-nos um relatório de debug</a> para que possamos te ajudar a realizar a migração!",
         "description": "Message shown if the import went wrong."
     },
     "installAndroidInstructions": {
@@ -598,7 +598,7 @@
         "description": "When a person inputs a number that is invalid"
     },
     "importComplete": {
-        "message": "We've successfully loaded your data. The next step is to restart the application!",
+        "message": "Importamos seus dados com sucesso. O próximo passo é reiniciar o aplicativo!",
         "description": "Shown when the import is complete."
     },
     "installWelcome": {
@@ -632,7 +632,7 @@
         "description": "Informational label, appears on messages that failed to send"
     },
     "autoUpdateNewVersionMessage": {
-        "message": "There is a new version of Signal available.",
+        "message": "Uma nova versão do Signal está disponível.",
         "description": ""
     },
     "disableNotifications": {
@@ -698,7 +698,7 @@
         "description": ""
     },
     "youMarkedAsNotVerifiedOtherDevice": {
-        "message": "Você marcou o seu número de segurança $name$como não verificado, usando um outro aparelho.",
+        "message": "Você marcou o seu número de segurança com $name$como não verificado, usando um outro aparelho.",
         "description": "Shown in the conversation history when we discover that the user marked a contact as not verified on another device.",
         "placeholders": {
             "name": {
@@ -708,7 +708,7 @@
         }
     },
     "installSignalLink": {
-        "message": "First, install <a $a_params$>Signal</a> on your mobile phone. We'll link your devices and keep your messages in sync.",
+        "message": "Primeiro, instale <a $a_params$>Signal</a> no seu celular. Nós vamos religar os seus aparelhos e manter suas mensagens sincronizadas.",
         "description": "Prompt the user to install Signal on their phone before linking",
         "placeholders": {
             "a_params": {
@@ -760,7 +760,7 @@
         }
     },
     "identityKeyErrorOnSend": {
-        "message": "O seu número de segurança com $name$mudou. Isso pode significar uma tentativa de interceptação das suas comunicações ou somente que $name$ reinstalou Signal. Recomendamos que você verifique o seu número de segurança com com esse contato.",
+        "message": "O seu número de segurança com $name$mudou. Isso pode significar uma tentativa de interceptação das suas comunicações ou somente que $name$ reinstalou Signal. Recomendamos que você verifique o seu número de segurança com essa pessoa.",
         "description": "Shown when user clicks on a failed recipient in the message detail view after an identity key change",
         "placeholders": {
             "name": {
@@ -790,7 +790,7 @@
         "description": "When export is complete, a button shows which sends user to Signal Desktop install instructions"
     },
     "exportChooserTitle": {
-        "message": "Choose target directory for data",
+        "message": "Escolha um diretório para armazenar os dados",
         "description": "Title of the popup window used to select data storage location"
     },
     "verify": {
@@ -798,7 +798,7 @@
         "description": ""
     },
     "exportButton": {
-        "message": "Export",
+        "message": "Exportar",
         "description": ""
     },
     "timerOption_10_seconds_abbreviated": {
@@ -822,7 +822,7 @@
         "description": ""
     },
     "changedSinceVerifiedMultiple": {
-        "message": "Os seus números de segurança com varios membros mudaram desde a última vez que você os verificou. Isso pode significar uma tentativa de interceptação das suas comunicações ou somente que esses contatos reinstalaram Signal.",
+        "message": "Os seus números de segurança com vários membros de grupos mudaram desde a última vez que você os verificou. Isso pode significar uma tentativa de interceptação das suas comunicações ou somente que esses contatos reinstalaram Signal.",
         "description": "Shown on confirmation dialog when user attempts to send a message"
     },
     "submitDebugLog": {
@@ -854,7 +854,7 @@
         }
     },
     "autoUpdateNewVersionTitle": {
-        "message": "Signal update available",
+        "message": "Atualização do Signal disponível",
         "description": ""
     },
     "timerOption_30_seconds_abbreviated": {
@@ -870,7 +870,7 @@
         "description": "Header for notification settings"
     },
     "tryAgain": {
-        "message": "Try again",
+        "message": "Tentar novamente",
         "description": "Button shown if the user runs into an error during import, allowing them to start over"
     },
     "resend": {

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -4,7 +4,7 @@
         "description": "Alt text for button to take user down to bottom of conversation, shown when user scrolls up"
     },
     "importChooserTitle": {
-        "message": "Choose directory with exported data",
+        "message": "Escolha a pasta exportar os dados",
         "description": "Title of the popup window used to select data previously exported"
     },
     "timerOption_10_seconds": {
@@ -34,7 +34,7 @@
         }
     },
     "importInstructions": {
-        "message": "The first step is to tell us where you previously exported your Signal data. It will be a directory whose name starts with 'Signal Export.'",
+        "message": "O primeiro passo será indicar onde os dados foram exportados. Será uma pasta em que o nome começa por \"Signal Export\".",
         "description": "Description of the export process"
     },
     "unsupportedAttachment": {
@@ -146,7 +146,7 @@
         "description": "Obvious instructions for when a user's computer loses its network connection"
     },
     "notificationSettingsDialog": {
-        "message": "Quando receber uma mensagem, as notificações irão revelar:",
+        "message": "Quando receber uma mensagem, mostrar notificações que revelem:",
         "description": "Explain the purpose of the notification settings"
     },
     "timestamp_h": {
@@ -172,10 +172,6 @@
     "deleteMessages": {
         "message": "Apagar mensagens",
         "description": "Menu item for deleting messages, title case."
-    },
-    "confirmMigration": {
-        "message": "Iniciar processo de migração? Não vai poder enviar ou receber mensagens do Signal através desta aplicação enquanto a migração estiver a ser efectuada.",
-        "description": "Confirmation dialogue when beginning migration"
     },
     "incomingError": {
         "message": "Erro a receber mensagem.",
@@ -231,14 +227,6 @@
         "message": "Enviada",
         "description": "Label for the time a message was sent"
     },
-    "migrationWarning": {
-        "message": "O Signal Desktop para o Chrome foi descontinuada. Pretende migrar para o novo Signal Desktop agora?",
-        "description": "Warning notification that this version of the app has been deprecated and the user must migrate"
-    },
-    "migrate": {
-        "message": "Migrar",
-        "description": "Button label to begin migrating this client to Electron"
-    },
     "theyChangedTheTimer": {
         "message": "$name$ definiu o temporizador para $time$",
         "description": "Message displayed when someone else changes the message expiration timer in a conversation.",
@@ -282,7 +270,7 @@
         "description": "Label for setting notifications to display sender name only"
     },
     "autoUpdateLaterButtonLabel": {
-        "message": "Later",
+        "message": "Mais tarde",
         "description": ""
     },
     "from": {
@@ -294,7 +282,7 @@
         "description": "Confirmation dialog text that asks the user if they really wish to delete the conversation. Answer buttons use the strings 'ok' and 'cancel'. The deletion is permanent, i.e. it cannot be undone."
     },
     "installImport": {
-        "message": "Set up with Chrome App export",
+        "message": "Configurar com dados exportados da Chrome App. ",
         "description": "One of two choices presented on the screen shown on first launch"
     },
     "unlinkedWarning": {
@@ -358,11 +346,11 @@
         "description": "Text that links to a support article on verifying safety numbers"
     },
     "installNew": {
-        "message": "Set up as new install",
+        "message": "Configurar como nova instalação",
         "description": "One of two choices presented on the screen shown on first launch"
     },
     "importing": {
-        "message": "Please wait while we import your data...",
+        "message": "Por favor espere enquanto os seus dados são importados...",
         "description": "Shown as we are loading the user's data from disk"
     },
     "unreadMessages": {
@@ -456,7 +444,7 @@
         "description": "Header for a key change dialog"
     },
     "installTagline": {
-        "message": "Privacidade é possível. Signal torna-a mais fácil.",
+        "message": "A privacidade é possível. O Signal torna-a fácil.",
         "description": "Tagline displayed under 'installWelcome' string on the install page"
     },
     "audioNotificationDescription": {
@@ -498,7 +486,7 @@
         "description": "Timestamp format string for displaying month and day (but not the year) of a date within the current year, ex: use 'MMM D' for 'Aug 8', or 'D MMM' for '8 Aug'."
     },
     "chooseDirectory": {
-        "message": "Choose directory",
+        "message": "Escolher pasta",
         "description": "Button to allow the user to export all data from app as part of migration process"
     },
     "timerOption_6_hours_abbreviated": {
@@ -514,11 +502,11 @@
         "description": "Very short format indicating current timer setting in the conversation header"
     },
     "autoUpdateRestartButtonLabel": {
-        "message": "Restart",
+        "message": "Reiniciar",
         "description": ""
     },
     "importButton": {
-        "message": "Import",
+        "message": "Importar",
         "description": ""
     },
     "sync": {
@@ -590,7 +578,7 @@
         "description": ""
     },
     "autoUpdateNewVersionInstructions": {
-        "message": "Press Restart to apply the updates.",
+        "message": "Carregue em Reiniciar para aplicar as actualizações.",
         "description": ""
     },
     "timerOption_0_seconds": {
@@ -598,23 +586,19 @@
         "description": "Label for option to turn off message expiration in the timer menu"
     },
     "importError": {
-        "message": "Unfortunately, something went wrong during the import. <p>First, double-check your target directory. It should start with 'Signal Export.'</p><p>Next, try with a new export of your data from the Chrome App.</p>If that still fails, please <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/215188737-How-do-I-submit-a-debug-log-from-the-Desktop-'>submit a debug log</a> so we can help you get migrated!",
+        "message": "Infelizmente algo correu mal durante ao importar. <p>Verifique a sua pasta de destino. Esta deverá começar por \"Signal Export\"</p><p>A seguir, tente exportar novamente os seus dados da Chrome App.</p> Se isto falhar, por favor <a target='_blank' href='https://support.whispersystems.org/hc/en-us/articles/215188737-How-do-I-submit-a-debug-log-from-the-Desktop-'>Envie um relatório de erros</a> para que possamos ajudar-lhe com a migração.",
         "description": "Message shown if the import went wrong."
     },
     "installAndroidInstructions": {
         "message": "Abra o Signal no seu telemóvel e vá até Definições > Dispositivos associados. Pressione o botão para adicionar um novo dispositivo, de seguida scaneie o código QR apresentado.",
         "description": ""
     },
-    "migrationDisconnecting": {
-        "message": "A desconectar...",
-        "description": "Displayed while we wait for pending incoming messages to process"
-    },
     "invalidNumberError": {
         "message": "Número inválido",
         "description": "When a person inputs a number that is invalid"
     },
     "importComplete": {
-        "message": "We've successfully loaded your data. The next step is to restart the application!",
+        "message": "Os seus dados foram carregados com sucesso. O próximo passo é reiniciar a aplicação.",
         "description": "Shown when the import is complete."
     },
     "installWelcome": {
@@ -648,7 +632,7 @@
         "description": "Informational label, appears on messages that failed to send"
     },
     "autoUpdateNewVersionMessage": {
-        "message": "There is a new version of Signal available.",
+        "message": "Está disponível uma nova versão do Signal.",
         "description": ""
     },
     "disableNotifications": {
@@ -724,7 +708,7 @@
         }
     },
     "installSignalLink": {
-        "message": "First, install <a $a_params$>Signal</a> on your mobile phone. We'll link your devices and keep your messages in sync.",
+        "message": "Primeiro, instale o <a $a_params$>Signal</a> no seu telefone. Vamos associar os seus dispositivos e manter as suas mensagens sincronizadas.",
         "description": "Prompt the user to install Signal on their phone before linking",
         "placeholders": {
             "a_params": {
@@ -806,7 +790,7 @@
         "description": "When export is complete, a button shows which sends user to Signal Desktop install instructions"
     },
     "exportChooserTitle": {
-        "message": "Choose target directory for data",
+        "message": "Escolha a pasta para os seus dados",
         "description": "Title of the popup window used to select data storage location"
     },
     "verify": {
@@ -814,7 +798,7 @@
         "description": ""
     },
     "exportButton": {
-        "message": "Export",
+        "message": "Exportar",
         "description": ""
     },
     "timerOption_10_seconds_abbreviated": {
@@ -840,10 +824,6 @@
     "changedSinceVerifiedMultiple": {
         "message": "Os números de segurança com vários membros do grupo mudaram desde a última vez que os verificou. Is poderá querer dizer que alguém está a tentar interceptar as suas comunicações ou simplesmente os membros do grupo reinstalaram o Signal.",
         "description": "Shown on confirmation dialog when user attempts to send a message"
-    },
-    "export": {
-        "message": "Escolher pasta",
-        "description": "Button to allow the user to export all data from app as part of migration process"
     },
     "submitDebugLog": {
         "message": "Enviar relatório de erros",
@@ -874,7 +854,7 @@
         }
     },
     "autoUpdateNewVersionTitle": {
-        "message": "Signal update available",
+        "message": "Há uma actualização para o Signal",
         "description": ""
     },
     "timerOption_30_seconds_abbreviated": {
@@ -890,7 +870,7 @@
         "description": "Header for notification settings"
     },
     "tryAgain": {
-        "message": "Try again",
+        "message": "Tente novamente",
         "description": "Button shown if the user runs into an error during import, allowing them to start over"
     },
     "resend": {

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -227,14 +227,6 @@
         "message": "Trimis",
         "description": "Label for the time a message was sent"
     },
-    "migrationWarning": {
-        "message": "The Signal Desktop Chrome app has been deprecated. Would you like to migrate to the new Signal Desktop now?",
-        "description": "Warning notification that this version of the app has been deprecated and the user must migrate"
-    },
-    "migrate": {
-        "message": "Migrează",
-        "description": "Button label to begin migrating this client to Electron"
-    },
     "theyChangedTheTimer": {
         "message": "$name$ a setat cronometrul la $time$.",
         "description": "Message displayed when someone else changes the message expiration timer in a conversation.",
@@ -278,7 +270,7 @@
         "description": "Label for setting notifications to display sender name only"
     },
     "autoUpdateLaterButtonLabel": {
-        "message": "Later",
+        "message": "Mai târziu",
         "description": ""
     },
     "from": {
@@ -358,7 +350,7 @@
         "description": "One of two choices presented on the screen shown on first launch"
     },
     "importing": {
-        "message": "Please wait while we import your data...",
+        "message": "Te rog așteaptă cât timp importăm datele tale...",
         "description": "Shown as we are loading the user's data from disk"
     },
     "unreadMessages": {
@@ -510,11 +502,11 @@
         "description": "Very short format indicating current timer setting in the conversation header"
     },
     "autoUpdateRestartButtonLabel": {
-        "message": "Restart",
+        "message": "Repornește",
         "description": ""
     },
     "importButton": {
-        "message": "Import",
+        "message": "Importă",
         "description": ""
     },
     "sync": {
@@ -600,10 +592,6 @@
     "installAndroidInstructions": {
         "message": "Deschide Signal de pe telefonul tău şi navighează la Setări > Dispozitive conectate. Apasă pe buton pentru a adăuga un dispozitiv nou, şi scanează codul de deasupra.",
         "description": ""
-    },
-    "migrationDisconnecting": {
-        "message": "Se deconectează...",
-        "description": "Displayed while we wait for pending incoming messages to process"
     },
     "invalidNumberError": {
         "message": "Număr invalid",
@@ -798,7 +786,7 @@
         "description": ""
     },
     "installNewSignal": {
-        "message": "Install new Signal Desktop",
+        "message": "Instalează noul Signal Desktop",
         "description": "When export is complete, a button shows which sends user to Signal Desktop install instructions"
     },
     "exportChooserTitle": {
@@ -836,10 +824,6 @@
     "changedSinceVerifiedMultiple": {
         "message": "Your safety numbers with multiple group members have changed since you last verified. This could mean that someone is trying to intercept your communication or that they have simply reinstalled Signal.",
         "description": "Shown on confirmation dialog when user attempts to send a message"
-    },
-    "export": {
-        "message": "Alege un director",
-        "description": "Button to allow the user to export all data from app as part of migration process"
     },
     "submitDebugLog": {
         "message": "Trimite log-ul de depanare",
@@ -886,7 +870,7 @@
         "description": "Header for notification settings"
     },
     "tryAgain": {
-        "message": "Try again",
+        "message": "Încearcă din nou",
         "description": "Button shown if the user runs into an error during import, allowing them to start over"
     },
     "resend": {

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -227,14 +227,6 @@
         "message": "已发送",
         "description": "Label for the time a message was sent"
     },
-    "migrationWarning": {
-        "message": "The Signal Desktop Chrome app has been deprecated. Would you like to migrate to the new Signal Desktop now?",
-        "description": "Warning notification that this version of the app has been deprecated and the user must migrate"
-    },
-    "migrate": {
-        "message": "迁移",
-        "description": "Button label to begin migrating this client to Electron"
-    },
     "theyChangedTheTimer": {
         "message": "$name$ 将计时器设置为 $time$ 。",
         "description": "Message displayed when someone else changes the message expiration timer in a conversation.",
@@ -601,10 +593,6 @@
         "message": "在您的手机上打开Signal，然后点击设置>已连接的设备。点击添加按钮来加入新的设备，然后扫描上面的二维码。",
         "description": ""
     },
-    "migrationDisconnecting": {
-        "message": "失去连接...",
-        "description": "Displayed while we wait for pending incoming messages to process"
-    },
     "invalidNumberError": {
         "message": "无效的号码",
         "description": "When a person inputs a number that is invalid"
@@ -836,10 +824,6 @@
     "changedSinceVerifiedMultiple": {
         "message": "Your safety numbers with multiple group members have changed since you last verified. This could mean that someone is trying to intercept your communication or that they have simply reinstalled Signal.",
         "description": "Shown on confirmation dialog when user attempts to send a message"
-    },
-    "export": {
-        "message": "选择目录",
-        "description": "Button to allow the user to export all data from app as part of migration process"
     },
     "submitDebugLog": {
         "message": "提交调试日志",

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -114,7 +114,7 @@
         "description": "Displayed for outgoing unsupported attachment"
     },
     "exportAgain": {
-        "message": "Export again",
+        "message": "再次匯出",
         "description": "If user has already exported once, this button allows user to do it again if needed"
     },
     "clickToSave": {
@@ -162,7 +162,7 @@
         "description": "Explanatory text for sync settings"
     },
     "restartSignal": {
-        "message": "從新開啟Signal",
+        "message": "重新開啟Signal",
         "description": "Menu item for restarting the program."
     },
     "youLeftTheGroup": {
@@ -254,7 +254,7 @@
         "description": "Label for a selectable option in the message expiration timer menu"
     },
     "exporting": {
-        "message": "Please wait while we export your data. It may take several minutes. You can still use Signal on your phone and other devices during this time.",
+        "message": "請耐心等待我們匯出你的資料，此過程將需數分鐘。你可以繼續在電話及其他裝置上使用Signal。",
         "description": "Message shown on the migration screen while we export data"
     },
     "reportIssue": {
@@ -350,7 +350,7 @@
         "description": "One of two choices presented on the screen shown on first launch"
     },
     "importing": {
-        "message": "Please wait while we import your data...",
+        "message": "請等待我們匯入你的資料",
         "description": "Shown as we are loading the user's data from disk"
     },
     "unreadMessages": {
@@ -502,7 +502,7 @@
         "description": "Very short format indicating current timer setting in the conversation header"
     },
     "autoUpdateRestartButtonLabel": {
-        "message": "Restart",
+        "message": "重新啟動",
         "description": ""
     },
     "importButton": {
@@ -786,7 +786,7 @@
         "description": ""
     },
     "installNewSignal": {
-        "message": "Install new Signal Desktop",
+        "message": "安裝新的Signal 桌面版",
         "description": "When export is complete, a button shows which sends user to Signal Desktop install instructions"
     },
     "exportChooserTitle": {
@@ -798,7 +798,7 @@
         "description": ""
     },
     "exportButton": {
-        "message": "Export",
+        "message": "匯出",
         "description": ""
     },
     "timerOption_10_seconds_abbreviated": {


### PR DESCRIPTION
Also, remove unneeded (and potentially brittle) title from support link in English `importError` string.

As part of verifying these changes, I also did a review of all URLs in all language files to ensure that they still link to https://support.whispersystems.org.