### PR TITLE
Retry failed signed key rotation; start rotation when registered

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -90,19 +90,20 @@
         console.log('listening for registration events');
         Whisper.events.on('registration_done', function() {
             console.log('handling registration event');
+            Whisper.RotateSignedPreKeyListener.init(Whisper.events);
             connect(true);
         });
 
         var appView = window.owsDesktopApp.appView = new Whisper.AppView({el: $('body')});
 
         Whisper.WallClockListener.init(Whisper.events);
-        Whisper.RotateSignedPreKeyListener.init(Whisper.events);
         Whisper.ExpiringMessagesListener.init(Whisper.events);
 
         if (Whisper.Import.isIncomplete()) {
             console.log('Import was interrupted, showing import error screen');
             appView.openImporter();
         } else if (Whisper.Registration.everDone()) {
+            Whisper.RotateSignedPreKeyListener.init(Whisper.events);
             connect();
             appView.openInbox({
                 initialLoadComplete: initialLoadComplete

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -37994,19 +37994,26 @@ var TextSecureServer = (function() {
                         keyId     : res.keyId,
                         publicKey : res.keyPair.pubKey,
                         signature : res.signature
-                    }).then(function() {
-                        textsecure.storage.put('signedKeyId', signedKeyId + 1);
-                        textsecure.storage.remove('signedKeyRotationRejected');
-                        return store.storeSignedPreKey(res.keyId, res.keyPair).then(function() {
-                            return cleanSignedPreKeys();
-                        });
-                    }).catch(function(e) {
-                        if (e instanceof Error && e.name == 'HTTPError' && e.code >= 400 && e.code <= 599) {
-                            var rejections = 1 + textsecure.storage.get('signedKeyRotationRejected', 0);
-                            textsecure.storage.put('signedKeyRotationRejected', rejections);
-                            console.log('Signed key rotation rejected count:', rejections);
-                        }
                     });
+                }).then(function() {
+                    textsecure.storage.put('signedKeyId', signedKeyId + 1);
+                    textsecure.storage.remove('signedKeyRotationRejected');
+                    return store.storeSignedPreKey(res.keyId, res.keyPair).then(function() {
+                        return cleanSignedPreKeys();
+                    });
+                }).catch(function(e) {
+                    console.log(
+                        'rotateSignedPrekey error:',
+                        e && e.stack ? e.stack : e
+                    );
+
+                    if (e instanceof Error && e.name == 'HTTPError' && e.code >= 400 && e.code <= 599) {
+                        var rejections = 1 + textsecure.storage.get('signedKeyRotationRejected', 0);
+                        textsecure.storage.put('signedKeyRotationRejected', rejections);
+                        console.log('Signed key rotation rejected count:', rejections);
+                    }
+
+                    throw e;
                 });
             }.bind(this));
         },

--- a/js/rotate_signed_prekey_listener.js
+++ b/js/rotate_signed_prekey_listener.js
@@ -17,7 +17,10 @@
 
     function run() {
         console.log('Rotating signed prekey...');
-        getAccountManager().rotateSignedPreKey();
+        getAccountManager().rotateSignedPreKey().catch(function() {
+            console.log('rotateSignedPrekey() failed. Trying again in five seconds');
+            setTimeout(runWhenOnline, 5000);
+        });
         scheduleNextRotation();
         setTimeoutForNextRun();
     }
@@ -26,6 +29,7 @@
         if (navigator.onLine) {
             run();
         } else {
+            console.log('We are offline; keys will be rotated when we are next online');
             var listener = function() {
                 window.removeEventListener('online', listener);
                 run();
@@ -52,8 +56,15 @@
         timeout = setTimeout(runWhenOnline, waitTime);
     }
 
+    var initComplete;
     Whisper.RotateSignedPreKeyListener = {
         init: function(events) {
+            if (initComplete) {
+                console.log('Rotate signed prekey listener: Already initialized');
+                return;
+            }
+            initComplete = true;
+
             if (Whisper.Registration.isDone()) {
                 setTimeoutForNextRun();
             }

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -132,19 +132,26 @@
                         keyId     : res.keyId,
                         publicKey : res.keyPair.pubKey,
                         signature : res.signature
-                    }).then(function() {
-                        textsecure.storage.put('signedKeyId', signedKeyId + 1);
-                        textsecure.storage.remove('signedKeyRotationRejected');
-                        return store.storeSignedPreKey(res.keyId, res.keyPair).then(function() {
-                            return cleanSignedPreKeys();
-                        });
-                    }).catch(function(e) {
-                        if (e instanceof Error && e.name == 'HTTPError' && e.code >= 400 && e.code <= 599) {
-                            var rejections = 1 + textsecure.storage.get('signedKeyRotationRejected', 0);
-                            textsecure.storage.put('signedKeyRotationRejected', rejections);
-                            console.log('Signed key rotation rejected count:', rejections);
-                        }
                     });
+                }).then(function() {
+                    textsecure.storage.put('signedKeyId', signedKeyId + 1);
+                    textsecure.storage.remove('signedKeyRotationRejected');
+                    return store.storeSignedPreKey(res.keyId, res.keyPair).then(function() {
+                        return cleanSignedPreKeys();
+                    });
+                }).catch(function(e) {
+                    console.log(
+                        'rotateSignedPrekey error:',
+                        e && e.stack ? e.stack : e
+                    );
+
+                    if (e instanceof Error && e.name == 'HTTPError' && e.code >= 400 && e.code <= 599) {
+                        var rejections = 1 + textsecure.storage.get('signedKeyRotationRejected', 0);
+                        textsecure.storage.put('signedKeyRotationRejected', rejections);
+                        console.log('Signed key rotation rejected count:', rejections);
+                    }
+
+                    throw e;
                 });
             }.bind(this));
         },


### PR DESCRIPTION
I've noticed that we're not adequately resilient to questionable situations in our signed key rotation. For example, I saw a log last week where the rotation failed because of network difficulties. Today, in that case, we would wait until the next scheduled key rotation time: a couple days.

With this change, after a failed rotation, we try every five seconds until it succeeds.

In this change we also get a little more precise about when we start up the signed key rotation. It doesn't make sense to do it before the user is registered, and it doesn't make sense to do it in the middle of an import, so we only do it if registration is complete, and import is complete.