### PR TITLE
Fixed drawAttention() position to comply with user's settings

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -42,8 +42,6 @@
                 return;
             }
 
-            window.drawAttention();
-
             var audioNotification = storage.get('audio-notification') || false;
             if (audioNotification) {
                 sound.play();
@@ -53,6 +51,8 @@
             if (setting === SETTINGS.OFF) {
                 return;
             }
+
+            window.drawAttention();
 
             var title;
             var message;


### PR DESCRIPTION
This fix is related about issue #1587
window.drawAttention() repositioned to allow complete control over notifications by settings. It now does not draw attention when the notifications are off.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My contribution is fully baked and ready to be merged as is
- [X] My changes are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [ ] I have tested my contribution on these platforms:
 * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
 * Amiga OS 3.1, Chrom{e,ium} Z.Y
- [ ] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [X] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->
In fact, didn't do any test because I didn't set my development environment yet and the fix is too easy.
