### PR TITLE
Load debug log dialog immediately, then populate log data

### DIFF
--- a/js/logging.js
+++ b/js/logging.js
@@ -77,7 +77,14 @@ function format(entries) {
 }
 
 function fetch() {
-  return getHeader() + '\n' + format(ipc.sendSync('fetch-log'));
+  return new Promise(function(resolve) {
+    ipc.send('fetch-log');
+
+    ipc.on('fetched-log', function(event, text) {
+      var result = getHeader() + '\n' + format(text);
+      resolve(result);
+    });
+  });
 }
 
 function publish(log) {

--- a/js/views/debug_log_view.js
+++ b/js/views/debug_log_view.js
@@ -22,7 +22,11 @@
         className: 'debug-log modal',
         initialize: function() {
             this.render();
-            this.$('textarea').val(log.fetch());
+            this.$('textarea').val(i18n('loading'));
+
+            window.log.fetch().then(function(text) {
+                this.$('textarea').val(text);
+            }.bind(this));
         },
         events: {
             'click .submit': 'submit',


### PR DESCRIPTION
An immediate response to the user request to see the log, and then we show the real data as soon as we've loaded it from disk.

Changes:
  - the IPC exchange to get the log data is now async
  - the API to fetch the log on the client side now returns a Promise
  - in the main process, the only disk access done synchronoously is reading the contents of the log directory. The JSON parsing of the resultant log data is now split up into three chunks.
  - We only send three keys from each log item to the renderer process: `msg`, `time`, `level`. Previously we sent the entire log entry with extra keys: `hostname`, `pid`, `name`.