### PR TITLE
Ensure final message before 'empty' is ready for notification

### DIFF
--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -493,12 +493,16 @@
                                         //   because we need to start expiration timers, etc.
                                         message.markRead();
                                     }
-                                    if (message.get('unread')) {
-                                        conversation.notify(message);
-                                    }
 
-                                    confirm();
-                                    return resolve();
+                                    if (message.get('unread')) {
+                                        conversation.notify(message).then(function() {
+                                            confirm();
+                                            return resolve();
+                                        }, handleError);
+                                    } else {
+                                        confirm();
+                                        return resolve();
+                                    }
                                 }
                                 catch (e) {
                                     handleError(e);


### PR DESCRIPTION
Without this change, there's a race condition for the notification we show when we get the 'empty' event after a large backlog download. If four messages have come in, the last might not be included in the first notification. So the count shown would be three. And then, when the final message's `notify()` call does finish, another notification would be shown.