### PR TITLE
Fix copy pasta of timestamp_m to timestamp_h in locales

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 ساعة",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "توقف",

--- a/_locales/bg/messages.json
+++ b/_locales/bg/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 час",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "изключено",

--- a/_locales/cs/messages.json
+++ b/_locales/cs/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hodina",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "vyp.",

--- a/_locales/da/messages.json
+++ b/_locales/da/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hour",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "off",

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 Stunde",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "aus",

--- a/_locales/el/messages.json
+++ b/_locales/el/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 ώρα",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "Σβησμένο",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -695,7 +695,7 @@
        "message": "1 minute"
     },
     "timestamp_h": {
-       "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble.",
+       "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble.",
        "message": "1 hour"
     },
     "timestampFormat_M": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hora",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "inactivo",

--- a/_locales/es_419/messages.json
+++ b/_locales/es_419/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hora",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "apagado",

--- a/_locales/fa/messages.json
+++ b/_locales/fa/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 ساعت",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "خاموش",

--- a/_locales/fi/messages.json
+++ b/_locales/fi/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 tunti",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "poissa päältä",

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 heure",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "Désactivé",

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hour",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "off",

--- a/_locales/hi/messages.json
+++ b/_locales/hi/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hour",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "off",

--- a/_locales/hr/messages.json
+++ b/_locales/hr/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 sat",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "isključi",

--- a/_locales/hu/messages.json
+++ b/_locales/hu/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 órája",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "ki",

--- a/_locales/id/messages.json
+++ b/_locales/id/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 jam",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "padam",

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 ora",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "off",

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1時間",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "オフ",

--- a/_locales/kn/messages.json
+++ b/_locales/kn/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 ಗಂಟೆ",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "off",

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hour",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "off",

--- a/_locales/lt/messages.json
+++ b/_locales/lt/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 valanda",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "išjungta",

--- a/_locales/mk/messages.json
+++ b/_locales/mk/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hour",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "off",

--- a/_locales/nl/messages.json
+++ b/_locales/nl/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 uur",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "uit",

--- a/_locales/no/messages.json
+++ b/_locales/no/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 time",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "av",

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 godzina",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "wyłącz",

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hora",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "desligar",

--- a/_locales/pt_PT/messages.json
+++ b/_locales/pt_PT/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hora",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "desligado",

--- a/_locales/ro/messages.json
+++ b/_locales/ro/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "o oră",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "Oprit",

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 час",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "выкл",

--- a/_locales/sk/messages.json
+++ b/_locales/sk/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 hour",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "vypnuté",

--- a/_locales/sl/messages.json
+++ b/_locales/sl/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 uro",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "Izključeno",

--- a/_locales/sr/messages.json
+++ b/_locales/sr/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 час",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "искљ.",

--- a/_locales/sv/messages.json
+++ b/_locales/sv/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 timme",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "av",

--- a/_locales/tr/messages.json
+++ b/_locales/tr/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 saat",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "kapalı",

--- a/_locales/uk/messages.json
+++ b/_locales/uk/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 година",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "вимкн",

--- a/_locales/vi/messages.json
+++ b/_locales/vi/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 giờ",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "Tắt",

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1小时",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "关闭",

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -151,7 +151,7 @@
     },
     "timestamp_h": {
         "message": "1 小時",
-        "description": "Brief timestamp for messages sent about one minute ago. Displayed in the conversation list and message bubble."
+        "description": "Brief timestamp for messages sent about one hour ago. Displayed in the conversation list and message bubble."
     },
     "timerOption_0_seconds_abbreviated": {
         "message": "關閉",


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [n/a] I have tested my contribution on these platforms:
 * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
 * Amiga OS 3.1, Chrom{e,ium} Z.Y
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->

Looks like a sneaky copy-pasta event where timestamp_s and timestamp_m descriptions in the locale files were accurate, but timestamp_h repeated the info for timestamp_m.

I didn't test any further than `grunt unit-tests` because I didn't think the "description" field is used in any code, let me know if this isn't the case and I need to test further.