### PR TITLE
window.onerror: move to proper window.log.error call

### DIFF
--- a/js/logging.js
+++ b/js/logging.js
@@ -141,6 +141,6 @@ window.log = {
 };
 
 window.onerror = function(message, script, line, col, error) {
-  log.error(error.stack);
+  window.log.error(error.stack);
 };
 


### PR DESCRIPTION
`log` was erroneously bound to `function log()` upfile, instead of `window.log`