### PR TITLE
Load profiles for a conversation without blocking convo load

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -470,11 +470,9 @@
             //   messages from the database, then ensure that the loading screen is only
             //   dismissed when that is complete.
             var messagesLoaded = this.inProgressFetch || Promise.resolve();
-            messagesLoaded = messagesLoaded.then(function() {
-                return this.model.decryptOldIncomingKeyErrors();
-            }.bind(this));
 
-            Promise.all([this.statusFetch, messagesLoaded])
+            messagesLoaded
+                .then(this.model.decryptOldIncomingKeyErrors.bind(this))
                 .then(this.onLoaded.bind(this), this.onLoaded.bind(this));
 
             this.view.resetScrollPosition();


### PR DESCRIPTION
If you've got a slow network connection, that's no reason to make the conversation load slow.