### PR TITLE
Harden our handling of config.json, verify that window is visible

### DIFF
--- a/main.js
+++ b/main.js
@@ -95,6 +95,7 @@ const DEFAULT_WIDTH = 800;
 const DEFAULT_HEIGHT = 610;
 const MIN_WIDTH = 700;
 const MIN_HEIGHT = 360;
+const BOUNDS_BUFFER = 100;
 
 function isVisible(window, bounds) {
   const boundsX = _.get(bounds, 'x') || 0;
@@ -102,13 +103,13 @@ function isVisible(window, bounds) {
   const boundsWidth = _.get(bounds, 'width') || DEFAULT_WIDTH;
   const boundsHeight = _.get(bounds, 'height') || DEFAULT_HEIGHT;
 
-  // Requiring the window to show at least 10 pixels on the left or right side
-  const rightSideClearOfLeftBound = (window.x + window.width > boundsX + 10);
-  const leftSideClearOfRightBound = (window.x < boundsX + boundsWidth - 10);
+  // requiring BOUNDS_BUFFER pixels on the left or right side
+  const rightSideClearOfLeftBound = (window.x + window.width > boundsX + BOUNDS_BUFFER);
+  const leftSideClearOfRightBound = (window.x < boundsX + boundsWidth - BOUNDS_BUFFER);
 
-  // the top of the window can't be offscreen, and must show at least 10 pixels at bottom
+  // top can't be offscreen, and must show at least BOUNDS_BUFFER pixels at bottom
   const topClearOfUpperBound = window.y > boundsY;
-  const topClearOfLowerBound = (window.y < boundsY + boundsHeight - 10);
+  const topClearOfLowerBound = (window.y < boundsY + boundsHeight - BOUNDS_BUFFER);
 
   return rightSideClearOfLeftBound
     && leftSideClearOfRightBound

--- a/main.js
+++ b/main.js
@@ -104,12 +104,12 @@ function isVisible(window, bounds) {
   const boundsHeight = _.get(bounds, 'height') || DEFAULT_HEIGHT;
 
   // requiring BOUNDS_BUFFER pixels on the left or right side
-  const rightSideClearOfLeftBound = (window.x + window.width > boundsX + BOUNDS_BUFFER);
-  const leftSideClearOfRightBound = (window.x < boundsX + boundsWidth - BOUNDS_BUFFER);
+  const rightSideClearOfLeftBound = (window.x + window.width >= boundsX + BOUNDS_BUFFER);
+  const leftSideClearOfRightBound = (window.x <= boundsX + boundsWidth - BOUNDS_BUFFER);
 
   // top can't be offscreen, and must show at least BOUNDS_BUFFER pixels at bottom
-  const topClearOfUpperBound = window.y > boundsY;
-  const topClearOfLowerBound = (window.y < boundsY + boundsHeight - BOUNDS_BUFFER);
+  const topClearOfUpperBound = window.y >= boundsY;
+  const topClearOfLowerBound = (window.y <= boundsY + boundsHeight - BOUNDS_BUFFER);
 
   return rightSideClearOfLeftBound
     && leftSideClearOfRightBound

--- a/main.js
+++ b/main.js
@@ -146,7 +146,11 @@ function createWindow () {
   }
 
   const visibleOnAnyScreen = _.some(screen.getAllDisplays(), function(display) {
-    return isVisible(windowConfig, _.get(display, 'bounds'));
+    if (!windowOptions.x || !windowOptions.y) {
+      return false;
+    }
+
+    return isVisible(windowOptions, _.get(display, 'bounds'));
   });
   if (!visibleOnAnyScreen) {
     console.log('Location reset needed');

--- a/main.js
+++ b/main.js
@@ -146,7 +146,7 @@ function createWindow () {
   }
 
   const visibleOnAnyScreen = _.some(screen.getAllDisplays(), function(display) {
-    if (!windowOptions.x || !windowOptions.y) {
+    if (!_.isNumber(windowOptions.x) || !_.isNumber(windowOptions.y)) {
       return false;
     }
 

--- a/main.js
+++ b/main.js
@@ -136,7 +136,7 @@ function createWindow () {
     windowOptions.width = DEFAULT_WIDTH;
   }
   if (!_.isNumber(windowOptions.height) || windowOptions.height < MIN_HEIGHT) {
-    windowOptions.width = DEFAULT_HEIGHT;
+    windowOptions.height = DEFAULT_HEIGHT;
   }
   if (!_.isBoolean(windowOptions.maximized)) {
     delete windowOptions.maximized;
@@ -391,11 +391,15 @@ ipc.on('restart', function(event) {
 });
 
 ipc.on("set-auto-hide-menu-bar", function(event, autoHide) {
-  mainWindow.setAutoHideMenuBar(autoHide);
+  if (mainWindow) {
+    mainWindow.setAutoHideMenuBar(autoHide);
+  }
 });
 
 ipc.on("set-menu-bar-visibility", function(event, visibility) {
-  mainWindow.setMenuBarVisibility(visibility);
+  if (mainWindow) {
+    mainWindow.setMenuBarVisibility(visibility);
+  }
 });
 
 ipc.on("close-about", function() {

--- a/main.js
+++ b/main.js
@@ -90,19 +90,68 @@ function captureClicks(window) {
   window.webContents.on('new-window', handleUrl);
 }
 
+
+const DEFAULT_WIDTH = 800;
+const DEFAULT_HEIGHT = 610;
+const MIN_WIDTH = 700;
+const MIN_HEIGHT = 360;
+
+function isVisible(window, bounds) {
+  const boundsX = _.get(bounds, 'x') || 0;
+  const boundsY = _.get(bounds, 'y') || 0;
+  const boundsWidth = _.get(bounds, 'width') || DEFAULT_WIDTH;
+  const boundsHeight = _.get(bounds, 'height') || DEFAULT_HEIGHT;
+
+  // Requiring the window to show at least 10 pixels on the left or right side
+  const rightSideClearOfLeftBound = (window.x + window.width > boundsX + 10);
+  const leftSideClearOfRightBound = (window.x < boundsX + boundsWidth - 10);
+
+  // the top of the window can't be offscreen, and must show at least 10 pixels at bottom
+  const topClearOfUpperBound = window.y > boundsY;
+  const topClearOfLowerBound = (window.y < boundsY + boundsHeight - 10);
+
+  return rightSideClearOfLeftBound
+    && leftSideClearOfRightBound
+    && topClearOfUpperBound
+    && topClearOfLowerBound;
+}
+
 function createWindow () {
+  const screen = electron.screen;
   const windowOptions = Object.assign({
-    width: 800,
-    height: 610,
-    minWidth: 700,
-    minHeight: 360,
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+    minWidth: MIN_WIDTH,
+    minHeight: MIN_HEIGHT,
     autoHideMenuBar: false,
     webPreferences: {
       nodeIntegration: false,
       //sandbox: true,
       preload: path.join(__dirname, 'preload.js')
     }
-  }, windowConfig);
+  }, _.pick(windowConfig, ['maximized', 'autoHideMenuBar', 'width', 'height', 'x', 'y']));
+
+  if (!_.isNumber(windowOptions.width) || windowOptions.width < MIN_WIDTH) {
+    windowOptions.width = DEFAULT_WIDTH;
+  }
+  if (!_.isNumber(windowOptions.height) || windowOptions.height < MIN_HEIGHT) {
+    windowOptions.width = DEFAULT_HEIGHT;
+  }
+  if (!_.isBoolean(windowOptions.maximized)) {
+    delete windowOptions.maximized;
+  }
+  if (!_.isBoolean(windowOptions.autoHideMenuBar)) {
+    delete windowOptions.autoHideMenuBar;
+  }
+
+  const visibleOnAnyScreen = _.some(screen.getAllDisplays(), function(display) {
+    return isVisible(windowConfig, _.get(display, 'bounds'));
+  });
+  if (!visibleOnAnyScreen) {
+    console.log('Location reset needed');
+    delete windowOptions.x;
+    delete windowOptions.y;
+  }
 
   if (windowOptions.fullscreen === false) {
     delete windowOptions.fullscreen;


### PR DESCRIPTION
We've gotten some reports that Signal Desktop fails to appear on Windows in some cases (https://github.com/WhisperSystems/Signal-Desktop/issues/1704). Further testing indicates that Windows, unlike OSX, does not do bounds-checking when initially placing a window, which can mean that a window can be totally off-screen, inaccessible.

This PR hardens our handling of an incoming window creation parameters from `config.json` :
1) We restrict the set of data we apply to the creation of the window
2) We validate the data types of everything we load
3) We ensure that the position/size of the window results at least of 100px of visible window contents (except the top, which must be onscreen) - if none of the available displays on startup are found to result in visibility, the provided `x` and `y` from the config data are dropped, and the window is opened in a generic start location