### PR TITLE
Logging for prekey fetches, load of log files

### DIFF
--- a/app/logging.js
+++ b/app/logging.js
@@ -89,6 +89,7 @@ function fetchLog(logFile) {
 
 function fetch(logPath) {
   const files = fs.readdirSync(logPath);
+  logger.info('Loaded this list of log files from logPath: ' + files.join(', '));
   const paths = files.map(function(file) {
     return path.join(logPath, file)
   });

--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -186,11 +186,15 @@
             var prekey = new PreKey({id: keyId});
             return new Promise(function(resolve) {
                 prekey.fetch().then(function() {
+                    console.log('Successfully fetched prekey:', keyId);
                     resolve({
-                        pubKey: prekey.attributes.publicKey,
-                        privKey: prekey.attributes.privateKey
+                        pubKey: prekey.get('publicKey'),
+                        privKey: prekey.get('privateKey'),
                     });
-                }).fail(resolve);
+                }, function() {
+                    console.log('Failed to load prekey:', keyId);
+                    resolve();
+                });
             });
         },
         storePreKey: function(keyId, keyPair) {


### PR DESCRIPTION
Continuing the trend of additional logging to track down issues started in https://github.com/WhisperSystems/Signal-Desktop/pull/1832

- I've encountered some logs which include very old entries; and my suspicion is that we're not cleaning up old log files properly. Whenever someone selects `View -> Debug Log` we'll log the set of log files we loaded
- We now log prekey fetch, both success and failure, to help track down bugs handling prekey messages.