### PR TITLE
Export: Fixes and debugging, Migration: show install step first

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -15,12 +15,20 @@
       "message": "Loading...",
       "description": "Message shown on the loading screen before we've loaded any messages"
     },
+    "installComplete": {
+      "message": "Install is complete",
+      "description": "Button to click when user has installed the new Signal Desktop"
+    },
     "migrationWarning": {
       "message": "The Signal Desktop Chrome app has been deprecated. Would you like to migrate to the new Signal Desktop now?",
       "description": "Warning notification that this version of the app has been deprecated and the user must migrate"
     },
+    "migrateInstallStep": {
+      "message": "The first step is to install the new Signal Desktop.",
+      "description": "The first step in the export process; installing the standalone desktop app, to ensure it is available for that platform."
+    },
     "exportInstructions": {
-      "message": "The first step is to choose a directory to store this application's exported data. It will contain your message history and sensitive cryptographic data, so be sure to save it somewhere private.",
+      "message": "Now, choose a directory to store this application's exported data. It will contain your message history and sensitive cryptographic data, so be sure to save it somewhere private.",
       "description": "Description of the export process"
     },
     "migrate": {

--- a/background.html
+++ b/background.html
@@ -17,6 +17,9 @@
         {{ #installButton }}
           <button class='install grey'>{{ installButton }}</button>
         {{ /installButton }}
+        {{ #nextButton }}
+          <button class='next grey'>{{ nextButton }}</button>
+        {{ /nextButton }}
         {{ #exportButton }}
           <button class='export grey'>{{ exportButton }}</button>
         {{ /exportButton }}

--- a/js/backup.js
+++ b/js/backup.js
@@ -61,7 +61,9 @@
   }
 
   function exportNonMessages(idb_db, parent) {
-    return createFileAndWriter(parent, 'db.json').then(function(writer) {
+    // We wouldn't want to overwrite another db file.
+    var exclusive = true;
+    return createFileAndWriter(parent, 'db.json', exclusive).then(function(writer) {
       return exportToJsonFile(idb_db, writer);
     });
   }
@@ -223,19 +225,19 @@
     });
   }
 
-  function createDirectory(parent, name) {
+  function createDirectory(parent, name, exclusive) {
     var sanitized = sanitizeFileName(name);
     console._log('-- about to create directory', sanitized);
     return new Promise(function(resolve, reject) {
-      parent.getDirectory(sanitized, {create: true}, resolve, reject);
+      parent.getDirectory(sanitized, {create: true, exclusive: exclusive}, resolve, reject);
     });
   }
 
-  function createFileAndWriter(parent, name) {
+  function createFileAndWriter(parent, name, exclusive) {
     var sanitized = sanitizeFileName(name);
     console._log('-- about to create file', sanitized);
     return new Promise(function(resolve, reject) {
-      parent.getFile(sanitized, {create: true}, function(file) {
+      parent.getFile(sanitized, {create: true, exclusive: exclusive}, function(file) {
         return file.createWriter(function(writer) {
           resolve(writer);
         }, reject);
@@ -322,14 +324,21 @@
 
   function writeAttachment(dir, attachment) {
     var filename = getAttachmentFileName(attachment);
-    return createFileAndWriter(dir, filename).then(function(writer) {
+    // If attachments are in messages with the same received_at and the same name,
+    //   then we'll let that overwrite happen. It should be very uncommon.
+    var exclusive = false;
+    return createFileAndWriter(dir, filename, exclusive).then(function(writer) {
       var stream = createOutputStream(writer);
       return stream.write(attachment.data);
     });
   }
 
   function writeAttachments(parentDir, name, messageId, attachments) {
-    return createDirectory(parentDir, messageId).then(function(dir) {
+    // We've had a lot of trouble with attachments, likely due to messages with the same
+    //   received_at in the same conversation. So we sacrifice one of the attachments in
+    //   this unusual case.
+    var exclusive = false;
+    return createDirectory(parentDir, messageId, exclusive).then(function(dir) {
       return Promise.all(_.map(attachments, function(attachment) {
         return writeAttachment(dir, attachment);
       }));
@@ -350,7 +359,9 @@
 
   function exportConversation(idb_db, name, conversation, dir) {
     console.log('exporting conversation', name);
-    return createFileAndWriter(dir, 'messages.json').then(function(writer) {
+    // We wouldn't want to overwrite the contents of a different conversation.
+    var exclusive = true;
+    return createFileAndWriter(dir, 'messages.json', exclusive).then(function(writer) {
       return new Promise(function(resolve, reject) {
         var transaction = idb_db.transaction('messages', "readwrite");
         transaction.onerror = function(e) {
@@ -499,7 +510,10 @@
           var name = getConversationLoggingName(conversation);
 
           var process = function() {
-            return createDirectory(parentDir, dir).then(function(dir) {
+            // If we have a conversation directory collision, the user will lose the
+            //   contents of the first conversation. So we throw an error.
+            var exclusive = true;
+            return createDirectory(parentDir, dir, exclusive).then(function(dir) {
               return exportConversation(idb_db, name, conversation, dir);
             });
           };
@@ -670,7 +684,9 @@
         return openDatabase().then(function(idb_db) {
           idb = idb_db;
           var name = 'Signal Export ' + getTimestamp();
-          return createDirectory(directoryEntry, name);
+          // We don't want to overwrite another signal export, so we set exclusive = true
+          var exclusive = true;
+          return createDirectory(directoryEntry, name, exclusive);
         }).then(function(directory) {
           dir = directory;
           return exportNonMessages(idb, dir);

--- a/js/backup.js
+++ b/js/backup.js
@@ -407,6 +407,9 @@
             if (attachments && attachments.length) {
               var process = function() {
                 console._log('-- writing attachments for message', message.id);
+                if (!message.received_at) {
+                  return Promise.reject(new Error('Message', message.id, 'had no received_at'));
+                }
                 return writeAttachments(dir, name, messageId, attachments);
               };
               promiseChain = promiseChain.then(process);

--- a/js/backup.js
+++ b/js/backup.js
@@ -3,6 +3,9 @@
   window.Whisper = window.Whisper || {};
 
   function stringToBlob(string) {
+    if (!string || (typeof string !== 'string' && !(string instanceof ArrayBuffer))) {
+      throw new Error('stringToBlob: provided value is something strange:', string, JSON.stringify(stringify(string)));
+    }
     var buffer = dcodeIO.ByteBuffer.wrap(string).toArrayBuffer();
     return new Blob([buffer]);
   }

--- a/js/backup.js
+++ b/js/backup.js
@@ -227,7 +227,7 @@
     var sanitized = sanitizeFileName(name);
     console._log('-- about to create directory', sanitized);
     return new Promise(function(resolve, reject) {
-      parent.getDirectory(sanitized, {create: true, exclusive: true}, resolve, reject);
+      parent.getDirectory(sanitized, {create: true}, resolve, reject);
     });
   }
 
@@ -235,7 +235,7 @@
     var sanitized = sanitizeFileName(name);
     console._log('-- about to create file', sanitized);
     return new Promise(function(resolve, reject) {
-      parent.getFile(sanitized, {create: true, exclusive: true}, function(file) {
+      parent.getFile(sanitized, {create: true}, function(file) {
         return file.createWriter(function(writer) {
           resolve(writer);
         }, reject);

--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -5,7 +5,8 @@
   var State = {
     DISCONNECTING: 1,
     EXPORTING: 2,
-    COMPLETE: 3
+    COMPLETE: 3,
+    CHOOSE_DIR: 4,
   };
 
   Whisper.Migration = {
@@ -53,6 +54,7 @@
       'click .export': 'onClickExport',
       'click .debug-log': 'onClickDebugLog',
       'click .cancel': 'onClickCancel',
+      'click .next': 'onClickNext',
     },
     initialize: function() {
       if (!Whisper.Migration.inProgress()) {
@@ -77,6 +79,7 @@
       var debugLogButton = i18n('submitDebugLog');
       var installButton = i18n('installNewSignal');
       var cancelButton;
+      var nextButton;
 
       if (this.error) {
         // If we've never successfully exported, then we allow user to cancel out
@@ -99,7 +102,6 @@
           message = i18n('exportComplete', location);
           exportButton = i18n('exportAgain');
           debugLogButton = null;
-          cancelButton = i18n('cancelMigration');
           break;
         case State.EXPORTING:
           message = i18n('exporting');
@@ -108,12 +110,20 @@
           message = i18n('migrationDisconnecting');
           installButton = null;
           break;
-        default:
+        case State.CHOOSE_DIR:
           hideProgress = true;
           message = i18n('exportInstructions');
           exportButton = i18n('export');
           debugLogButton = null;
           installButton = null;
+          break;
+        default:
+          message = i18n('migrateInstallStep');
+          hideProgress = true;
+          debugLogButton = null;
+          nextButton = i18n('installComplete');
+          cancelButton = i18n('cancel');
+          break;
       }
 
       return {
@@ -123,11 +133,16 @@
         debugLogButton: debugLogButton,
         installButton: installButton,
         cancelButton: cancelButton,
+        nextButton: nextButton,
       };
     },
     onClickInstall: function() {
       var url = 'https://support.whispersystems.org/hc/en-us/articles/214507138';
       window.open(url, '_blank');
+    },
+    onClickNext: function() {
+      storage.put('migrationState', State.CHOOSE_DIR);
+      this.render();
     },
     cancel: function() {
       console.log('Cancelling out of migration workflow after error');

--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -101,10 +101,12 @@
           var location = Whisper.Migration.getExportLocation() || i18n('selectedLocation');
           message = i18n('exportComplete', location);
           exportButton = i18n('exportAgain');
+          installButton = null;
           debugLogButton = null;
           break;
         case State.EXPORTING:
           message = i18n('exporting');
+          installButton = null;
           break;
         case State.DISCONNECTING:
           message = i18n('migrationDisconnecting');


### PR DESCRIPTION
Migration flow:
- The first step is now 'Install new Signal Desktop', linking to a support page which shows the supported platforms. The user can cancel out of this step.
- Subsequent steps no longer have 'Install new Signal Desktop' buttons
- The cancel button has been removed from the final 'Export complete' screen, since it allows the user to get into a very bad situation if that data is imported as well. Two competing clients with the same information. Lots and lots of errors. Some users get into that situation because they can't yet install the new standalone Signal Desktop, which is why we have our new first step. If users have trouble importing into the new standalone Signal Desktop, they can contact support and get the manual workaround.

Export:
- We now allow for duplicate message directories and attachment filenames, which is a likely cause of our `InvalidModificationError` errors.
- We throw an error if a message has attachments but no `received_at` field, which is important for storing that message's attachments
- We throw an error with (hopefully) more useful information if an attachment's `data` field is falsey, or neither a string nor an `ArrayBuffer`. This is to help track down the cause of the `Illegal buffer` errors we've been seeing.