### PR TITLE
deselect conversation *FREEBIE*

### DIFF
--- a/js/views/conversation_list_item_view.js
+++ b/js/views/conversation_list_item_view.js
@@ -20,6 +20,7 @@
             this.listenTo(this.model, 'change', _.debounce(this.render.bind(this), 1000));
             this.listenTo(this.model, 'destroy', this.remove); // auto update
             this.listenTo(this.model, 'opened', this.markSelected); // auto update
+            this.listenTo(this.model, 'closed', this.unmarkSelected);
 
             var updateLastMessage = _.debounce(this.model.updateLastMessage.bind(this.model), 1000);
             this.listenTo(this.model.messageCollection, 'add remove', updateLastMessage);
@@ -34,6 +35,12 @@
 
         markSelected: function() {
             this.$el.addClass('selected').siblings('.selected').removeClass('selected');
+        },
+
+        unmarkSelected: function() {
+            // Similar to markSelected, this is necessary to remove the selection
+            // from the conversation list item after closing the conversation
+            this.$el.removeClass('selected');
         },
 
         select: function(e) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read the [README](https://github.com/WhisperSystems/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] My contribution is fully baked and ready to be merged as is
- [x] My changes are rebased on the latest master branch
- [x] My commits are in nice logical chunks
- [x] I have followed the [best practices](http://chris.beams.io/posts/git-commit/) in my commit messages
- [x] I have tested my contribution on these platforms:
 * macOS 10.13.2 (17C88) - standalone
- [x] My changes pass all the [local tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests) 100%
- [x] I have considered whether my changes need additional [tests](https://github.com/WhisperSystems/Signal-Desktop/blob/master/CONTRIBUTING.md#tests), and in the case they do, I have written them

----------------------------------------

### Description
This introduced the feature requested in https://github.com/WhisperSystems/Signal-Desktop/issues/1784
Now it's possible to deselect the conversation by pressing Shift + ESC.
In order to do that, now the conversations are not stacked anymore, but when a new conversation is opened, the DIV of the previous one is removed. This should also help in case of a very large number of conversations opened, but it requires some additional time to load the messages when a new conversation is opened.