### PR TITLE
Fix timeouts

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37818,9 +37818,9 @@ var TextSecureServer = (function() {
                 urlParameters       : '/' + id,
                 responseType        : 'json',
                 validateResponse    : {location: 'string'},
-                timeout             : 0
             }).then(function(response) {
                 return ajax(response.location, {
+                    timeout     : 0
                     type        : "GET",
                     responseType: "arraybuffer",
                     contentType : "application/octet-stream"
@@ -37832,9 +37832,9 @@ var TextSecureServer = (function() {
                 call         : 'attachment',
                 httpType     : 'GET',
                 responseType : 'json',
-                timeout      : 0
             }).then(function(response) {
                 return ajax(response.location, {
+                    timeout     : 0
                     type        : "PUT",
                     contentType : "application/octet-stream",
                     data        : encryptedBin,

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -381,9 +381,9 @@ var TextSecureServer = (function() {
                 urlParameters       : '/' + id,
                 responseType        : 'json',
                 validateResponse    : {location: 'string'},
-                timeout             : 0
             }).then(function(response) {
                 return ajax(response.location, {
+                    timeout     : 0
                     type        : "GET",
                     responseType: "arraybuffer",
                     contentType : "application/octet-stream"
@@ -395,9 +395,9 @@ var TextSecureServer = (function() {
                 call         : 'attachment',
                 httpType     : 'GET',
                 responseType : 'json',
-                timeout      : 0
             }).then(function(response) {
                 return ajax(response.location, {
+                    timeout     : 0
                     type        : "PUT",
                     contentType : "application/octet-stream",
                     data        : encryptedBin,


### PR DESCRIPTION
These 0's are intended to disable request timeouts on attachment upload and download since those can take a while for large files, but they should be applied to the s3 requests, not the signal server requests that return the urls for the s3 requests.