### PR TITLE
Improve OS menu

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -360,6 +360,38 @@
       "message": "Submit debug log",
       "description": "Menu item and header text for debug log modal, title case."
     },
+    "debugLog": {
+      "message": "Debug Log",
+      "description": "View menu item to open the debug log, capitalized"
+    },
+    "goToReleaseNotes": {
+      "message": "Go to release notes",
+      "description": ""
+    },
+    "goToForums": {
+      "message": "Go to forums",
+      "description": "Item under the Help menu, takes you to the forums"
+    },
+    "goToSupportPage": {
+      "message": "Go to support page",
+      "description": "Item under the Help menu, takes you to the support page"
+    },
+    "fileABug": {
+      "message": "File a bug",
+      "description": "Item under the Help menu, takes you to GitHub new issue form"
+    },
+    "aboutSignalDesktop": {
+      "message": "About Signal Desktop",
+      "description": "Item under the Help menu, which opens a small about window"
+    },
+    "speech": {
+      "message": "Speech",
+      "description": "Item under the Edit menu, with 'start/stop speaking' items below it"
+    },
+    "show": {
+      "message": "Show",
+      "description": "Command under Window menu, to show the window"
+    },
     "searchForPeopleOrGroups": {
       "message": "Search...",
       "description": "Placeholder text in the search input"

--- a/about.html
+++ b/about.html
@@ -1,0 +1,6 @@
+Electron!!
+
+<script>
+  document.write('Version: ', window.version);
+  document.write('Hostname: ', window.hostname);
+</script>

--- a/about.html
+++ b/about.html
@@ -1,6 +1,39 @@
-Electron!!
+<html>
+<head>
+<link href="stylesheets/manifest.css" rel="stylesheet" type="text/css" />
+<style>
 
+body {
+  text-align: center;
+  background-color: #2090EA;
+  color: white;
+  font-size: 14px;
+}
+
+img {
+  margin-top: 2em;
+  margin-bottom: 1em;
+}
+
+a {
+  color: white;
+}
+
+</style>
+</head>
+<body>
+
+<img src='images/icon_250.png'>
+
+<div>
 <script>
-  document.write('Version: ', window.version);
-  document.write('Hostname: ', window.hostname);
+  document.write('v', window.config.version);
 </script>
+</div>
+<div>
+  <a href="https://signal.org">signal.org</a>
+</div>
+
+</body>
+
+</html>

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,7 +1,10 @@
-function createTemplate(options) {
+function createTemplate(options, messages) {
   const showDebugLog = options.showDebugLog;
-  const showWindow = options.showWindow;
   const showAbout = options.showAbout;
+  const openReleaseNotes = options.openReleaseNotes;
+  const openNewBugForm = options.openNewBugForm;
+  const openSupportPage = options.openSupportPage;
+  const openForums = options.openForums;
 
   let template = [{
     label: 'File',
@@ -65,7 +68,7 @@ function createTemplate(options) {
         type: 'separator',
       },
       {
-        label: 'Debug Log',
+        label: messages.debugLog.message,
         click: showDebugLog,
       },
       {
@@ -88,25 +91,55 @@ function createTemplate(options) {
     role: 'help',
     submenu: [
       {
-        label: 'about',
+        label: messages.goToReleaseNotes.message,
+        click: openReleaseNotes,
+      },
+      {
+        type: 'separator',
+      },
+      {
+        label: messages.goToForums.message,
+        click: openForums,
+      },
+      {
+        label: messages.goToSupportPage.message,
+        click: openSupportPage,
+      },
+      {
+        label: messages.fileABug.message,
+        click: openNewBugForm,
+      },
+      {
+        type: 'separator',
+      },
+      {
+        label: messages.aboutSignalDesktop.message,
         click: showAbout,
       },
     ]
   }];
 
-  if (process.platform !== 'darwin') {
-    return template;
+  if (process.platform === 'darwin') {
+    return updateForMac(template, messages, options);
   }
 
-  // Remove Help menu
-  template.pop();
+  return template;
+}
+
+function updateForMac(template, messages, options) {
+  const showWindow = options.showWindow;
+  const showAbout = options.showAbout;
+
+  // Remove About item and separator from Help menu, since it's on the first menue
+  template[4].submenu.pop();
+  template[4].submenu.pop();
 
   // Replace File menu
   template.shift();
   template.unshift({
     submenu: [
       {
-        label: 'about',
+        label: messages.aboutSignalDesktop.message,
         click: showAbout,
       },
       {
@@ -136,7 +169,7 @@ function createTemplate(options) {
       type: 'separator'
     },
     {
-      label: 'Speech',
+      label: messages.speech.message,
       submenu: [
         {
           role: 'startspeaking',
@@ -151,28 +184,24 @@ function createTemplate(options) {
   // Add to Window menu
   template[3].submenu = [
     {
-      label: 'Close',
       accelerator: 'CmdOrCtrl+W',
       role: 'close',
     },
     {
-      label: 'Minimize',
       accelerator: 'CmdOrCtrl+M',
       role: 'minimize',
     },
     {
-      label: 'Zoom',
       role: 'zoom',
     },
     {
-      label: 'Show',
+      label: messages.show.message,
       click: showWindow,
     },
     {
       type: 'separator',
     },
     {
-      label: 'Bring All to Front',
       role: 'front',
     },
   ];

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,6 +1,7 @@
 function createTemplate(options) {
   const showDebugLog = options.showDebugLog;
   const showWindow = options.showWindow;
+  const showAbout = options.showAbout;
 
   let template = [{
     label: 'File',
@@ -80,15 +81,16 @@ function createTemplate(options) {
     submenu: [
       {
         role: 'minimize',
-      }
+      },
     ]
   },
   {
     role: 'help',
     submenu: [
       {
-        role: 'about',
-      }
+        label: 'about',
+        click: showAbout,
+      },
     ]
   }];
 
@@ -104,7 +106,8 @@ function createTemplate(options) {
   template.unshift({
     submenu: [
       {
-        role: 'about',
+        label: 'about',
+        click: showAbout,
       },
       {
         type: 'separator',
@@ -123,7 +126,7 @@ function createTemplate(options) {
       },
       {
         role: 'quit',
-      }
+      },
     ]
   });
 
@@ -140,7 +143,7 @@ function createTemplate(options) {
         },
         {
           role: 'stopspeaking',
-        }
+        },
       ]
     }
   );
@@ -171,7 +174,7 @@ function createTemplate(options) {
     {
       label: 'Bring All to Front',
       role: 'front',
-    }
+    },
   ];
 
   return template;

--- a/app/menu.js
+++ b/app/menu.js
@@ -130,7 +130,7 @@ function updateForMac(template, messages, options) {
   const showWindow = options.showWindow;
   const showAbout = options.showAbout;
 
-  // Remove About item and separator from Help menu, since it's on the first menue
+  // Remove About item and separator from Help menu, since it's on the first menu
   template[4].submenu.pop();
   template[4].submenu.pop();
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,11 +1,12 @@
-const {Menu} = require('electron')
+function createTemplate(options) {
+  const showDebugLog = options.showDebugLog;
+  const showWindow = options.showWindow;
 
-const template = [
-  {
+  let template = [{
     label: 'File',
     submenu: [
       {
-        role: 'exit'
+        role: 'quit',
       },
     ]
   },
@@ -13,31 +14,31 @@ const template = [
     label: 'Edit',
     submenu: [
       {
-        role: 'undo'
+        role: 'undo',
       },
       {
-        role: 'redo'
+        role: 'redo',
       },
       {
-        type: 'separator'
+        type: 'separator',
       },
       {
-        role: 'cut'
+        role: 'cut',
       },
       {
-        role: 'copy'
+        role: 'copy',
       },
       {
-        role: 'paste'
+        role: 'paste',
       },
       {
-        role: 'pasteandmatchstyle'
+        role: 'pasteandmatchstyle',
       },
       {
-        role: 'delete'
+        role: 'delete',
       },
       {
-        role: 'selectall'
+        role: 'selectall',
       }
     ]
   },
@@ -45,31 +46,32 @@ const template = [
     label: 'View',
     submenu: [
       {
-        role: 'resetzoom'
+        role: 'resetzoom',
       },
       {
-        role: 'zoomin'
+        role: 'zoomin',
       },
       {
-        role: 'zoomout'
+        role: 'zoomout',
       },
       {
-        type: 'separator'
+        type: 'separator',
       },
       {
-        role: 'togglefullscreen'
+        role: 'togglefullscreen',
       },
       {
-        type: 'separator'
+        type: 'separator',
       },
       {
-        label: 'Debug Log'
+        label: 'Debug Log',
+        click: showDebugLog,
       },
       {
-        type: 'separator'
+        type: 'separator',
       },
       {
-        role: 'toggledevtools'
+        role: 'toggledevtools',
       },
     ]
   },
@@ -77,10 +79,7 @@ const template = [
     role: 'window',
     submenu: [
       {
-        role: 'minimize'
-      },
-      {
-        role: 'close'
+        role: 'minimize',
       }
     ]
   },
@@ -88,44 +87,45 @@ const template = [
     role: 'help',
     submenu: [
       {
-        role: 'about'
+        role: 'about',
       }
     ]
+  }];
+
+  if (process.platform !== 'darwin') {
+    return template;
   }
-]
 
-if (process.platform === 'darwin') {
-  // get rid of File menu
-  template.shift();
-
-  // get rid of Help menu
+  // Remove Help menu
   template.pop();
 
+  // Replace File menu
+  template.shift();
   template.unshift({
     submenu: [
       {
-        role: 'about'
+        role: 'about',
       },
       {
-        type: 'separator'
+        type: 'separator',
       },
       {
-        role: 'hide'
+        role: 'hide',
       },
       {
-        role: 'hideothers'
+        role: 'hideothers',
       },
       {
-        role: 'unhide'
+        role: 'unhide',
       },
       {
-        type: 'separator'
+        type: 'separator',
       },
       {
-        role: 'quit'
+        role: 'quit',
       }
     ]
-  })
+  });
 
   // Add to Edit menu
   template[1].submenu.push(
@@ -136,42 +136,45 @@ if (process.platform === 'darwin') {
       label: 'Speech',
       submenu: [
         {
-          role: 'startspeaking'
+          role: 'startspeaking',
         },
         {
-          role: 'stopspeaking'
+          role: 'stopspeaking',
         }
       ]
     }
-  )
+  );
 
   // Add to Window menu
   template[3].submenu = [
     {
       label: 'Close',
       accelerator: 'CmdOrCtrl+W',
-      role: 'close'
+      role: 'close',
     },
     {
       label: 'Minimize',
       accelerator: 'CmdOrCtrl+M',
-      role: 'minimize'
+      role: 'minimize',
     },
     {
       label: 'Zoom',
-      role: 'zoom'
+      role: 'zoom',
     },
     {
       label: 'Show',
+      click: showWindow,
     },
     {
-      type: 'separator'
+      type: 'separator',
     },
     {
       label: 'Bring All to Front',
-      role: 'front'
+      role: 'front',
     }
-  ]
+  ];
+
+  return template;
 }
 
-module.exports = template;
+module.exports = createTemplate;

--- a/app/menu.js
+++ b/app/menu.js
@@ -2,6 +2,14 @@ const {Menu} = require('electron')
 
 const template = [
   {
+    label: 'File',
+    submenu: [
+      {
+        role: 'exit'
+      },
+    ]
+  },
+  {
     label: 'Edit',
     submenu: [
       {
@@ -37,24 +45,6 @@ const template = [
     label: 'View',
     submenu: [
       {
-        label: 'Debug Log'
-      },
-      {
-        type: 'separator'
-      },
-      {
-        role: 'reload'
-      },
-      {
-        role: 'forcereload'
-      },
-      {
-        role: 'toggledevtools'
-      },
-      {
-        type: 'separator'
-      },
-      {
         role: 'resetzoom'
       },
       {
@@ -68,7 +58,19 @@ const template = [
       },
       {
         role: 'togglefullscreen'
-      }
+      },
+      {
+        type: 'separator'
+      },
+      {
+        label: 'Debug Log'
+      },
+      {
+        type: 'separator'
+      },
+      {
+        role: 'toggledevtools'
+      },
     ]
   },
   {
@@ -81,10 +83,24 @@ const template = [
         role: 'close'
       }
     ]
+  },
+  {
+    role: 'help',
+    submenu: [
+      {
+        role: 'about'
+      }
+    ]
   }
 ]
 
 if (process.platform === 'darwin') {
+  // get rid of File menu
+  template.shift();
+
+  // get rid of Help menu
+  template.pop();
+
   template.unshift({
     submenu: [
       {
@@ -110,7 +126,8 @@ if (process.platform === 'darwin') {
       }
     ]
   })
-  // Edit menu.
+
+  // Add to Edit menu
   template[1].submenu.push(
     {
       type: 'separator'
@@ -127,7 +144,8 @@ if (process.platform === 'darwin') {
       ]
     }
   )
-  // Window menu.
+
+  // Add to Window menu
   template[3].submenu = [
     {
       label: 'Close',

--- a/js/views/inbox_view.js
+++ b/js/views/inbox_view.js
@@ -147,7 +147,6 @@
             welcomeToSignal         : i18n('welcomeToSignal'),
             selectAContact          : i18n('selectAContact'),
             searchForPeopleOrGroups : i18n('searchForPeopleOrGroups'),
-            submitDebugLog          : i18n('submitDebugLog'),
             settings                : i18n('settings'),
             restartSignal           : i18n('restartSignal'),
         },

--- a/js/views/install_view.js
+++ b/js/views/install_view.js
@@ -45,13 +45,7 @@
 
             var deviceName = textsecure.storage.user.getDeviceName();
             if (!deviceName) {
-                if (navigator.userAgent.match('Mac OS')) {
-                    deviceName = 'Mac';
-                } else if (navigator.userAgent.match('Linux')) {
-                    deviceName = 'Linux';
-                } else if (navigator.userAgent.match('Windows')) {
-                    deviceName = 'Windows';
-                }
+                deviceName = window.config.hostname;
             }
 
             this.$('#device-name').val(deviceName);

--- a/main.js
+++ b/main.js
@@ -186,6 +186,12 @@ function showDebugLog() {
   }
 }
 
+function showWindow() {
+  if (mainWindow) {
+    mainWindow.show();
+  }
+};
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
@@ -200,16 +206,12 @@ app.on('ready', function() {
 
   createWindow();
 
-  let template = require('./app/menu.js');
-
-  if (process.platform === 'darwin') {
-    template[3].submenu[3].click = function() {
-      mainWindow.show();
-    };
-    template[2].submenu[0].click = showDebugLog;
-  } else {
-    template[1].submenu[0].click = showDebugLog;
-  }
+  const options = {
+    showDebugLog,
+    showWindow,
+  };
+  const createTemplate = require('./app/menu.js');
+  const template = createTemplate(options);
 
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);

--- a/main.js
+++ b/main.js
@@ -52,6 +52,24 @@ const loadLocale = require('./app/locale').load;
 
 let locale;
 
+function prepareURL(pathSegments) {
+  return url.format({
+    pathname: path.join.apply(null, pathSegments),
+    protocol: 'file:',
+    slashes: true,
+    query: {
+      locale: locale.name,
+      version: app.getVersion(),
+      buildExpiration: config.get('buildExpiration'),
+      serverUrl: config.get('serverUrl'),
+      cdnUrl: config.get('cdnUrl'),
+      certificateAuthorities: config.get('certificateAuthorities'),
+      environment: config.environment,
+      node_version: process.versions.node
+    }
+  })
+}
+
 function createWindow () {
   const windowOptions = Object.assign({
     width: 800,
@@ -108,24 +126,6 @@ function createWindow () {
   ipc.on('locale-data', function(event, arg) {
     event.returnValue = locale.messages;
   });
-
-  function prepareURL(pathSegments) {
-    return url.format({
-      pathname: path.join.apply(null, pathSegments),
-      protocol: 'file:',
-      slashes: true,
-      query: {
-        locale: locale.name,
-        version: app.getVersion(),
-        buildExpiration: config.get('buildExpiration'),
-        serverUrl: config.get('serverUrl'),
-        cdnUrl: config.get('cdnUrl'),
-        certificateAuthorities: config.get('certificateAuthorities'),
-        environment: config.environment,
-        node_version: process.versions.node
-      }
-    })
-  }
 
   if (config.environment === 'test') {
     mainWindow.loadURL(prepareURL([__dirname, 'test', 'index.html']));
@@ -192,6 +192,27 @@ function showWindow() {
   }
 };
 
+let aboutWindow;
+function showAbout() {
+  if (!aboutWindow) {
+    const options = {
+      width: 800,
+      height: 610,
+      minWidth: 700,
+      minHeight: 360,
+      webPreferences: {
+        nodeIntegration: false,
+        //sandbox: true,
+        preload: path.join(__dirname, 'preload.js')
+      }
+    };
+
+    aboutWindow = new BrowserWindow(options);
+
+    aboutWindow.loadURL(prepareURL([__dirname, 'about.html']));
+  }
+}
+
 // This method will be called when Electron has finished
 // initialization and is ready to create browser windows.
 // Some APIs can only be used after this event occurs.
@@ -209,6 +230,7 @@ app.on('ready', function() {
   const options = {
     showDebugLog,
     showWindow,
+    showAbout,
   };
   const createTemplate = require('./app/menu.js');
   const template = createTemplate(options);

--- a/main.js
+++ b/main.js
@@ -232,6 +232,7 @@ function showAbout() {
     title: locale.messages.aboutSignalDesktop.message,
     autoHideMenuBar: true,
     backgroundColor: '#2090EA',
+    show: false,
     webPreferences: {
       nodeIntegration: false,
       preload: path.join(__dirname, 'preload.js')
@@ -246,6 +247,10 @@ function showAbout() {
 
   aboutWindow.on('closed', function () {
     aboutWindow = null;
+  });
+
+  aboutWindow.once('ready-to-show', function() {
+    aboutWindow.show();
   });
 }
 

--- a/preload.js
+++ b/preload.js
@@ -1,9 +1,6 @@
 (function () {
   'use strict';
 
-  window.version = require('./package.json').version;
-  window.hostname = require('os').hostname();
-
   console.log('preload');
   const electron = require('electron');
 

--- a/preload.js
+++ b/preload.js
@@ -1,6 +1,9 @@
 (function () {
   'use strict';
 
+  window.version = require('./package.json').version;
+  window.hostname = require('os').hostname();
+
   console.log('preload');
   const electron = require('electron');
 

--- a/test/index.html
+++ b/test/index.html
@@ -47,7 +47,6 @@
                 <button class='hamburger' alt='signal menu'></button>
                 <ul class='menu-list'>
                     <li class='showSettings'>{{ settings }}</li>
-                    <li class='show-debug-log'>{{ submitDebugLog }}</li>
                     <li class='restart-signal'>{{ restartSignal }}</li>
                 </ul>
               </div>


### PR DESCRIPTION
Quite a few changes made in this PR
- All menu item labels provided by us (and not by built-in Electron roles) are now localizable
- There's now an About box you can get to on Windows and Linux
- The help menu now has four new items: Go to release notes, Go to forums, Go to support, File a bug

`app/menu.js` was changed radically to return a function that creates the menu based on provided 
actions and locale-specific messages. The menu creation code was also refactored to put all the Mac-related menu manipulation in one place.

Lastly, there's one little bonus in this change - when setting up a new desktop app, we now set the machine's hostname as the default device name. Only we developers have a lot of different OSes we install the app on.