### PR TITLE
Wait for IndexedDB transactions to complete for import scale

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -499,7 +499,7 @@
         "description": "One of two choices presented on the screen shown on first launch"
     },
     "installImport": {
-        "message": "Set up with Chrome App export",
+        "message": "Set up with exported data",
         "description": "One of two choices presented on the screen shown on first launch"
     },
     "installGetStartedButton": {

--- a/js/backup.js
+++ b/js/backup.js
@@ -178,8 +178,18 @@
 
       console.log('Importing to these stores:', storeNames.join(', '));
 
+      var finished = false;
+      var finish = function(via) {
+        console.log('non-messages import done via', via);
+        if (finished) {
+          resolve();
+        }
+        finished = true;
+      };
+
       var transaction = idb_db.transaction(storeNames, 'readwrite');
       transaction.onerror = reject;
+      transaction.oncomplete = finish.bind(null, 'transaction complete');
 
       _.each(storeNames, function(storeName) {
           console.log('Importing items for store', storeName);
@@ -202,7 +212,7 @@
                   if (_.keys(importObject).length === 0) {
                     // added all object stores
                     console.log('DB import complete');
-                    resolve();
+                    finish('puts scheduled');
                   }
                 }
               };
@@ -581,6 +591,15 @@
     }
 
     return new Promise(function(resolve, reject) {
+      var finished = false;
+      var finish = function(via) {
+        console.log('messages done saving via', via);
+        if (finished) {
+          resolve();
+        }
+        finished = true;
+      };
+
       var transaction = idb_db.transaction('messages', 'readwrite');
       transaction.onerror = function(e) {
         console.log(
@@ -589,6 +608,7 @@
         );
         return reject(e);
       };
+      transaction.oncomplete = finish.bind(null, 'transaction complete');
 
       var store = transaction.objectStore('messages');
       var conversationId = messages[0].conversationId;
@@ -606,7 +626,7 @@
               // Don't know if group or private conversation, so we blindly redact
               '[REDACTED]' + conversationId.slice(-3)
             );
-            resolve();
+            finish('puts scheduled');
           }
         };
         request.onerror = function(event) {


### PR DESCRIPTION
Previously we were forging ahead with more data import without waiting for IndexedDB to tell us that its transaction was complete. This may help us process large-scale imports which were previously failing after exhausting available RAM: https://github.com/WhisperSystems/Signal-Desktop/issues/1629

And we make the start screen simpler, no longer referencing 'Chrome App,' just exported data.