### PR TITLE
Fix json parsing exceptions obscuring server errors

### DIFF
--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37501,12 +37501,13 @@ var TextSecureServer = (function() {
         }
         window.nodeFetch(url, fetchOptions).then(function(response) {
           var resultPromise;
-          if (options.responseType === 'json') {
+          if (options.responseType === 'json'
+              && response.headers.get('Content-Type') === 'application/json') {
             resultPromise = response.json();
-          } else if (!options.responseType || options.responseType === 'text') {
-            resultPromise = response.text();
           } else if (options.responseType === 'arraybuffer') {
             resultPromise = response.buffer();
+          } else {
+            resultPromise = response.text();
           }
           return resultPromise.then(function(result) {
             if (options.responseType === 'arraybuffer') {

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -64,12 +64,13 @@ var TextSecureServer = (function() {
         }
         window.nodeFetch(url, fetchOptions).then(function(response) {
           var resultPromise;
-          if (options.responseType === 'json') {
+          if (options.responseType === 'json'
+              && response.headers.get('Content-Type') === 'application/json') {
             resultPromise = response.json();
-          } else if (!options.responseType || options.responseType === 'text') {
-            resultPromise = response.text();
           } else if (options.responseType === 'arraybuffer') {
             resultPromise = response.buffer();
+          } else {
+            resultPromise = response.text();
           }
           return resultPromise.then(function(result) {
             if (options.responseType === 'arraybuffer') {


### PR DESCRIPTION
I got a 413 (Rate limit exceeded) error from the server while fetching prekeys. The client tried to parse the response as json since we expect json from the prekey endpoint, which threw an exception because the response is not json in this case.

This caused us to present the failure as a general network failure instead of a rate limit issue. The overall impact on UX was minimal, since the resend button appeared and worked as expected, but the error message was wrong.

This change prevents us from treating the response as json unless it has the Content-Type header set accordingly. If for some reason, the client and server disagree on whether the response
should be or is json, we'll default to treating it as text.

// FREEBIE
