### PR TITLE
Add 100MB file size limit for arbitrary file types

### DIFF
--- a/js/views/file_input_view.js
+++ b/js/views/file_input_view.js
@@ -146,6 +146,8 @@
                         limitKb = 100000; break;
                     case 'video':
                         limitKb = 100000; break;
+                    default:
+                        limitKb = 100000; break;
                 }
                 if ((blob.size/1024).toFixed(4) >= limitKb) {
                     var units = ['kB','MB','GB'];


### PR DESCRIPTION
Previously we only had limits for audio, video, and image files.

Fixes #1553