### PR TITLE
Add icon to the window manually on creation

### DIFF
--- a/main.js
+++ b/main.js
@@ -104,7 +104,8 @@ function createWindow () {
       nodeIntegration: false,
       //sandbox: true,
       preload: path.join(__dirname, 'preload.js')
-    }
+    },
+    icon: __dirname + '/build/icons/png/512x512.png',
   }, windowConfig);
 
   if (windowOptions.fullscreen === false) {

--- a/package.json
+++ b/package.json
@@ -135,6 +135,8 @@
       "audio/**",
       "images/**",
       "fonts/*",
+      "build/assets",
+      "build/icons/png/512x512.png",
       "node_modules/**",
       "!node_modules/spellchecker/vendor/hunspell/**/*",
       "!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme,test,__tests__,tests,powered-test,example,examples,*.d.ts}",


### PR DESCRIPTION
This supplements the work we already do to tell the OS about our icon.

Should fix https://github.com/WhisperSystems/Signal-Desktop/issues/1649

As recommended here: https://github.com/WhisperSystems/Signal-Desktop/issues/1654#issuecomment-341436771

