### PR TITLE
A variety of logging improvements to track down bugs

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -557,8 +557,7 @@
 
     function onError(ev) {
         var error = ev.error;
-        console.log(error);
-        console.log(error.stack);
+        console.log('background onError:', error && error.stack ? error.stack : error);
 
         if (error.name === 'HTTPError' && (error.code == 401 || error.code == 403)) {
             Whisper.Registration.remove();

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -39144,6 +39144,7 @@ MessageReceiver.prototype.extend({
         }.bind(this));
     },
     handleBlocked: function(envelope, blocked) {
+        console.log('Setting these numbers as blocked:', blocked.numbers);
         textsecure.storage.put('blocked', blocked.numbers);
     },
     isBlocked: function(number) {

--- a/js/libtextsecure.js
+++ b/js/libtextsecure.js
@@ -38042,7 +38042,7 @@ var TextSecureServer = (function() {
                 console.log("Old signed prekey record count: " + oldRecords.length);
 
                 oldRecords.forEach(function(oldRecord) {
-                    if ( oldRecord.keyId > activeSignedPreKeyId - 3 ) {
+                    if ( oldRecord.keyId >= activeSignedPreKeyId - 3 ) {
                         // keep at least the last 3 signed keys
                         return;
                     }

--- a/js/logging.js
+++ b/js/logging.js
@@ -161,7 +161,8 @@ window.log = {
 };
 
 window.onerror = function(message, script, line, col, error) {
-  window.log.error('Top-level unhandled error: ' + error.stack);
+  const errorInfo = error && error.stack ? error.stack : JSON.stringify(error);
+  window.log.error('Top-level unhandled error: ' + errorInfo);
 };
 
 window.addEventListener('unhandledrejection', function(rejectionEvent) {

--- a/js/logging.js
+++ b/js/logging.js
@@ -161,6 +161,9 @@ window.log = {
 };
 
 window.onerror = function(message, script, line, col, error) {
-  window.log.error(error.stack);
+  window.log.error('Top-level unhandled error: ' + error.stack);
 };
 
+window.addEventListener('unhandledrejection', function(rejectionEvent) {
+  window.log.error('Top-level unhandled promise rejection: ' + rejectionEvent.reason);
+});

--- a/js/models/messages.js
+++ b/js/models/messages.js
@@ -314,8 +314,11 @@
                 errors = [errors];
             }
             errors.forEach(function(e) {
-                console.log(e);
-                console.log(e.reason, e.stack);
+                console.log(
+                    'Message.saveErrors:',
+                    e && e.reason ? e.reason : null,
+                    e && e.stack ? e.stack : e
+                );
             });
             errors = errors.map(function(e) {
                 if (e.constructor === Error ||

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -222,6 +222,7 @@
             var prekey = new SignedPreKey({id: keyId});
             return new Promise(function(resolve) {
                 prekey.fetch().then(function() {
+                    console.log('Successfully loaded prekey:', prekey.get('id'));
                     resolve({
                         pubKey     : prekey.get('publicKey'),
                         privKey    : prekey.get('privateKey'),
@@ -229,14 +230,14 @@
                         keyId      : prekey.get('id')
                     });
                 }).fail(function() {
-                    console.log("Failed to load signed prekey:", keyId);
+                    console.log('Failed to load signed prekey:', keyId);
                     resolve();
                 });
             });
         },
         loadSignedPreKeys: function() {
             if (arguments.length > 0) {
-              return Promise.reject(new Error("loadSignedPreKeys takes no arguments"));
+              return Promise.reject(new Error('loadSignedPreKeys takes no arguments'));
             }
             var signedPreKeys = new SignedPreKeyCollection();
             return new Promise(function(resolve) {

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -219,7 +219,7 @@
                 return deferred.then(resolve, function(error) {
                     console.log(
                         'removePreKey error:',
-                        error && error.stack ? error.stack : error,
+                        error && error.stack ? error.stack : error
                     );
                     resolve();
                 });

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -211,7 +211,16 @@
             this.trigger('removePreKey');
 
             return new Promise(function(resolve) {
-                prekey.destroy().then(function() {
+                var deferred = prekey.destroy();
+                if (!deferred) {
+                    return resolve();
+                }
+
+                return deferred.then(resolve, function(error) {
+                    console.log(
+                        'removePreKey error:',
+                        error && error.stack ? error.stack : error,
+                    );
                     resolve();
                 });
             });

--- a/libtextsecure/account_manager.js
+++ b/libtextsecure/account_manager.js
@@ -172,7 +172,7 @@
                 console.log("Old signed prekey record count: " + oldRecords.length);
 
                 oldRecords.forEach(function(oldRecord) {
-                    if ( oldRecord.keyId > activeSignedPreKeyId - 3 ) {
+                    if ( oldRecord.keyId >= activeSignedPreKeyId - 3 ) {
                         // keep at least the last 3 signed keys
                         return;
                     }

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -730,6 +730,7 @@ MessageReceiver.prototype.extend({
         }.bind(this));
     },
     handleBlocked: function(envelope, blocked) {
+        console.log('Setting these numbers as blocked:', blocked.numbers);
         textsecure.storage.put('blocked', blocked.numbers);
     },
     isBlocked: function(number) {


### PR DESCRIPTION
- Log when we successfully load a signed prekey, which will help us track down prekey errors (what key id is being used by the successful incoming prekey messages?)
- Add a top-level handler for unhandled promise rejections
- Improve logging for top-level unhandled exception handler
- `removeSignedPrekey` log and ensure that promise is resolved in error cases
- Get rid of the two-log pattern for some of our error handling
- Log our handling of blocked number sync messages

Not logging, but important: Save three old signed keys in addition to the current active key. Will give us a little more breathing room, especially when a desktop client has been offline for a long time.