### PR TITLE
Show proper icon when attachment is not an image

### DIFF
--- a/js/views/file_input_view.js
+++ b/js/views/file_input_view.js
@@ -131,7 +131,7 @@
                     this.addThumb(this.oUrl);
                     break;
                 default:
-                    this.addThumb('../images/file.svg'); break;
+                    this.addThumb('images/file.svg'); break;
             }
 
             this.autoScale(file).then(function(blob) {


### PR DESCRIPTION
This may just be the last image path problem left over from the move to Electron! :0)