### PR TITLE
Fix device ID check, clean up prekey fetch logging

### DIFF
--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -192,7 +192,7 @@
                         privKey: prekey.get('privateKey'),
                     });
                 }, function() {
-                    console.log('Failed to load prekey:', keyId);
+                    console.log('Failed to fetch prekey:', keyId);
                     resolve();
                 });
             });
@@ -235,7 +235,7 @@
             var prekey = new SignedPreKey({id: keyId});
             return new Promise(function(resolve) {
                 prekey.fetch().then(function() {
-                    console.log('Successfully loaded prekey:', prekey.get('id'));
+                    console.log('Successfully fetched signed prekey:', prekey.get('id'));
                     resolve({
                         pubKey     : prekey.get('publicKey'),
                         privKey    : prekey.get('privateKey'),
@@ -244,7 +244,7 @@
                         confirmed  : prekey.get('confirmed'),
                     });
                 }).fail(function() {
-                    console.log('Failed to load signed prekey:', keyId);
+                    console.log('Failed to fetch signed prekey:', keyId);
                     resolve();
                 });
             });

--- a/libtextsecure/sendmessage.js
+++ b/libtextsecure/sendmessage.js
@@ -422,7 +422,7 @@ MessageSender.prototype = {
         var myDevice = textsecure.storage.user.getDeviceId();
         var now = Date.now();
 
-        if (myDevice === 1) {
+        if (myDevice == 1) {
             return Promise.resolve();
         }
 


### PR DESCRIPTION
A couple quick changes:
- turns out that the device id was actually a string in my testing, so we change it back to `==`
- our prekey fetch logging had a bug in it - it didn't differentiate between prekeys and signed prekeys.