### PR TITLE
Beta builds: A few updates required for successful release

### DIFF
--- a/fix_broken_perms.sh
+++ b/fix_broken_perms.sh
@@ -1,4 +1,4 @@
 set -e
 find release/linux -type d | xargs chmod 755
 find release/linux -type f | xargs chmod 644
-chmod +x release/linux/signal-desktop
+chmod +x release/linux/signal-desktop*

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "build-mas-dev": "npm run build-release -- -m --config.mac.target=mas --config.type=development",
     "prep-mac-release": "npm run build-release -- -m --dir",
     "prep-release": "npm run generate && grunt prep-release && npm run build-release && npm run build-mas-release && grunt test-release",
-    "release-mac": "npm run build-release -- -m --prepackaged release/mac/Signal.app --publish=always",
+    "release-mac": "npm run build-release -- -m --prepackaged release/mac/Signal*.app --publish=always",
     "release-win": "npm run build-release -- -w --prepackaged release/windows --publish=always",
     "release-lin": "npm run build-release -- -l --prepackaged release/linux && VERSION=$npm_package_version ./aptly.sh",
     "release": "npm run release-mac && npm run release-win && npm run release-lin"


### PR DESCRIPTION
The files aren't always called 'Signal.app' or 'signal-desktop' anymore!