### PR TITLE
Remove all references to BitHub

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,6 @@
 - [ ] My changes are rebased on the latest master branch
 - [ ] My commits are in nice logical chunks
 - [ ] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
-- [ ] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my Git commit messages
 - [ ] I have tested my contribution on these platforms:
  * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
  * Amiga OS 3.1, Chrom{e,ium} Z.Y

--- a/README.md
+++ b/README.md
@@ -31,18 +31,11 @@ Please see
 for setup instructions and contributor guidelines. And don't forget to sign the
 [CLA](https://whispersystems.org/cla/).
 
-This repository is set up with [BitHub](https://whispersystems.org/blog/bithub/), so you can make money for committing to Signal. The current BitHub price for an accepted pull request is:
-
-[![Current BitHub Price](https://bithub.herokuapp.com/v1/status/payment/commit/)](https://whispersystems.org/blog/bithub/)
-
-
 ## Contributing Ideas
 Have something you want to say about Open Whisper Systems projects or want to be part of the conversation? Get involved in the [community forum](https://whispersystems.discoursehosting.net)!
 
 ## Contributing Funds
-[![Donate](https://cloud.githubusercontent.com/assets/3121306/11278543/d46e03d0-8eeb-11e5-9691-0da1bf643192.png)](https://www.coinbase.com/checkouts/51dac699e660a4d773216b5ad94d6a0b)
-
-You can add funds to [BitHub](https://whispersystems.org/blog/bithub/) to directly help further development efforts.
+You can donate to Signal development through the [Freedom of the Press Foundation](https://freedom.press/crowdfunding/signal/).
 
 ## Cryptography Notice
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

Since BitHub is broken and not coming back, the references to BitHub in the docs are obsolete and probably confusing to those who don't know that it's broken. This commit removes all references to BitHub in the repository.

See WhisperSystems/Signal-Android@258910504cc2fcc57b8868cb0ea210b21086d314