### PR TITLE
 Add 5s timeout for all requests except attachment up/down, avatar

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37461,22 +37461,8 @@ var TextSecureServer = (function() {
         return true;
     }
 
-    // On Linux/Electron multiple quick web requests can result in the Node.js event
-    //   loop getting wedged. Bug: https://github.com/electron/electron/issues/10570
-    //   This forces the event loop to move.
-    function scheduleHangWorkaround() {
-        setTimeout(function() {
-            setImmediate(function() {
-                // noop
-            });
-        }, 1000);
-    }
-
     function createSocket(url) {
       var requestOptions = { ca: window.config.certificateAuthorities };
-
-      scheduleHangWorkaround();
-
       return new nodeWebSocket(url, null, null, null, requestOptions);
     }
 
@@ -37544,7 +37530,6 @@ var TextSecureServer = (function() {
           console.log(e);
           reject(HTTPError(0, e.toString(), options.stack));
         });
-        scheduleHangWorkaround();
       });
     }
 

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37474,11 +37474,14 @@ var TextSecureServer = (function() {
             url = options.host +  '/' + options.path;
         }
         console.log(options.type, url);
+        var timeout = typeof options.timeout !== 'undefined' ? options.timeout : 5000;
+
         var fetchOptions = {
           method: options.type,
           body: options.data || null,
           headers: { 'X-Signal-Agent': 'OWD' },
-          agent: new httpsAgent({ca: options.certificateAuthorities})
+          agent: new httpsAgent({ca: options.certificateAuthorities}),
+          timeout: timeout
         };
 
         if (fetchOptions.body instanceof ArrayBuffer) {
@@ -37517,7 +37520,7 @@ var TextSecureServer = (function() {
                 }
               }
             }
-            if ( 0 <= response.status && response.status < 400) {
+            if (0 <= response.status && response.status < 400) {
               console.log(options.type, url, response.status, 'Success');
               resolve(result, response.status);
             } else {
@@ -37605,7 +37608,8 @@ var TextSecureServer = (function() {
                     user         : this.username,
                     password     : this.password,
                     validateResponse: param.validateResponse,
-                    certificateAuthorities: window.config.certificateAuthorities
+                    certificateAuthorities: window.config.certificateAuthorities,
+                    timeout      : param.timeout
             }).catch(function(e) {
                 var code = e.code;
                 if (code === 200) {
@@ -37654,7 +37658,8 @@ var TextSecureServer = (function() {
                 type        : "GET",
                 responseType: "arraybuffer",
                 contentType : "application/octet-stream",
-                certificateAuthorities: window.config.certificateAuthorities
+                certificateAuthorities: window.config.certificateAuthorities,
+                timeout: 0
             });
         },
         requestVerificationSMS: function(number) {
@@ -37812,7 +37817,8 @@ var TextSecureServer = (function() {
                 httpType            : 'GET',
                 urlParameters       : '/' + id,
                 responseType        : 'json',
-                validateResponse    : {location: 'string'}
+                validateResponse    : {location: 'string'},
+                timeout             : 0
             }).then(function(response) {
                 return ajax(response.location, {
                     type        : "GET",
@@ -37826,6 +37832,7 @@ var TextSecureServer = (function() {
                 call         : 'attachment',
                 httpType     : 'GET',
                 responseType : 'json',
+                timeout      : 0
             }).then(function(response) {
                 return ajax(response.location, {
                     type        : "PUT",

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -37,11 +37,14 @@ var TextSecureServer = (function() {
             url = options.host +  '/' + options.path;
         }
         console.log(options.type, url);
+        var timeout = typeof options.timeout !== 'undefined' ? options.timeout : 5000;
+
         var fetchOptions = {
           method: options.type,
           body: options.data || null,
           headers: { 'X-Signal-Agent': 'OWD' },
-          agent: new httpsAgent({ca: options.certificateAuthorities})
+          agent: new httpsAgent({ca: options.certificateAuthorities}),
+          timeout: timeout
         };
 
         if (fetchOptions.body instanceof ArrayBuffer) {
@@ -80,7 +83,7 @@ var TextSecureServer = (function() {
                 }
               }
             }
-            if ( 0 <= response.status && response.status < 400) {
+            if (0 <= response.status && response.status < 400) {
               console.log(options.type, url, response.status, 'Success');
               resolve(result, response.status);
             } else {
@@ -168,7 +171,8 @@ var TextSecureServer = (function() {
                     user         : this.username,
                     password     : this.password,
                     validateResponse: param.validateResponse,
-                    certificateAuthorities: window.config.certificateAuthorities
+                    certificateAuthorities: window.config.certificateAuthorities,
+                    timeout      : param.timeout
             }).catch(function(e) {
                 var code = e.code;
                 if (code === 200) {
@@ -217,7 +221,8 @@ var TextSecureServer = (function() {
                 type        : "GET",
                 responseType: "arraybuffer",
                 contentType : "application/octet-stream",
-                certificateAuthorities: window.config.certificateAuthorities
+                certificateAuthorities: window.config.certificateAuthorities,
+                timeout: 0
             });
         },
         requestVerificationSMS: function(number) {
@@ -375,7 +380,8 @@ var TextSecureServer = (function() {
                 httpType            : 'GET',
                 urlParameters       : '/' + id,
                 responseType        : 'json',
-                validateResponse    : {location: 'string'}
+                validateResponse    : {location: 'string'},
+                timeout             : 0
             }).then(function(response) {
                 return ajax(response.location, {
                     type        : "GET",
@@ -389,6 +395,7 @@ var TextSecureServer = (function() {
                 call         : 'attachment',
                 httpType     : 'GET',
                 responseType : 'json',
+                timeout      : 0
             }).then(function(response) {
                 return ajax(response.location, {
                     type        : "PUT",

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -24,22 +24,8 @@ var TextSecureServer = (function() {
         return true;
     }
 
-    // On Linux/Electron multiple quick web requests can result in the Node.js event
-    //   loop getting wedged. Bug: https://github.com/electron/electron/issues/10570
-    //   This forces the event loop to move.
-    function scheduleHangWorkaround() {
-        setTimeout(function() {
-            setImmediate(function() {
-                // noop
-            });
-        }, 1000);
-    }
-
     function createSocket(url) {
       var requestOptions = { ca: window.config.certificateAuthorities };
-
-      scheduleHangWorkaround();
-
       return new nodeWebSocket(url, null, null, null, requestOptions);
     }
 
@@ -107,7 +93,6 @@ var TextSecureServer = (function() {
           console.log(e);
           reject(HTTPError(0, e.toString(), options.stack));
         });
-        scheduleHangWorkaround();
       });
     }
 


### PR DESCRIPTION
We've seen some logs where some requests take more than 30s to return. This change introduces a timeout provided to `node-fetch` of 5s by default, and unlimited when dealing with large files: download or upload of an attachment, or download of an avatar.