### PR TITLE
Migration View: Handle non-errors from export process

### DIFF
--- a/js/views/migration_view.js
+++ b/js/views/migration_view.js
@@ -189,8 +189,8 @@
       Whisper.Migration.beginExport()
         .then(this.completeMigration.bind(this))
         .catch(function(error) {
-          if (error.name !== 'ChooseError') {
-            this.error = error.message;
+          if (!error || error.name !== 'ChooseError') {
+            this.error = error || new Error('in case we reject() null!');
           }
           // Even if we run into an error, we call this complete because the user has
           //   completed the process once before.
@@ -223,12 +223,11 @@
       this.render();
     },
     onError: function(error) {
-      if (error.name === 'ChooseError') {
+      if (error && error.name === 'ChooseError') {
         this.cancelMigration();
       } else {
-        Whisper.Migration.cancel();
-        this.error = error.message;
-        this.render();
+        this.error = error || new Error('in case we reject() null!');
+        this.cancelMigration();
       }
     },
     cancelMigration: function() {


### PR DESCRIPTION
We wire up Promise `reject()` methods to a number of callbacks, which means that they can provide weird things to us: non-errors. This then results in the `MigrationView` not knowing that there was an error, because it relies on the `error.message` property, which is always there if an `Error` is constructed properly. This hardens `MigrationView` to handle a promise that `reject()`s with anything.