### PR TITLE
Make messages.json checking stats only, don't block export

### DIFF
--- a/js/backup.js
+++ b/js/backup.js
@@ -387,23 +387,20 @@
 
   // Because apparently we sometimes create malformed JSON files. Let's double-check them.
   function checkConversation(conversationId, dir) {
-    return delay(10000).then(function() {
+    conversations += 1;
+    return delay(5000).then(function() {
       console.log('Verifying messages.json produced for conversation', conversationId);
       return readFileAsText(dir, 'messages.json');
     }).then(function(contents) {
-      try {
-        conversations += 1;
-        JSON.parse(contents);
-      }
-      catch (error) {
-        failedConversations += 1;
-        console.log(
-          'Export of conversation',
-          conversationId,
-          'was malformed:',
-          error && error.stack ? error.stack : error
-        );
-      }
+      JSON.parse(contents);
+    }).catch(function(error) {
+      failedConversations += 1;
+      console.log(
+        'Export of conversation',
+        conversationId,
+        'may be malformed:',
+        error && error.stack ? error.stack : error
+      );
     });
   }
 
@@ -738,7 +735,7 @@
   function printConversationStats() {
     console.log(
       'Total conversations:', conversations,
-      'Failed conversations:', failedConversations
+      'Possibly malformed conversations:', failedConversations
     );
   }
 
@@ -767,9 +764,6 @@
         console.log('done backing up!');
         if (failedAttachments) {
           throw new Error('Export failed, one or more attachments failed');
-        }
-        if (failedConversations) {
-          throw new Error('Export failed, one or more conversations failed');
         }
         return path;
       }, function(error) {


### PR DESCRIPTION
Our attempt to verify the structure of a just-written `messages.json` sometimes fails. It can be because the file hasn't been flushed to disk, or because we can't load the file for some reason. 

With this change, neither type of problem will stop the export, nor will they cause the export to be considered a failure. Instead, they will simply result in log entries and some overall statistics printed out at the end of the export.

This seems like the right tradeoff for debugging needs and reliable imports right after export.