### PR TITLE
Use cdn endpoint for auto update

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,13 +59,19 @@
     "mac": {
       "category": "public.app-category.social-networking",
       "icon": "build/icons/mac/icon.icns",
-      "publish": {
-        "provider": "s3",
-        "region": "us-east-1",
-        "bucket": "updates.signal.org",
-        "path": "desktop",
-        "acl": "public-read"
-      },
+      "publish": [
+        {
+          "provider": "generic",
+          "url": "https://updates.signal.org/desktop"
+        },
+        {
+          "provider": "s3",
+          "region": "us-east-1",
+          "bucket": "updates.signal.org",
+          "path": "desktop",
+          "acl": "public-read"
+        }
+      ],
       "target": [
         "dmg",
         "zip"
@@ -77,13 +83,19 @@
       "artifactName": "${productName}-Setup_${version}.${ext}",
       "certificateSubjectName": "Signal",
       "icon": "build/icons/win/icon.ico",
-      "publish": {
-        "provider": "s3",
-        "region": "us-east-1",
-        "bucket": "updates.signal.org",
-        "path": "desktop",
-        "acl": "public-read"
-      },
+      "publish": [
+        {
+          "provider": "generic",
+          "url": "https://updates.signal.org/desktop"
+        },
+        {
+          "provider": "s3",
+          "region": "us-east-1",
+          "bucket": "updates.signal.org",
+          "path": "desktop",
+          "acl": "public-read"
+        }
+      ],
       "target": [
         "nsis",
         "zip"


### PR DESCRIPTION
This will make electron-updater use the cdn-fronted updates.signal.org instead
of the s3 endpoint. You can verify it worked by looking at the url generated in
dist/latest-mac.json and dist/win-unpacked/resources/app-update.yml