### PR TITLE
Added option to minimize to tray

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -412,6 +412,14 @@
       "message": "Show",
       "description": "Command under Window menu, to show the window"
     },
+    "hide": {
+      "message": "Hide",
+      "description": "Command under Tray menu, to hide the window"
+    },
+    "quit": {
+      "message": "Quit Signal",
+      "description": "Command under Tray menu, to quit Signal"
+    },
     "searchForPeopleOrGroups": {
       "message": "Search...",
       "description": "Placeholder text in the search input"
@@ -609,6 +617,10 @@
     "notifications": {
         "message": "Notifications",
         "description": "Header for notification settings"
+    },
+    "trayTip": {
+        "message": "Signal Desktop",
+        "description": "Tooltip displayed when mouse hovers over tray icon"
     },
     "notificationSettingsDialog": {
         "message": "When messages arrive, display notifications that reveal:",
@@ -867,6 +879,10 @@
     "hideMenuBar": {
       "message": "Hide menu bar",
       "description": "Label text for menu bar visibility setting"
+    },
+    "allowTrayMinimize": {
+      "message": "Minimize app to tray on close",
+      "description": "Label text for allow minimize to tray setting"
     },
     "newContact": {
       "message": "Click to create new contact",

--- a/background.html
+++ b/background.html
@@ -588,6 +588,10 @@
         <input type='checkbox' name='hide-menu-bar' id='hide-menu-bar'/>
         <label for='hide-menu-bar'>{{ hideMenuBar }}</label>
       </div>
+      <div class='tray-minimize-setting'>
+        <input type='checkbox' name='allow-tray-minimize' id='allow-tray-minimize'/>
+        <label for='allow-tray-minimize'>{{ allowTrayMinimize }}</label>
+      </div>
       <hr>
       <div class='notification-settings'>
         <h3>{{ notifications }}</h3>

--- a/js/views/app_view.js
+++ b/js/views/app_view.js
@@ -9,6 +9,7 @@
           this.installView = null;
           this.applyTheme();
           this.applyHideMenu();
+          this.applyAllowTrayMinimize();
         },
         events: {
             'click .openInstaller': 'openInstaller',
@@ -16,6 +17,7 @@
             'openInbox': 'openInbox',
             'change-theme': 'applyTheme',
             'change-hide-menu': 'applyHideMenu',
+            'change-minimize-tray': 'applyAllowTrayMinimize',
         },
         applyTheme: function() {
             var theme = storage.get('theme-setting') || 'android';
@@ -28,6 +30,10 @@
             var hideMenuBar = storage.get('hide-menu-bar', false);
             window.setAutoHideMenuBar(hideMenuBar);
             window.setMenuBarVisibility(!hideMenuBar);
+        },
+        applyAllowTrayMinimize: function() {
+            var allowTrayMinimize = storage.get('allow-tray-minimize', false);
+            window.setAllowTrayMinimize(allowTrayMinimize);
         },
         openView: function(view) {
           this.el.innerHTML = "";

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -78,6 +78,12 @@
                 name: 'hide-menu-bar',
                 event: 'change-hide-menu'
             });
+            new CheckboxView({
+                el: this.$('.tray-minimize-setting'),
+                defaultValue: false,
+                name: 'allow-tray-minimize',
+                event: 'change-minimize-tray'
+            });
             if (textsecure.storage.user.getDeviceId() != '1') {
                 var syncView = new SyncView().render();
                 this.$('.content').append(syncView.el);
@@ -99,6 +105,7 @@
               audioNotificationDescription: i18n('audioNotificationDescription'),
               themeAndroidDark: i18n('themeAndroidDark'),
               hideMenuBar: i18n('hideMenuBar'),
+              allowTrayMinimize: i18n('allowTrayMinimize'),
             };
         }
     });

--- a/preload.js
+++ b/preload.js
@@ -27,6 +27,9 @@
   window.setMenuBarVisibility = function(visibility) {
     ipc.send('set-menu-bar-visibility', visibility);
   };
+  window.setAllowTrayMinimize = function(allowTrayMinimize) {
+    ipc.send('set-allow-tray-minimize', allowTrayMinimize);
+  };
   window.restart = function() {
     console.log('restart');
     ipc.send('restart');


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have tested my contribution on these platforms:
 * OSX Sierra
 * Windows 10
 * Xubuntu 17.04
 * Ubuntu 17.10
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.

Please note, that after you have submitted your PR, the Travis CI build check will fail. This is a known issue (#708) and you don't have to worry about it. (■_■¬)
-->
This commit proposes to address #1480

Added an option to minimize the application to tray. The option defaults to false on first run, but is saved according to current practices and loaded on subsequent runs.

This commit needed 4 new localization strings for the menu items.

System tray icon maintains a menu and click-behavior consistent with modern communication applications.

System tray icon has been tested on Windows, OSX, and Linux (XFCE and older versions of gnome). Newer versions of Gnome (including newest non-LTS versions of Ubuntu) do not support a system tray without modification. If this is an issue in the future, suggest adding module "getos" and maintaining a supported release list (beyond the scope of this commit).
