### PR TITLE
Fix intermittent conversation sort order problem

### DIFF
--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -35,7 +35,7 @@
             }
             var title1 = m1.getTitle().toLowerCase();
             var title2 = m2.getTitle().toLowerCase();
-            if (title1 ===  title2) {
+            if (title1 === title2) {
                 return 0;
             }
             if (title1 < title2) {

--- a/js/views/conversation_list_view.js
+++ b/js/views/conversation_list_view.js
@@ -8,11 +8,14 @@
     Whisper.ConversationListView = Whisper.ListView.extend({
         tagName: 'div',
         itemView: Whisper.ConversationListItemView,
-        sort: function(conversation) {
+        updateLocation: function(conversation) {
             var $el = this.$('.' + conversation.cid);
             if ($el && $el.length > 0) {
-                var index = getInboxCollection().indexOf(conversation);
-                if (index === this.$el.index($el)) {
+                var inboxCollection = getInboxCollection();
+                var index = inboxCollection.indexOf(conversation);
+                var elIndex = this.$el.index($el);
+
+                if (index === elIndex) {
                     return;
                 }
                 if (index === 0) {
@@ -20,7 +23,9 @@
                 } else if (index === this.collection.length - 1) {
                     this.$el.append($el);
                 } else {
-                    $el.insertBefore(this.$('.conversation-list-item')[index+1]);
+                    var targetConversation = inboxCollection.at(index + 1);
+                    var target = this.$('.' + targetConversation.cid);
+                    $el.insertBefore(target);
                 }
             }
         }

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -110,7 +110,7 @@
 
             this.inboxListView.listenTo(inboxCollection,
                     'add change:timestamp change:name change:number',
-                    this.inboxListView.sort);
+                    this.inboxListView.updateLocation);
 
             this.searchView = new Whisper.ConversationSearchView({
                 el    : this.$('.search-results'),


### PR DESCRIPTION
We were inserting based on neighbor items from the DOM, instead of finding neighbor items from the collection, then finding those in the DOM.

Fixes #1500. Pretty sure. :0)