### PR TITLE
Update electron to v1.6.14 to get security fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "asar": "^0.13.0",
     "bower": "^1.3.12",
-    "electron": "^1.6.1",
+    "electron": "~1.6.1",
     "electron-builder": "^19.27.3",
     "electron-icon-maker": "^0.0.3",
     "electron-publisher-s3": "^19.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,10 @@
     "7zip-bin-mac" "^1.0.1"
     "7zip-bin-win" "^2.1.0"
 
+"@types/node@^7.0.18":
+  version "7.0.43"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.43.tgz#a187e08495a075f200ca946079c914e1a5fe962c"
+
 "JSV@>= 4.0.x":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
@@ -1143,10 +1147,11 @@ electron-updater@^2.1.2:
     source-map-support "^0.4.15"
     xelement "^1.0.16"
 
-electron@^1.6.1:
-  version "1.6.7"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.7.tgz#08b90812912a66f80cfb47bdaef6edfd6b78aa81"
+electron@~1.6.1:
+  version "1.6.14"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.14.tgz#47af610f0c21694266254e8b02ff8cd0fa6a64b7"
   dependencies:
+    "@types/node" "^7.0.18"
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
 


### PR DESCRIPTION
Security issue details here: https://electron.atom.io/blog/2017/09/27/chromium-rce-vulnerability-fix