### PR TITLE
Fix deployment: No longer use CI windows assets, include about.html

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -285,9 +285,6 @@ module.exports = function(grunt) {
     var files = [{
       zip: 'signal-desktop-' + package_json.version + '.zip',
       extractedTo: 'linux'
-    }, {
-      zip: 'Signal-win-' + package_json.version + '.zip',
-      extractedTo: 'windows'
     }];
 
     var extract = require('extract-zip');

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,12 +22,5 @@ test_script:
   - node build\grunt.js test-release:win
   - node build\grunt.js test
 
-artifacts:
-  - path: dist/*.*
-
 environment:
   SIGNAL_ENV: production
-
-deploy:
-  provider: Environment
-  name: signal-desktop-builds

--- a/fix_broken_perms.sh
+++ b/fix_broken_perms.sh
@@ -1,6 +1,4 @@
 set -e
 find release/linux -type d | xargs chmod 755
 find release/linux -type f | xargs chmod 644
-find release/windows -type d | xargs chmod 755
-find release/windows -type f | xargs chmod 644
 chmod +x release/linux/signal-desktop

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
       "config/${env.SIGNAL_ENV}.json",
       "config/local-${env.SIGNAL_ENV}.json",
       "background.html",
+      "about.html",
       "_locales/**",
       "protos/*",
       "js/**",


### PR DESCRIPTION
We no longer use the assets built on AppVeyor for windows, so we eliminate them from `AppVeyor.yml`, the `fetch-release` Grunt task, and the `fix_broken_perms.sh` script.

Also, the new About window shows up as blank in production because `about.html` is not included in the final build. It's now included.