### PR TITLE
On group/contact import: don't re-add hidden entries to left pane

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -367,6 +367,14 @@
         return ConversationController.getOrCreateAndWait(id, 'private')
             .then(function(conversation) {
                 return new Promise(function(resolve, reject) {
+                    var activeAt = conversation.get('active_at');
+
+                    // The idea is to make any new contact show up in the left pane. If
+                    //   activeAt is null, then this contact has been purposefully hidden.
+                    if (activeAt !== null) {
+                        activeAt = activeAt || Date.now();
+                    }
+
                     if (details.profileKey) {
                       conversation.set({profileKey: details.profileKey});
                     }
@@ -374,7 +382,7 @@
                         name: details.name,
                         avatar: details.avatar,
                         color: details.color,
-                        active_at: conversation.get('active_at') || Date.now(),
+                        active_at: activeAt,
                     }).then(resolve, reject);
                 }).then(function() {
                     if (details.verified) {

--- a/js/background.js
+++ b/js/background.js
@@ -419,7 +419,13 @@
                 type: 'group',
             };
             if (details.active) {
-                updates.active_at = Date.now();
+                var activeAt = conversation.get('active_at');
+
+                // The idea is to make any new group show up in the left pane. If
+                //   activeAt is null, then this group has been purposefully hidden.
+                if (activeAt !== null) {
+                    updates.active_at = activeAt || Date.now();
+                }
             } else {
                 updates.left = true;
             }


### PR DESCRIPTION
https://github.com/WhisperSystems/Signal-Desktop/pull/1807 introduced some new behavior to the 'delete messages' option - it would remove the item from the left pane as well.

A new group/contact import will restore all of these contacts to the left pane. This fix addresses that - if the user has explicitly hidden an item, new import will not restore it. Only receiving or sending a new message in that conversation will re-add the item to the left pane.

-- Tested re-imports on an old installation, as well as starting a new install from scratch, and re-importing on top of that.