### PR TITLE
More information on http errors, resilient to invalid group members

### DIFF
--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -112,8 +112,8 @@
                 if (!conversation.isValid()) {
                     var validationError = conversation.validationError || {};
                     console.log(
-                        'Contact is not valid. Not saving, but adding to collection :',
-                        conversation.attribures,
+                        'Contact is not valid. Not saving, but adding to collection:',
+                        conversation.idForLogging(),
                         validationError.stack
                     );
 

--- a/js/conversation_controller.js
+++ b/js/conversation_controller.js
@@ -109,8 +109,18 @@
                 type: type
             });
             conversation.initialPromise = new Promise(function(resolve, reject) {
-                var deferred = conversation.save();
+                if (!conversation.isValid()) {
+                    var validationError = conversation.validationError || {};
+                    console.log(
+                        'Contact is not valid. Not saving, but adding to collection :',
+                        conversation.attribures,
+                        validationError.stack
+                    );
 
+                    return resolve(conversation);
+                }
+
+                var deferred = conversation.save();
                 if (!deferred) {
                     console.log('Conversation save failed! ', id, type);
                     return reject(new Error('getOrCreate: Conversation save failed'));

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -155,14 +155,14 @@ var TextSecureServer = (function() {
         return retry_ajax(url, options);
     }
 
-    function HTTPError(code, response, stack) {
+    function HTTPError(message, code, response, stack) {
         if (code > 999 || code < 100) {
             code = -1;
         }
-        var e = new Error();
+        var e = new Error(message + '; code: ' + code);
         e.name     = 'HTTPError';
         e.code     = code;
-        e.stack   += 'Original stack:\n' + stack;
+        e.stack   += '\nOriginal stack:\n' + stack;
         if (response) {
             e.response = response;
         }

--- a/libtextsecure/api.js
+++ b/libtextsecure/api.js
@@ -76,7 +76,8 @@ var TextSecureServer = (function() {
         }
 
         if (options.user && options.password) {
-          fetchOptions.headers["Authorization"] = "Basic " + btoa(getString(options.user) + ":" + getString(options.password));
+          fetchOptions.headers["Authorization"] =
+            "Basic " + btoa(getString(options.user) + ":" + getString(options.password));
         }
         if (options.contentType) {
           fetchOptions.headers["Content-Type"] = options.contentType;
@@ -93,13 +94,21 @@ var TextSecureServer = (function() {
           }
           return resultPromise.then(function(result) {
             if (options.responseType === 'arraybuffer') {
-              result = result.buffer.slice(result.byteOffset, result.byteOffset + result.byteLength);
+              result = result.buffer.slice(
+                result.byteOffset,
+                result.byteOffset + result.byteLength
+              );
             }
             if (options.responseType === 'json') {
               if (options.validateResponse) {
                 if (!validateResponse(result, options.validateResponse)) {
                   console.log(options.type, url, response.status, 'Error');
-                  reject(HTTPError(response.status, result, options.stack));
+                  reject(HTTPError(
+                    'promise_ajax: invalid response',
+                    response.status,
+                    result,
+                    options.stack
+                  ));
                 }
               }
             }
@@ -108,13 +117,18 @@ var TextSecureServer = (function() {
               resolve(result, response.status);
             } else {
               console.log(options.type, url, response.status, 'Error');
-              reject(HTTPError(response.status, result, options.stack));
+              reject(HTTPError(
+                'promise_ajax: error response',
+                response.status,
+                result,
+                options.stack
+              ));
             }
           });
         }).catch(function(e) {
           console.log(options.type, url, 0, 'Error');
-          console.log(e);
-          reject(HTTPError(0, e.toString(), options.stack));
+          var stack = e.stack + '\nInitial stack:\n' + options.stack;
+          reject(HTTPError('promise_ajax catch', 0, e.toString(), stack));
         });
       });
     }
@@ -148,7 +162,7 @@ var TextSecureServer = (function() {
         var e = new Error();
         e.name     = 'HTTPError';
         e.code     = code;
-        e.stack    = stack;
+        e.stack   += 'Original stack:\n' + stack;
         if (response) {
             e.response = response;
         }


### PR DESCRIPTION
Two primary changes in this pull request, both inspired by https://github.com/WhisperSystems/Signal-Desktop/issues/1964:

- When a group comes in with a number we don't understand, we currently fail quite spectacularly. With this change, we will note the invalid number in the log, and add the contact to the `ConversationController` without saving to the database. This will allow most scenarios to move forward without interrupt.
- When we get an error from the server, or when a web request fails, we generally drop the original error's information, preferring to use our own error messages and the stack on the way in to the original web request. This change brings back some of that key information to ensure that our logging in these cases is a bit more useful.