### PR TITLE
Update to electron-builder 19.29.0 for better shortcut behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "config": "^1.26.2",
     "electron-config": "^1.0.0",
     "electron-editor-context-menu": "^1.1.1",
-    "electron-updater": "^2.9.3",
+    "electron-updater": "^2.16.1",
     "emoji-datasource-apple": "^3.0.0",
     "emoji-js": "^3.2.2",
     "emoji-panel": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "asar": "^0.13.0",
     "bower": "^1.3.12",
     "electron": "~1.7.9",
-    "electron-builder": "^19.27.3",
+    "electron-builder": "^19.29.2",
     "electron-icon-maker": "^0.0.3",
     "electron-publisher-s3": "^19.0.1",
     "grunt": "^1.0.1",


### PR DESCRIPTION
Fixes #1744

To get this bugfix: https://github.com/electron-userland/electron-builder/pull/2085