### PR TITLE
Clean up attachments with unexpected structure

### DIFF
--- a/background.html
+++ b/background.html
@@ -23,6 +23,9 @@
         {{ #debugLogButton }}
           <button class='debug-log grey'>{{ debugLogButton }}</button>
         {{ /debugLogButton }}
+        {{ #cancelButton }}
+          <button class='cancel grey'>{{ cancelButton }}</button>
+        {{ /cancelButton }}
       </div>
     </div>
   </script>

--- a/js/database.js
+++ b/js/database.js
@@ -51,7 +51,7 @@
         }
 
         return changed;
-    }
+    };
 
     Whisper.Database.migrations = [
         {

--- a/js/database.js
+++ b/js/database.js
@@ -319,6 +319,15 @@
                         }
                     }
 
+                    var attachmentsWithData = _.filter(attachments, function(attachment) {
+                        return attachment.data;
+                    });
+
+                    if (attachments.length !== attachmentsWithData.length) {
+                        attributes.attachments = attachmentsWithData;
+                        changed = true;
+                    }
+
                     if (!changed) {
                         return cursor.continue();
                     }

--- a/js/database.js
+++ b/js/database.js
@@ -9,6 +9,50 @@
     window.Whisper.Database.id = window.Whisper.Database.id || 'signal';
     window.Whisper.Database.nolog = true;
 
+    window.Whisper.Database.cleanMessageAttachments = function(message) {
+        var attachments = message.attachments;
+        var changed = false;
+
+        if (!attachments || !attachments.length) {
+            return false;
+        }
+
+        for (var i = 0, max = attachments.length; i < max; i += 1) {
+            var attachment = attachments[i];
+
+            // catch missing and non-string filenames
+            if (typeof attachment.fileName !== 'string') {
+                if (attachment.fileName) {
+                    delete attachment.fileName;
+                    changed = true;
+                }
+
+                // if id is falsey, or neither number or string, we make our own id
+                if (!attachment.id || (typeof attachment.id !== 'number' && typeof attachment.id !== 'string')) {
+                    attachment.id = _.uniqueId('attachment');
+                    changed = true;
+                }
+            }
+            // if contentType is truthy, we ensure it's a string
+            if (attachment.contentType && typeof attachment.contentType !== 'string') {
+                delete attachment.contentType;
+                changed = true;
+            }
+        }
+
+        // elminate all attachments without data
+        var attachmentsWithData = _.filter(attachments, function(attachment) {
+            return attachment.data;
+        });
+
+        if (attachments.length !== attachmentsWithData.length) {
+            message.attachments = attachmentsWithData;
+            changed = true;
+        }
+
+        return changed;
+    }
+
     Whisper.Database.migrations = [
         {
             version: "1.0",
@@ -276,7 +320,7 @@
             }
         },
         {
-            version: "16.0",
+            version: "17.0",
             migrate: function(transaction, next) {
                 console.log('migration 16.0');
                 console.log('Cleaning up dirty attachment data');
@@ -294,49 +338,15 @@
                         });
                     }
 
