### PR TITLE
Cancel out of a complete migration

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,4 +1,16 @@
 {
+    "cancelMigration": {
+      "message": "Cancel migration",
+      "description": "Shown on 'export complete' screen, allowing user to use Chrome App again"
+    },
+    "continueMigration": {
+      "message": "Continue migration",
+      "description": "Shown on 'cancel migration' confirmation dialog, dismissing the dialog without restoring Chrome App use',"
+    },
+    "cancelWarning": {
+      "message": "Are you sure? If you import the data you've already exported, it will conflict with this installation. Please consider deleting all exported data if you continue with cancellation.",
+      "description": "Shown on a confirmation dialog presented before the user cancels out of the migration process"
+    },
     "loading": {
       "message": "Loading...",
       "description": "Message shown on the loading screen before we've loaded any messages"

--- a/js/backup.js
+++ b/js/backup.js
@@ -132,6 +132,12 @@
               stream.write('}').then(function() {
                 console.log('Finished writing all stores to disk');
                 resolve();
+              }, function(error) {
+                console.log(
+                  'Failed to write db.json to disk',
+                  error && error.stack ? error.stack : error
+                );
+                reject(error);
               });
             }
           }

--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -23,7 +23,11 @@
       }
     },
     cancel: function() {
-      return storage.remove('migrationState');
+      return Promise.all([
+        storage.remove('migrationState'),
+        storage.remove('migrationEverCompleted'),
+        storage.remove('migrationStorageLocation')
+      ]);
     },
     beginExport: function() {
       storage.put('migrationState', State.EXPORTING);
@@ -95,6 +99,7 @@
           message = i18n('exportComplete', location);
           exportButton = i18n('exportAgain');
           debugLogButton = null;
+          cancelButton = i18n('cancelMigration');
           break;
         case State.EXPORTING:
           message = i18n('exporting');
@@ -124,12 +129,23 @@
       var url = 'https://support.whispersystems.org/hc/en-us/articles/214507138';
       window.open(url, '_blank');
     },
-    onClickCancel: function() {
+    cancel: function() {
       console.log('Cancelling out of migration workflow after error');
       Whisper.Migration.cancel().then(function() {
         console.log('Restarting now');
         window.location.reload();
       });
+    },
+    onClickCancel: function() {
+      var dialog = new Whisper.ConfirmationDialogView({
+          message: i18n('cancelWarning'),
+          okText: i18n('cancelMigration'),
+          cancelText: i18n('continueMigration'),
+          resolve: this.cancel.bind(this),
+      });
+
+      this.$el.prepend(dialog.el);
+      dialog.focusCancel();
     },
     onClickDebugLog: function() {
       this.openDebugLog();
@@ -204,3 +220,4 @@
     }
   });
 }());
+


### PR DESCRIPTION
Because people are running into errors on import, or simply situations where they can't install the new standalone signal desktop, we now all cancellation of the migration.

And a little bonus: handling export errors from `stream.write()` a little bit better.