### PR TITLE
Remove duplicate definition of getSyncRequest

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -66,10 +66,6 @@
         start();
     });
 
-    window.getSyncRequest = function() {
-        return new textsecure.SyncRequest(textsecure.messaging, messageReceiver);
-    };
-
     Whisper.events.on('shutdown', function() {
       if (messageReceiver) {
         messageReceiver.close().then(function() {


### PR DESCRIPTION
Somehow we ended up with two getSyncRequests. Let's delete this one and keep [the other](https://github.com/WhisperSystems/Signal-Desktop/pull/1530/files#diff-2650fb3e14b7f42d68a8766269c54434L145).