### PR TITLE
Update electron-updater and supply it with windows/publisherName

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
       "asarUnpack": "node_modules/spellchecker/vendor/hunspell_dictionaries",
       "artifactName": "${productName}-Setup_${version}.${ext}",
       "certificateSubjectName": "Signal",
+      "publisherName": "Signal (Quiet Riddle Ventures, LLC)",
       "icon": "build/icons/win/icon.ico",
       "publish": {
         "provider": "s3",
@@ -135,7 +136,7 @@
     "config": "^1.26.2",
     "electron-config": "^1.0.0",
     "electron-editor-context-menu": "^1.1.1",
-    "electron-updater": "^2.1.2",
+    "electron-updater": "^2.9.3",
     "emoji-datasource-apple": "^3.0.0",
     "emoji-js": "^3.2.2",
     "lodash": "^4.17.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,6 +404,14 @@ builder-util-runtime@1.0.1, builder-util-runtime@^1.0.0:
     debug "^3.0.1"
     fs-extra-p "^4.4.0"
 
+builder-util-runtime@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-1.0.6.tgz#3087c39608470fa1b6ee90a4c565d96bd768c531"
+  dependencies:
+    bluebird-lst "^1.0.3"
+    debug "^3.1.0"
+    fs-extra-p "^4.4.2"
+
 builder-util@2.0.1, builder-util@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/builder-util/-/builder-util-2.0.1.tgz#b0ec6cec56d73545306c21d8e23f801a4af35764"
@@ -810,6 +818,12 @@ debug@^3.0.0, debug@^3.0.1:
   dependencies:
     ms "2.0.0"
 
+debug@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  dependencies:
+    ms "2.0.0"
+
 debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -958,13 +972,6 @@ ejs@^2.5.7, ejs@~2.5.6:
   version "2.5.7"
   resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
 
-electron-builder-http@~18.7.0:
-  version "18.7.0"
-  resolved "https://registry.yarnpkg.com/electron-builder-http/-/electron-builder-http-18.7.0.tgz#a3154d25c80c62e1e15becaf10770811e338aefe"
-  dependencies:
-    debug "2.6.8"
-    fs-extra-p "^4.3.0"
-
 electron-builder-http@~19.0.1:
   version "19.0.1"
   resolved "https://registry.yarnpkg.com/electron-builder-http/-/electron-builder-http-19.0.1.tgz#fc1486e4b4bd31b5a44293dc61d4f1afb092ac77"
@@ -1086,9 +1093,9 @@ electron-icon-maker@^0.0.3:
     icon-gen "^1.0.7"
     jimp "^0.2.27"
 
-electron-is-dev@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-0.1.2.tgz#8a1043e32b3a1da1c3f553dce28ce764246167e3"
+electron-is-dev@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-0.3.0.tgz#14e6fda5c68e9e4ecbeff9ccf037cbd7c05c5afe"
 
 electron-osx-sign@0.4.7:
   version "0.4.7"
@@ -1133,18 +1140,19 @@ electron-publisher-s3@^19.0.1:
     fs-extra-p "^4.3.0"
     mime "^1.3.6"
 
-electron-updater@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-2.1.2.tgz#e6d006476c36712ab6be0382100cd9612c6b69d6"
+electron-updater@^2.9.3:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-2.10.1.tgz#5763bda9153c08459d7058d9afedccc178b88304"
   dependencies:
-    bluebird-lst "^1.0.2"
-    debug "^2.6.8"
-    electron-builder-http "~18.7.0"
-    electron-is-dev "^0.1.2"
-    fs-extra-p "^4.3.0"
-    js-yaml "^3.8.4"
-    semver "^5.3.0"
-    source-map-support "^0.4.15"
+    bluebird-lst "^1.0.3"
+    builder-util-runtime "^1.0.6"
+    electron-is-dev "^0.3.0"
+    fs-extra-p "^4.4.2"
+    js-yaml "^3.10.0"
+    lazy-val "^1.0.2"
+    lodash.isequal "^4.5.0"
+    semver "^5.4.1"
+    source-map-support "^0.4.18"
     xelement "^1.0.16"
 
 electron@~1.6.1:
@@ -1212,10 +1220,6 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
 esprima@^2.6.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
-
-esprima@^3.1.1:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esprima@^4.0.0:
   version "4.0.0"
@@ -1389,6 +1393,13 @@ fs-extra-p@^4.4.0:
     bluebird-lst "^1.0.2"
     fs-extra "^4.0.0"
 
+fs-extra-p@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/fs-extra-p/-/fs-extra-p-4.4.2.tgz#b6abd882a9b89f41b977771d3da788ce38f085f3"
+  dependencies:
+    bluebird-lst "^1.0.2"
+    fs-extra "^4.0.2"
+
 fs-extra@0.26.7:
   version "0.26.7"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
@@ -1417,7 +1428,7 @@ fs-extra@^3.0.1:
     jsonfile "^3.0.0"
     universalify "^0.1.0"
 
-fs-extra@^4.0.0, fs-extra@^4.0.1:
+fs-extra@^4.0.0, fs-extra@^4.0.1, fs-extra@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.2.tgz#f91704c53d1b461f893452b0c307d9997647ab6b"
   dependencies:
@@ -2055,19 +2066,12 @@ js-base64@^2.1.8:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
-js-yaml@^3.2.7, js-yaml@^3.9.1:
+js-yaml@^3.10.0, js-yaml@^3.2.7, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
-
-js-yaml@^3.8.4:
-  version "3.8.4"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^3.1.1"
 
 js-yaml@~3.4.0:
   version "3.4.6"
@@ -2310,6 +2314,10 @@ lodash.isarray@^4.0.0:
 lodash.isempty@^4.1.2:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
 
 lodash.isfunction@^3.0.8:
   version "3.0.8"
@@ -3307,7 +3315,7 @@ source-map-resolve@^0.3.0:
     source-map-url "~0.3.0"
     urix "~0.1.0"
 
-source-map-support@^0.4.0, source-map-support@^0.4.17:
+source-map-support@^0.4.0, source-map-support@^0.4.17, source-map-support@^0.4.18:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:


### PR DESCRIPTION
These changes ensure that the signing certificate of any binary pulled down as part of auto-update on Windows is in the trusted CA chain (not self-signed) and has the right `publisherName`. `electron-updater` also rejects any unsigned binary when asked to check the `publisherName`.

Note: the version chosen for `electron-updater` is the one released around the same time as the version of `electron-builder` we're using.

As an aside, a semantic release monorepo makes it really hard to track down when stuff was released. :0/