### PR TITLE
Added top level menu shortcuts and pull the top level menu labels from messages.json

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,4 +1,24 @@
 {
+    "mainMenuFile": {
+      "message": "&File",
+      "description": "The label that is used for the File menu in the program main menu. The '&' indicates that the following letter will be used as the keyboard 'shortcut letter' for accessing the menu with the Alt-<letter> combination."
+    },
+    "mainMenuEdit": {
+      "message": "&Edit",
+      "description": "The label that is used for the Edit menu in the program main menu. The '&' indicates that the following letter will be used as the keyboard 'shortcut letter' for accessing the menu with the Alt-<letter> combination."
+    },
+    "mainMenuView": {
+      "message": "&View",
+      "description": "The label that is used for the View menu in the program main menu. The '&' indicates that the following letter will be used as the keyboard 'shortcut letter' for accessing the menu with the Alt-<letter> combination."
+    },
+    "mainMenuWindow": {
+      "message": "&Window",
+      "description": "The label that is used for the Window menu in the program main menu. The '&' indicates that the following letter will be used as the keyboard 'shortcut letter' for accessing the menu with the Alt-<letter> combination."
+    },
+    "mainMenuHelp": {
+      "message": "&Help",
+      "description": "The label that is used for the Help menu in the program main menu. The '&' indicates that the following letter will be used as the keyboard 'shortcut letter' for accessing the menu with the Alt-<letter> combination."
+    },
     "loading": {
       "message": "Loading...",
       "description": "Message shown on the loading screen before we've loaded any messages"

--- a/app/menu.js
+++ b/app/menu.js
@@ -7,7 +7,7 @@ function createTemplate(options, messages) {
   const openForums = options.openForums;
 
   let template = [{
-    label: 'File',
+    label: '&File',
     submenu: [
       {
         role: 'quit',
@@ -15,7 +15,7 @@ function createTemplate(options, messages) {
     ]
   },
   {
-    label: 'Edit',
+    label: '&Edit',
     submenu: [
       {
         role: 'undo',
@@ -47,7 +47,7 @@ function createTemplate(options, messages) {
     ]
   },
   {
-    label: 'View',
+    label: '&View',
     submenu: [
       {
         role: 'resetzoom',
@@ -80,6 +80,7 @@ function createTemplate(options, messages) {
     ]
   },
   {
+    label: '&Window',
     role: 'window',
     submenu: [
       {
@@ -88,6 +89,7 @@ function createTemplate(options, messages) {
     ]
   },
   {
+    label: '&Help',
     role: 'help',
     submenu: [
       {

--- a/app/menu.js
+++ b/app/menu.js
@@ -7,7 +7,7 @@ function createTemplate(options, messages) {
   const openForums = options.openForums;
 
   let template = [{
-    label: '&File',
+    label: messages.mainMenuFile.message,
     submenu: [
       {
         role: 'quit',
@@ -15,7 +15,7 @@ function createTemplate(options, messages) {
     ]
   },
   {
-    label: '&Edit',
+    label: messages.mainMenuEdit.message,
     submenu: [
       {
         role: 'undo',
@@ -47,7 +47,7 @@ function createTemplate(options, messages) {
     ]
   },
   {
-    label: '&View',
+    label: messages.mainMenuView.message,
     submenu: [
       {
         role: 'resetzoom',
@@ -80,7 +80,7 @@ function createTemplate(options, messages) {
     ]
   },
   {
-    label: '&Window',
+    label: messages.mainMenuWindow.message,
     role: 'window',
     submenu: [
       {
@@ -89,7 +89,7 @@ function createTemplate(options, messages) {
     ]
   },
   {
-    label: '&Help',
+    label: messages.mainMenuHelp.message,
     role: 'help',
     submenu: [
       {


### PR DESCRIPTION
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have tested my contribution on these platforms:
 * KDE Neon User Edition (Ubuntu Linux 16.04 core with KDE 5.11.2)
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests).

----------------------------------------

### Description
Two commits in this pull-request.

The first one added support for file menu shortcuts. This commits add a feature (#1695), and also resolves a bug (#1688).

The second commit makes the code conform to the coding style of the signal desktop app. One of the bullet points in the `Pull request` checklist mentions that we should: 

`Never use plain strings right in the source code - pull them from messages.json! You only need to modify the default locale _locales/en/messages.json. Other locales are generated automatically based on that file and then periodically uploaded to Transifex for translation.`

However, even existing code for the menu labels did not conform to that bullet point.