### PR TITLE
Remove 'debug' from the list of stores we import

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -173,7 +173,7 @@
   function importFromJsonString(idb_db, jsonString) {
     return new Promise(function(resolve, reject) {
       var importObject = JSON.parse(jsonString);
-      var storeNames = _.keys(importObject);
+      var storeNames = _.without(_.keys(importObject), ['debug']);
 
       console.log('Importing to these stores:', storeNames.join(', '));
 


### PR DESCRIPTION
Now that we log to disk, we no longer need the 'debug' object store from the Chrome export. Fixes #1531.
