### PR TITLE
Left pane: small sorting fix, logging for error cases

### DIFF
--- a/js/views/conversation_list_view.js
+++ b/js/views/conversation_list_view.js
@@ -10,23 +10,45 @@
         itemView: Whisper.ConversationListItemView,
         updateLocation: function(conversation) {
             var $el = this.$('.' + conversation.cid);
-            if ($el && $el.length > 0) {
-                var inboxCollection = getInboxCollection();
-                var index = inboxCollection.indexOf(conversation);
-                var elIndex = this.$el.index($el);
 
-                if (index === elIndex) {
-                    return;
-                }
-                if (index === 0) {
-                    this.$el.prepend($el);
-                } else if (index === this.collection.length - 1) {
-                    this.$el.append($el);
-                } else {
-                    var targetConversation = inboxCollection.at(index + 1);
-                    var target = this.$('.' + targetConversation.cid);
-                    $el.insertBefore(target);
-                }
+            if (!$el || !$el.length) {
+                console.log(
+                    'updateLocation: did not find element for conversation',
+                    conversation.idForLogging()
+                );
+                return;
+            }
+            if ($el.length > 1) {
+                console.log(
+                    'updateLocation: found more than one element for conversation',
+                    conversation.idForLogging()
+                );
+                return;
+            }
+
+            var $allConversations = this.$('.conversation-list-item');
+            var inboxCollection = getInboxCollection();
+            var index = inboxCollection.indexOf(conversation);
+
+            var elIndex = $allConversations.index($el);
+            if (elIndex < 0) {
+                console.log(
+                    'updateLocation: did not find index for conversation',
+                    conversation.idForLogging()
+                );
+            }
+
+            if (index === elIndex) {
+                return;
+            }
+            if (index === 0) {
+                this.$el.prepend($el);
+            } else if (index === this.collection.length - 1) {
+                this.$el.append($el);
+            } else {
+                var targetConversation = inboxCollection.at(index - 1);
+                var target = this.$('.' + targetConversation.cid);
+                $el.insertAfter(target);
             }
         },
         removeItem: function(conversation) {


### PR DESCRIPTION
We recently received a number of reports saying that the left pane would stop sorting, or that it was wrong. This change introduces two changes to help with the sorting of that left pane:

1. If we reach any invalid states, where the target conversation isn't yet added to the DOM, or we can't figure out where it is by index, we log and in some cases fully bail out
2. our previous technique of trying to discover the location of the current conversation in the DOM by index seems to be incorrect. My investigation seems to indicate that it was returning `-1` for the index all the time. Pulling the full set of conversations then checking the index against that does seem to work, however. This may help make our sorting a little less error-prone.