### PR TITLE
Export: remove zero-length attachments, devtools-only logging

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -219,6 +219,7 @@
 
   function createDirectory(parent, name) {
     var sanitized = sanitizeFileName(name);
+    console._log('-- about to create directory', sanitized);
     return new Promise(function(resolve, reject) {
       parent.getDirectory(sanitized, {create: true, exclusive: true}, resolve, reject);
     });
@@ -226,6 +227,7 @@
 
   function createFileAndWriter(parent, name) {
     var sanitized = sanitizeFileName(name);
+    console._log('-- about to create file', sanitized);
     return new Promise(function(resolve, reject) {
       parent.getFile(sanitized, {create: true, exclusive: true}, function(file) {
         return file.createWriter(function(writer) {
@@ -398,6 +400,7 @@
 
             if (attachments && attachments.length) {
               var process = function() {
+                console._log('-- writing attachments for message', message.id);
                 return writeAttachments(dir, name, messageId, attachments);
               };
               promiseChain = promiseChain.then(process);

--- a/test/database_test.js
+++ b/test/database_test.js
@@ -114,4 +114,54 @@ describe('Database', function() {
       assert.strictEqual(actual, true);
     });
   });
+
+  describe('dropZeroLengthAttachments', function() {
+    it('does not modify a message with no attachments field', function() {
+      const message = {};
+      const actual = window.Whisper.Database.dropZeroLengthAttachments(message);
+
+      assert.strictEqual(actual, false);
+    });
+
+    it('does not modify a message with no attachments', function() {
+      const message = {
+        attachments: [],
+      };
+      const actual = window.Whisper.Database.dropZeroLengthAttachments(message);
+
+      assert.strictEqual(actual, false);
+    });
+
+    it('does not modify a message with an attachment with a non-zero data field', function() {
+      const message = {
+        attachments: [{
+          fileName: 'blah.jpg',
+          data: 'something',
+        }],
+      };
+      const actual = window.Whisper.Database.dropZeroLengthAttachments(message);
+
+      assert.strictEqual(actual, false);
+    });
+
+    it('drops an attachment with null or zero-length data field', function() {
+      const message = {
+        attachments: [{
+          id: 1,
+          data: null,
+        }, {
+          id: 2,
+          data: [],
+        }, {
+          id: 3,
+          data: 'something'
+        }],
+      };
+      const actual = window.Whisper.Database.dropZeroLengthAttachments(message);
+
+      assert.strictEqual(message.attachments.length, 1);
+      assert.strictEqual(message.attachments[0].id, 3);
+      assert.strictEqual(actual, true);
+    });
+  });
 });


### PR DESCRIPTION
Because we're still getting `Illegal Buffer` errors on export, we remove all zero-length attachments.

Because previous attempts to clean up attachments didn't solve the `InvalidModificationError` errors, we log extra information to the devtools only. This will only show up for users monitoring the export with the DevTools open. It shows three things:
- Any time we try to create a directory
- Any time we try to create a file
- Any time we start writing attachments for a message, showing the message id

This should help with bug #1616