### PR TITLE
Add .deb specific dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,9 @@
       ],
       "icon": "build/icons/png"
     },
+    "deb": {
+      "depends": ["gconf2", "gconf-service", "libnotify4", "libappindicator1", "libxtst6", "libnss3", "libasound2", "libxss1"]
+    },
     "files": [
       "package.json",
       "config/default.json",


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] My contribution is fully baked and ready to be merged as is
- [ ] My changes are rebased on the latest master branch
- [X] My commits are in nice logical chunks
- [X] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [X] I have tested my contribution on these platforms:
 * Debian docker image on Arch 4.14.3-1-ARCH
- [X] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [X] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
Adds `libasound2` and `libxss1` to the generated `.deb`'s dependencies, as well as the [default `.deb` dependencies](https://www.electron.build/configuration/linux#debian-package-options) included by `electron-builder` (`["gconf2", "gconf-service", "libnotify4", "libappindicator1", "libxtst6", "libnss3"]`).

Probably fixes #1838, but @angelo-v should probably test this out first, since I can't get my docker setup to open windows on my host OS.