### PR TITLE
Use icon from /images for window creation

### DIFF
--- a/main.js
+++ b/main.js
@@ -105,7 +105,7 @@ function createWindow () {
       //sandbox: true,
       preload: path.join(__dirname, 'preload.js')
     },
-    icon: __dirname + '/build/icons/png/512x512.png',
+    icon: path.join(__dirname, 'images', 'icon_256.png'),
   }, windowConfig);
 
   if (windowOptions.fullscreen === false) {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
       "images/**",
       "fonts/*",
       "build/assets",
-      "build/icons/png/512x512.png",
       "node_modules/**",
       "!node_modules/spellchecker/vendor/hunspell/**/*",
       "!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme,test,__tests__,tests,powered-test,example,examples,*.d.ts}",


### PR DESCRIPTION
In https://github.com/WhisperSystems/Signal-Desktop/pull/1735 we pulled the image from `/build`, but we can just load it from `/images`.