### PR TITLE
Eliminate attachment when errors saved full message details

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -458,8 +458,16 @@
             var messageId = message.received_at;
             var attachments = message.attachments;
 
+            // eliminate attachment data from the JSON, since it will go to disk
             message.attachments = _.map(attachments, function(attachment) {
               return _.omit(attachment, ['data']);
+            });
+            // completely drop any attachments in messages cached in error objects
+            message.errors = _.map(message.errors, function(error) {
+              if (_.get(error, 'args[0].attachments')) {
+                error.args[0].attachments = [];
+              }
+              return error;
             });
 
             var jsonString = JSON.stringify(stringify(message));


### PR DESCRIPTION
Some logs have indicated that large amounts of data is saved to `messages.json` when a message was unsuccessfully sent and had an attachment. In this case, we open the `errors` array and delete any attachments hanging around in the cached message.