### PR TITLE
Video/audio: rely on the browser to detect content type

### DIFF
--- a/js/views/attachment_view.js
+++ b/js/views/attachment_view.js
@@ -45,7 +45,6 @@
       render: function() {
           var $el = $('<source>');
           $el.attr('src', this.dataUrl);
-          $el.attr('type', this.contentType);
           this.$el.append($el);
           return this;
       }


### PR DESCRIPTION
Fixes #1963, which reported a video which could not be played back after being forwarded by Android. The problem stems from Android's use of the content-type 'video/*', which the browser treats as invalid, skipping the `<source>` entry entirely.

If we omit the `type` parameter to the `<source>` tag, the video plays. So this is a bullet-proofing fix. The right fix, which will give us a good filename, is for Android to fix how it forwards media.