### PR TITLE
Update available dialog: default is now 'later', not 'restart'

### DIFF
--- a/app/auto_update.js
+++ b/app/auto_update.js
@@ -34,8 +34,8 @@ function showUpdateDialog(mainWindow, messages) {
     title: messages.autoUpdateNewVersionTitle.message,
     message: messages.autoUpdateNewVersionMessage.message,
     detail: messages.autoUpdateNewVersionInstructions.message,
-    defaultId: RESTART_BUTTON,
-    cancelId: LATER_BUTTON
+    defaultId: LATER_BUTTON,
+    cancelId: RESTART_BUTTON,
   }
 
   dialog.showMessageBox(mainWindow, options, function(response) {


### PR DESCRIPTION
Fixes #1885

This prevents the user from restarting the app by pressing space on MacOS,  which happens frequently during the course of normal typing of a message.

In the future we'll move to a less-obtrusive system a little more like Chrome, where you choose to do the restart when it is convenient for you. For now, we minimize the chance of accidental restart in the middle of typing a message.