### PR TITLE
A slightly more reasonable min-width

### DIFF
--- a/main.js
+++ b/main.js
@@ -113,7 +113,7 @@ function captureClicks(window) {
 
 const DEFAULT_WIDTH = 800;
 const DEFAULT_HEIGHT = 610;
-const MIN_WIDTH = 700;
+const MIN_WIDTH = 640;
 const MIN_HEIGHT = 360;
 const BOUNDS_BUFFER = 100;
 


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have tested my contribution on these platforms:
 * MacOS 10.12.6, Chrome 62.0.3202.94
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
This is a very small change, but allows the chat window to better fit into smaller spaces (e.g. tiled window managers)

The previous Chrome app version had a min-width of 650px. I figured 640px might be a little better, although I'd be happy with either over the current value of 700px, which no longer fits into the space I had assigned it to.