-                    var attributes = cursor.value;
-
-                    var attachments = attributes.attachments;
-                    if (!attachments || !attachments.length) {
-                        return cursor.continue();
-                    }
-
-                    var changed = false;
-                    for (var i = 0, max = attachments.length; i < max; i += 1) {
-                        var attachment = attachments[i];
-
-                        if (typeof attachment.fileName !== 'string') {
-                            if (attachment.fileName) {
-                                delete attachment.fileName;
-                                changed = true;
-                            }
-
-                            if (!attachment.id || (typeof attachment.id !== 'number' && typeof attachment.id !== 'string')) {
-                                attachment.id = _.uniqueId('attachment');
-                                changed = true;
-                            }
-                        }
-                        if (attachment.contentType && typeof attachment.contentType !== 'string') {
-                            delete attachment.contentType;
-                            changed = true;
-                        }
-                    }
-
-                    var attachmentsWithData = _.filter(attachments, function(attachment) {
-                        return attachment.data;
-                    });
-
-                    if (attachments.length !== attachmentsWithData.length) {
-                        attributes.attachments = attachmentsWithData;
-                        changed = true;
-                    }
+                    var message = cursor.value;
+                    var changed = window.Whisper.Database.cleanMessageAttachments(message);
 
                     if (!changed) {
                         return cursor.continue();
                     }
 
                     promises.push(new Promise(function(resolve, reject) {
-                        var putRequest = messages.put(attributes, attributes.id);
+                        var putRequest = messages.put(message, message.id);
                         putRequest.onsuccess = resolve;
                         putRequest.onerror = function(e) {
                             console.log(e);

--- a/js/database.js
+++ b/js/database.js
@@ -320,7 +320,7 @@
             }
         },
         {
-            version: "17.0",
+            version: "16.0",
             migrate: function(transaction, next) {
                 console.log('migration 16.0');
                 console.log('Cleaning up dirty attachment data');

--- a/js/database.js
+++ b/js/database.js
@@ -305,13 +305,16 @@
                     for (var i = 0, max = attachments.length; i < max; i += 1) {
                         var attachment = attachments[i];
 
-                        if (attachment.fileName && typeof attachment.fileName !== 'string') {
-                            delete attachment.fileName;
-                            changed = true;
-                        }
-                        if (!attachment.id || (typeof attachment.id !== 'number' && typeof attachment.id !== 'string')) {
-                            attachment.id = _.uniqueId('attachment');
-                            changed = true;
+                        if (typeof attachment.fileName !== 'string') {
+                            if (attachment.fileName) {
+                                delete attachment.fileName;
+                                changed = true;
+                            }
+
+                            if (!attachment.id || (typeof attachment.id !== 'number' && typeof attachment.id !== 'string')) {
+                                attachment.id = _.uniqueId('attachment');
+                                changed = true;
+                            }
                         }
                         if (attachment.contentType && typeof attachment.contentType !== 'string') {
                             delete attachment.contentType;

--- a/js/storage.js
+++ b/js/storage.js
@@ -44,8 +44,12 @@
             var item = items.get("" + key);
             if (item) {
                 items.remove(item);
-                item.destroy();
+                return new Promise(function(resolve, reject) {
+                    item.destroy().then(resolve, reject);
+                });
             }
+
+            return Promise.resolve();
         },
 
         onready: function(callback) {

--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -23,7 +23,7 @@
       }
     },
     cancel: function() {
-      storage.remove('migrationState');
+      return storage.remove('migrationState');
     },
     beginExport: function() {
       storage.put('migrationState', State.EXPORTING);
@@ -48,6 +48,7 @@
       'click .install': 'onClickInstall',
       'click .export': 'onClickExport',
       'click .debug-log': 'onClickDebugLog',
+      'click .cancel': 'onClickCancel',
     },
     initialize: function() {
       if (!Whisper.Migration.inProgress()) {
@@ -71,13 +72,20 @@
       var hideProgress = Whisper.Migration.isComplete();
       var debugLogButton = i18n('submitDebugLog');
       var installButton = i18n('installNewSignal');
+      var cancelButton;
 
       if (this.error) {
+        // If we've never successfully exported, then we allow user to cancel out
+        if (!Whisper.Migration.everComplete()) {
+          cancelButton = i18n('cancel');
+        }
+
         return {
           message: i18n('exportError'),
           hideProgress: true,
           exportButton: i18n('exportAgain'),
           debugLogButton: i18n('submitDebugLog'),
+          cancelButton: cancelButton,
         };
       }
 
@@ -109,11 +117,19 @@
         exportButton: exportButton,
         debugLogButton: debugLogButton,
         installButton: installButton,
+        cancelButton: cancelButton,
       };
     },
     onClickInstall: function() {
       var url = 'https://support.whispersystems.org/hc/en-us/articles/214507138';
       window.open(url, '_blank');
+    },
+    onClickCancel: function() {
+      console.log('Cancelling out of migration workflow after error');
+      Whisper.Migration.cancel().then(function() {
+        console.log('Restarting now');
+        window.location.reload();
+      });
     },
     onClickDebugLog: function() {
       this.openDebugLog();

--- a/test/database_test.js
+++ b/test/database_test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+describe('Database', function() {
+  describe('cleanMessageAttachments', function() {
+    it('does not modify a message with no attachments field', function() {
+      const message = {};
+      const actual = window.Whisper.Database.cleanMessageAttachments(message);
+
+      assert.strictEqual(actual, false);
+    });
+
+    it('does not modify a message with no attachments', function() {
+      const message = {
+        attachments: [],
+      };
+      const actual = window.Whisper.Database.cleanMessageAttachments(message);
+
+      assert.strictEqual(actual, false);
+    });
+
+    it('does not modify a message with an attachment with a string fileName', function() {
+      const message = {
+        attachments: [{
+          fileName: 'blah.jpg',
+          data: 'something',
+        }],
+      };
+      const actual = window.Whisper.Database.cleanMessageAttachments(message);
+
+      assert.strictEqual(actual, false);
+    });
+
+    it('does not modify a message with an attachment with no fileName and a number id', function() {
+      const message = {
+        attachments: [{
+          id: 4,
+          data: 'something',
+        }],
+      };
+      const actual = window.Whisper.Database.cleanMessageAttachments(message);
+
+      console.log(message);
+      assert.strictEqual(actual, false);
+    });
+
+    it('does not modify a message with an attachment with no fileName and a string id', function() {
+      const message = {
+        attachments: [{
+          id: '4',
+          data: 'something',
+        }],
+      };
+      const actual = window.Whisper.Database.cleanMessageAttachments(message);
+      console.log(message);
+
+      assert.strictEqual(actual, false);
+    });
+
+    it('eliminates non-string fileName', function() {
+      const message = {
+        attachments: [{
+          fileName: 4,
+          data: 'something',
+        }],
+      };
+      const actual = window.Whisper.Database.cleanMessageAttachments(message);
+
+      assert.isUndefined(message.attachments[0].fileName);
+      assert.strictEqual(actual, true);
+    });
+
+    it('eliminates object id', function() {
+      const message = {
+        attachments: [{
+          id: {
+            info: 'yes',
+          },
+          data: 'something',
+        }],
+      };
+      const actual = window.Whisper.Database.cleanMessageAttachments(message);
+
+      assert.strictEqual(typeof message.attachments[0].id, 'string');
+      assert.strictEqual(actual, true);
+    });
+
+    it('eliminates non-string contentType', function() {
+      const message = {
+        attachments: [{
+          contentType: 4,
+          data: 'something',
+        }],
+      };
+      const actual = window.Whisper.Database.cleanMessageAttachments(message);
+
+      assert.isUndefined(message.attachments[0].contentType);
+      assert.strictEqual(actual, true);
+    });
+
+    it('drops an attachment with no data attribute', function() {
+      const message = {
+        attachments: [{
+          id: 1,
+          data: null,
+        }, {
+          id: 2,
+          data: 'something'
+        }],
+      };
+      const actual = window.Whisper.Database.cleanMessageAttachments(message);
+
+      assert.strictEqual(message.attachments.length, 1);
+      assert.strictEqual(message.attachments[0].id, 2);
+      assert.strictEqual(actual, true);
+    });
+  });
+});

--- a/test/index.html
+++ b/test/index.html
@@ -650,6 +650,7 @@
   <script type="text/javascript" src="emoji_util_test.js"></script>
   <script type="text/javascript" src="reliable_trigger_test.js"></script>
   <script type="text/javascript" src="backup_test.js"></script>
+  <script type="text/javascript" src="database_test.js"></script>
 
   <script type="text/javascript" src="fixtures.js"></script>
   <script type="text/javascript" src="fixtures_test.js"></script>


### PR DESCRIPTION
This introduces a database upgrade which processes all messages with attachments, checking to see if they need a bit of help. The goal is to fix #1617 and fix #1616 (and their `InvalidModificationError` and `Invalid Buffer` errors).

The key culprits appear to be:
- no `fileName` and no `id` fields. So, if there's no string `fileName`, and `id` is not a string or number, then we generate our own unique id.
- no `data` field - we drop these attachments entirely

For good measure we also ensure that `fileName` and `contentType` are strings if they are present. Don't think these caused any problems, but why not do some quick checks?

**Bonus:** if the export process fails, we allow you to cancel out of the workflow and go back to use the app normally.