### PR TITLE
Delay our call to quitAndInstall(); doesn't work inside callback

### DIFF
--- a/app/auto_update.js
+++ b/app/auto_update.js
@@ -40,8 +40,13 @@ function showUpdateDialog(mainWindow, messages) {
 
   dialog.showMessageBox(mainWindow, options, function(response) {
     if (response == RESTART_BUTTON) {
-      windowState.markShouldQuit();
-      autoUpdater.quitAndInstall();
+      // We delay these update calls because they don't seem to work in this
+      //   callback - but only if the message box has a parent window.
+      // Fixes this bug: https://github.com/WhisperSystems/Signal-Desktop/issues/1864
+      setTimeout(function() {
+        windowState.markShouldQuit();
+        autoUpdater.quitAndInstall();
+      }, 200);
     }
 
     showingDialog = false;


### PR DESCRIPTION
Fixes https://github.com/WhisperSystems/Signal-Desktop/issues/1864. Sadly, it will not take effect in the next release, but the release after that. The bug is in the on-disk version of the app when a new version becomes available.

Originally introduced in https://github.com/WhisperSystems/Signal-Desktop/pull/1795, which went out in `v1.0.39` and `v1.1.0-beta.2`.

It does seem to have been discussed previously in this closed issue: https://github.com/electron/electron/issues/6345#issuecomment-271055970