### PR TITLE
Treat tiffs like unrecognized files; Chrome doesn't render them

### DIFF
--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -130,7 +130,8 @@
         return this.model.contentType.startsWith('video/');
     },
     isImage: function() {
-        return this.model.contentType.startsWith('image/');
+        var type = this.model.contentType;
+        return type.startsWith('image/') && type !== 'image/tiff';
     },
     mediaType: function() {
         if (this.isVoiceMessage()) {

--- a/js/views/file_input_view.js
+++ b/js/views/file_input_view.js
@@ -70,7 +70,9 @@
         },
 
         autoScale: function(file) {
-            if (file.type.split('/')[0] !== 'image' || file.type === 'image/gif') {
+            if (file.type.split('/')[0] !== 'image'
+                || file.type === 'image/gif'
+                || file.type === 'image/tiff') {
                 // nothing to do
                 return Promise.resolve(file);
             }
@@ -123,6 +125,9 @@
             if (!file) { return; }
 
             var type = file.type.split('/')[0];
+            if (file.type === 'image/tiff') {
+                type = 'file';
+            }
             switch (type) {
                 case 'audio': this.addThumb('images/audio.svg'); break;
                 case 'video': this.addThumb('images/video.svg'); break;


### PR DESCRIPTION
Fixes #1713.

iOS renders my test tiffs properly, but Android `v4.14.7` just shows an empty square.