### PR TITLE
Remove last seen indicator if we get a sync'd outgoing message

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -646,6 +646,9 @@
             this.model.messageCollection.add(message, {merge: true});
             message.setToExpire();
 
+            if (message.isOutgoing()) {
+                this.removeLastSeenIndicator();
+            }
             if (this.lastSeenIndicator) {
                 this.lastSeenIndicator.increment(1);
             }


### PR DESCRIPTION
This mirrors the way Android does things. Fixes https://github.com/WhisperSystems/Signal-Desktop/issues/1777

