### PR TITLE
Log when we've detected a new version

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -79,6 +79,14 @@
     function start() {
         ConversationController.load();
 
+        var currentVersion = window.config.version;
+        var lastVersion = storage.get('version');
+        storage.put('version', currentVersion);
+
+        if (!lastVersion || currentVersion !== lastVersion) {
+            console.log('New version detected:', currentVersion);
+        }
+
         window.dispatchEvent(new Event('storage_ready'));
 
         console.log('listening for registration events');


### PR DESCRIPTION
Helps with tracking down per-version bugs when log could contain output from more than one version.