### PR TITLE
Increase web request timeout, drop failed delivery receipts, export error logging

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -630,8 +630,8 @@
           }
         };
         request.onerror = function(event) {
-          console.log('Error adding object to store:', error);
-          reject();
+          console.log('Error adding object to store:', event);
+          reject(new Error('saveAllMessage: onerror fired'));
         };
       });
     });

--- a/js/delivery_receipts.js
+++ b/js/delivery_receipts.js
@@ -67,6 +67,7 @@
                         receipt.get('source'),
                         receipt.get('timestamp')
                     );
+                    resolve();
                 }
             }.bind(this)).catch(function(error) {
                 console.log(

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38679,7 +38679,7 @@ MessageReceiver.prototype.extend({
 
             return Promise.all(_.map(items, function(item) {
                 var attempts = 1 + (item.attempts || 0);
-                if (attempts >= 2) {
+                if (attempts >= 5) {
                     console.log('getAllFromCache final attempt for envelope', item.id);
                     return textsecure.storage.unprocessed.remove(item.id);
                 } else {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37474,7 +37474,7 @@ var TextSecureServer = (function() {
             url = options.host +  '/' + options.path;
         }
         console.log(options.type, url);
-        var timeout = typeof options.timeout !== 'undefined' ? options.timeout : 5000;
+        var timeout = typeof options.timeout !== 'undefined' ? options.timeout : 10000;
 
         var fetchOptions = {
           method: options.type,
@@ -38679,7 +38679,7 @@ MessageReceiver.prototype.extend({
 
             return Promise.all(_.map(items, function(item) {
                 var attempts = 1 + (item.attempts || 0);
-                if (attempts >= 5) {
+                if (attempts >= 2) {
                     console.log('getAllFromCache final attempt for envelope', item.id);
                     return textsecure.storage.unprocessed.remove(item.id);
                 } else {

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -37,7 +37,7 @@ var TextSecureServer = (function() {
             url = options.host +  '/' + options.path;
         }
         console.log(options.type, url);
-        var timeout = typeof options.timeout !== 'undefined' ? options.timeout : 5000;
+        var timeout = typeof options.timeout !== 'undefined' ? options.timeout : 10000;
 
         var fetchOptions = {
           method: options.type,

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -273,7 +273,7 @@ MessageReceiver.prototype.extend({
 
             return Promise.all(_.map(items, function(item) {
                 var attempts = 1 + (item.attempts || 0);
-                if (attempts >= 2) {
+                if (attempts >= 5) {
                     console.log('getAllFromCache final attempt for envelope', item.id);
                     return textsecure.storage.unprocessed.remove(item.id);
                 } else {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -273,7 +273,7 @@ MessageReceiver.prototype.extend({
 
             return Promise.all(_.map(items, function(item) {
                 var attempts = 1 + (item.attempts || 0);
-                if (attempts >= 5) {
+                if (attempts >= 2) {
                     console.log('getAllFromCache final attempt for envelope', item.id);
                     return textsecure.storage.unprocessed.remove(item.id);
                 } else {


### PR DESCRIPTION
Should help with #1669, where users are seeing a regression from the Chrome App, which didn't have a timeout for web requests. This changes our timeout from 5s to 10s.

Should also help with #1664, which talks about the number of messages downloaded on startup on the loading screen. We tend to build up more and more of these messages that need to retried, since we retry them so many times. This change makes it so we retry a message just once before discarding it. Before, it was four times.