### PR TITLE
Re-enable read receipts and read syncs

### DIFF
--- a/js/models/conversations.js
+++ b/js/models/conversations.js
@@ -784,10 +784,11 @@
                                 'it was not in messageCollection.');
                 }
                 promises.push(m.markRead());
+                var errors = m.get('errors');
                 return {
                     sender    : m.get('source'),
                     timestamp : m.get('sent_at'),
-                    hasErrors : Boolean(m.get('errors'))
+                    hasErrors : Boolean(errors && errors.length)
                 };
             }.bind(this));
 


### PR DESCRIPTION
Turns out that sometimes a message with no errors has an empty array, and sometimes it has just null. Now we handle both.