### PR TITLE
Export fixes, tracking export metrics, show new versions in log

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -4,13 +4,15 @@
 
   function stringToBlob(string) {
     if (string === null || string === undefined) {
+      console.log('stringToBlob: replacing null/undefined with empty string');
       string = '';
     }
     if (typeof string !== 'string' && !(string instanceof ArrayBuffer)) {
       // Not sure what this is, but perhaps we can make the right thing happen by sending
       //   it to a Uint8Array, which the wrap() method below handles just fine. Uint8Array
       //   can take an ArrayBuffer, so it will help if I'm right that the weird attachment
-      //   data is an ArrayBuffer-like thing, while not being techincally an instanceof.
+      //   data is an ArrayBuffer-like thing, while not being technically an instanceof.
+      console.log('stringToBlob: sending strange object to Uint8Array --', typeof string, JSON.stringify(string), string);
       string = new Uint8Array(string);
     }
     var buffer = dcodeIO.ByteBuffer.wrap(string).toArrayBuffer();

--- a/js/backup.js
+++ b/js/backup.js
@@ -3,8 +3,11 @@
   window.Whisper = window.Whisper || {};
 
   function stringToBlob(string) {
-    if (!string || (typeof string !== 'string' && !(string instanceof ArrayBuffer))) {
-      throw new Error('stringToBlob: provided value is something strange:', string, JSON.stringify(stringify(string)));
+    if (string === null || string === undefined) {
+      string = '';
+    }
+    if (typeof string !== 'string' && !(string instanceof ArrayBuffer)) {
+      string = new Uint8Array(string);
     }
     var buffer = dcodeIO.ByteBuffer.wrap(string).toArrayBuffer();
     return new Blob([buffer]);

--- a/js/backup.js
+++ b/js/backup.js
@@ -49,10 +49,8 @@
 
   function createOutputStream(fileWriter) {
     var wait = Promise.resolve();
-    var count = 0;
     return {
       write: function(string) {
-        var i = count++;
         wait = wait.then(function() {
           return new Promise(function(resolve, reject) {
             fileWriter.onwriteend = resolve;

--- a/js/chromium.js
+++ b/js/chromium.js
@@ -255,13 +255,15 @@
 
     if (chrome.runtime.onInstalled) {
         chrome.runtime.onInstalled.addListener(function(options) {
+            var version = chrome.runtime.getManifest().version;
+
             if (options.reason === 'install') {
-                console.log('new install');
+                console.log('new install:', version);
                 extension.install();
             } else if (options.reason === 'update') {
-                console.log('new update. previous version:', options.previousVersion);
+                console.log('new update:', version, '- previous version:', options.previousVersion);
             } else {
-                console.log('onInstalled', options.reason);
+                console.log('onInstalled', options.reason, 'version:', version);
             }
         });
     }


### PR DESCRIPTION
To get a better handle on the export issues we're dealing with, we now continue on with the export even if we run into an attachment or malformed `messages.json`. We count up how many problems we encounter, then report that at the end of the process. If non-zero, we consider the whole export failed, but there's useful metrics in the log.

For the `Illegal buffer` issue (https://github.com/WhisperSystems/Signal-Desktop/issues/1616), we now attempt to handle these 'strange' pieces of data by first giving them to a `Uint8Array`.

For the malformed JSON issue (https://github.com/WhisperSystems/Signal-Desktop/issues/1637), we now verify the structure of every `messages.json` file before considering that conversation export done. However, I discovered that immediate checking of these files found a lot of malformed files - so we first manually wait 10s after we're told that the write is done.

Export takes quite a bit longer with this change, but should be more reliable.

Lastly, we now log the current version of the app when we detect a version upgrade. Previously we only showed the version were replacing. Because we're releasing new versions pretty frequently, this will help us track things down.