### PR TITLE
Better handling of online/offline behavior, socket shutdown

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -185,6 +185,10 @@
             disconnectTimer = null;
             return;
         }
+        if (disconnectTimer) {
+            clearTimeout(disconnectTimer);
+            disconnectTimer = null;
+        }
 
         connect();
     }

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38351,7 +38351,7 @@ var TextSecureServer = (function() {
                 ev.code = code;
                 ev.reason = reason;
                 this.dispatchEvent(ev);
-            }.bind(this), 10000);
+            }.bind(this), 1000);
         };
     };
     window.WebSocketResource.prototype = new textsecure.EventTarget();
@@ -38435,6 +38435,10 @@ MessageReceiver.prototype = new textsecure.EventTarget();
 MessageReceiver.prototype.extend({
     constructor: MessageReceiver,
     connect: function() {
+        if (this.calledClose) {
+            return;
+        }
+
         this.hasConnected = true;
 
         if (this.socket && this.socket.readyState !== WebSocket.CLOSED) {
@@ -38484,8 +38488,6 @@ MessageReceiver.prototype.extend({
         if (this.wsr) {
             this.wsr.close(3000, 'called close');
         }
-
-        this.shutdown();
 
         return this.drain();
     },

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -28,6 +28,10 @@ MessageReceiver.prototype = new textsecure.EventTarget();
 MessageReceiver.prototype.extend({
     constructor: MessageReceiver,
     connect: function() {
+        if (this.calledClose) {
+            return;
+        }
+
         this.hasConnected = true;
 
         if (this.socket && this.socket.readyState !== WebSocket.CLOSED) {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -82,8 +82,6 @@ MessageReceiver.prototype.extend({
             this.wsr.close(3000, 'called close');
         }
 
-        this.shutdown();
-
         return this.drain();
     },
     onopen: function() {

--- a/libtextsecure/websocket-resources.js
+++ b/libtextsecure/websocket-resources.js
@@ -182,7 +182,7 @@
                 ev.code = code;
                 ev.reason = reason;
                 this.dispatchEvent(ev);
-            }.bind(this), 10000);
+            }.bind(this), 1000);
         };
     };
     window.WebSocketResource.prototype = new textsecure.EventTarget();


### PR DESCRIPTION
We got a user log showing an overlap in online/offline events and our check to see if we were offline in the `onclose` method of `MessageReceiver`. This change prevents that kind of race condition. It also attempts to make the experience better on Linux with changing network conditions.

The changes:
- In `background.js` we stop the `disconnectTimer` even if we weren't already connected to the socket
- In `MessageReceiver` we don't try to connect again if `calledClose` is true
- In `WebSocketResource` we wait just 1s before sending our own socket `close` event
- In `MessageReceiver` we no longer `shutdown()` in `close()` - we actually wait for the socket (or `WebSocketResource` to send us the `close` event.