### PR TITLE
Override console.log in main process, handle non-strings

### DIFF
--- a/app/logging.js
+++ b/app/logging.js
@@ -83,6 +83,39 @@ function fetch(logPath) {
 }
 
 
+function logAtLevel() {
+  const level = arguments[0];
+  const args = Array.prototype.slice.call(arguments, 1);
+
+  if (logger) {
+    // To avoid [Object object] in our log since console.log handles non-strings smoothly
+    const str = args.map(function(item) {
+      if (typeof item !== 'string') {
+        try {
+          return JSON.stringify(item);
+        }
+        catch (e) {
+          return item;
+        }
+      }
+
+      return item;
+    });
+    logger[level](str.join(' '));
+  } else {
+    console._log.apply(console, consoleArgs);
+  }
+}
+
+
+console._log = console.log;
+console.log = _.partial(logAtLevel, 'info');
+console._error = console.error;
+console.error = _.partial(logAtLevel, 'error');
+console._warn = console.warn;
+console.warn = _.partial(logAtLevel, 'warn');
+
+
 module.exports = {
   initialize,
   getLogger,

--- a/js/logging.js
+++ b/js/logging.js
@@ -43,8 +43,21 @@ function log() {
   const consoleArgs = ['INFO ', now()].concat(args);
   console._log.apply(console, consoleArgs);
 
-  const str = redactGroup(redactPhone(args.join(' ')));
-  ipc.send('log-info', str);
+  // To avoid [Object object] in our log since console.log handles non-strings smoothly
+  const str = args.map(function(item) {
+    if (typeof item !== 'string') {
+      try {
+        return JSON.stringify(item);
+      }
+      catch (e) {
+        return item;
+      }
+    }
+
+    return item;
+  });
+  const toSend = redactGroup(redactPhone(str.join(' ')));
+  ipc.send('log-info', toSend);
 }
 
 if (window.console) {


### PR DESCRIPTION
Overriding `console.log()` in the main process should allow us to get an insight into auto-update behavior and other low-level things, all very useful for debugging.

Also, we now look for non-strings passed to `console.log()` and `JSON.stringify()` them first. No more `[Object object]` in our logs!