### PR TITLE
add urgency hints for linux platform

### DIFF
--- a/main.js
+++ b/main.js
@@ -332,6 +332,8 @@ ipc.on('draw-attention', function(event, count) {
     setTimeout(function() {
       mainWindow.flashFrame(false);
     }, 1000);
+  } else if (process.platform == 'linux') {
+    mainWindow.flashFrame(true);
   }
 });
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [ ] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [ ] I have tested my contribution on these platforms:
 * GNU Hurd 1.0, Chrom{e,ium} X.Y.Z
 * Amiga OS 3.1, Chrom{e,ium} Z.Y
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description

Use `mainWindow.flashFrame` on platform `linux`, which was previously only done for windows and mac. For `X11` in linux, the implementation of [flashFrame uses `urgency hints`](https://chromium.googlesource.com/chromium/src/+/master/ui/views/widget/desktop_aura/desktop_window_tree_host_x11.cc#1099).
