### PR TITLE
Re-enable fullscreen on OSX

### DIFF
--- a/main.js
+++ b/main.js
@@ -65,6 +65,13 @@ function createWindow () {
     }
   }, windowConfig);
 
+  if (windowOptions.fullscreen === false) {
+    delete windowOptions.fullscreen;
+  }
+
+  console.log('Initializing BrowserWindow');
+  console.log(windowOptions);
+
   // Create the browser window.
   mainWindow = new BrowserWindow(windowOptions);
 
@@ -75,13 +82,20 @@ function createWindow () {
     // so if we need to recreate the window, we have the most recent settings
     windowConfig = {
       maximized: mainWindow.isMaximized(),
-      fullscreen: mainWindow.isFullScreen(),
       width: size[0],
       height: size[1],
       x: position[0],
       y: position[1]
     };
 
+    if (mainWindow.isFullScreen()) {
+      // Only include this property if true, because when explicitly set to
+      // false the fullscreen button will be disabled on osx
+      windowConfig.fullscreen = true;
+    }
+
+    console.log('Updating window config');
+    console.log(windowConfig);
     userConfig.set('window', windowConfig);
   }
 

--- a/main.js
+++ b/main.js
@@ -69,8 +69,7 @@ function createWindow () {
     delete windowOptions.fullscreen;
   }
 
-  console.log('Initializing BrowserWindow');
-  console.log(windowOptions);
+  logger.info('Initializing BrowserWindow config: %s', JSON.stringify(windowOptions));
 
   // Create the browser window.
   mainWindow = new BrowserWindow(windowOptions);
@@ -94,8 +93,7 @@ function createWindow () {
       windowConfig.fullscreen = true;
     }
 
-    console.log('Updating window config');
-    console.log(windowConfig);
+    logger.info('Updating BrowserWindow config: %s', JSON.stringify(windowConfig));
     userConfig.set('window', windowConfig);
   }
 


### PR DESCRIPTION
We were inadvertantly disabling the fullscreen button due to a quick of the
BrowserWindow api. Add some guards to make sure we no longer save or use a
previously-stored `fullscreen: false` in our window configs.

Fixes #1516

See also: https://electron.atom.io/docs/all/#new-browserwindowoptions