### PR TITLE
Introduce library for notifications on downlevel windows

### DIFF
--- a/js/notifications.js
+++ b/js/notifications.js
@@ -1,6 +1,7 @@
 /*
  * vim: ts=4:sw=4:expandtab
  */
+
 ;(function() {
     'use strict';
     window.Whisper = window.Whisper || {};
@@ -84,14 +85,26 @@
                 iconUrl = last.get('iconUrl');
                 break;
             }
-            var notification = new Notification(title, {
-                body   : message,
-                icon   : iconUrl,
-                tag    : 'signal',
-                silent : true
-            });
 
-            notification.onclick = this.onClick.bind(this, last.get('conversationId'));
+            if (windows.config.polyfillNotifications) {
+                window.nodeNotifier.notify({
+                    title: title,
+                    message: message,
+                    sound: false
+                });
+                window.nodeNotifier.on('click', function(notifierObject, options) {
+                    last.get('conversationId');
+                });
+            } else {
+                var notification = new Notification(title, {
+                    body   : message,
+                    icon   : iconUrl,
+                    tag    : 'signal',
+                    silent : true
+                });
+
+                notification.onclick = this.onClick.bind(this, last.get('conversationId'));
+            }
 
             // We don't want to notify the user about these same messages again
             this.clear();

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ const os = require('os');
 
 const _ = require('lodash');
 const electron = require('electron');
+const semver = require('semver');
 
 const BrowserWindow = electron.BrowserWindow;
 const app = electron.app;
@@ -63,6 +64,13 @@ const loadLocale = require('./app/locale').load;
 
 let locale;
 
+
+const WINDOWS_8 = '8.0.0';
+const osRelease = os.release();
+const polyfillNotifications =
+  os.platform() === 'win32' && semver.lt(osRelease, WINDOWS_8);
+console.log('OS Release:', osRelease, '- notifications polyfill?', polyfillNotifications);
+
 function prepareURL(pathSegments) {
   return url.format({
     pathname: path.join.apply(null, pathSegments),
@@ -80,6 +88,7 @@ function prepareURL(pathSegments) {
       node_version: process.versions.node,
       hostname: os.hostname(),
       appInstance: process.env.NODE_APP_INSTANCE,
+      polyfillNotifications: polyfillNotifications,
     }
   })
 }

--- a/package.json
+++ b/package.json
@@ -160,6 +160,7 @@
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "node-fetch": "^1.7.3",
+    "node-notifier": "^5.1.2",
     "os-locale": "^2.1.0",
     "rimraf": "^2.6.2",
     "semver": "^5.4.1",

--- a/preload.js
+++ b/preload.js
@@ -59,6 +59,7 @@
   window.EmojiPanel = require('emoji-panel');
   window.libphonenumber = require('google-libphonenumber').PhoneNumberUtil.getInstance();
   window.libphonenumber.PhoneNumberFormat = require('google-libphonenumber').PhoneNumberFormat;
+  window.nodeNotifier = require('node-notifier');
 
   // We pull this in last, because the native module involved appears to be sensitive to
   //   /tmp mounted as noexec on Linux.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,6 +1633,10 @@ graceful-fs@^4.1.0, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3,
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
+growly@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
+
 grunt-cli@^1.2.0, grunt-cli@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/grunt-cli/-/grunt-cli-1.2.0.tgz#562b119ebb069ddb464ace2845501be97b35b6a8"
@@ -2604,6 +2608,15 @@ node-gyp@^3.3.1:
     tar "^2.0.0"
     which "1"
 
+node-notifier@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
+  dependencies:
+    growly "^1.3.0"
+    semver "^5.3.0"
+    shellwords "^0.1.0"
+    which "^1.2.12"
+
 node-sass-import-once@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/node-sass-import-once/-/node-sass-import-once-1.2.0.tgz#4e523aa05d68d9b37c7ebacf3f15684e635b2f2e"
@@ -3364,6 +3377,10 @@ shelljs@0.3.x:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.3.0.tgz#3596e6307a781544f591f37da618360f31db57b1"
 
+shellwords@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
@@ -4007,6 +4024,12 @@ which-module@^2.0.0:
 which@1, which@^1.2.9, which@~1.2.1, which@~1.2.10:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.12:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
     isexe "^2.0.0"
 


### PR DESCRIPTION
Right now SIgnal Desktop Standalone has no notification experience for Windows 7. The beta build apparently shows one notification, and thereafter nothing. These changes, adapted from [the original PR](https://github.com/WhisperSystems/Signal-Desktop/pull/1783), get us notifications on downlevel Windows. No changes have been made to the experience on OSX, Linux, or recent versions of Windows.