### PR TITLE
Account setup: confirm first signed prekey, clear all prekeys

### DIFF
--- a/js/signal_protocol_store.js
+++ b/js/signal_protocol_store.js
@@ -89,6 +89,11 @@
 
     var Model = Backbone.Model.extend({ database: Whisper.Database });
     var PreKey = Model.extend({ storeName: 'preKeys' });
+    var PreKeyCollection = Backbone.Collection.extend({
+        storeName: 'preKeys',
+        database: Whisper.Database,
+        model: PreKey
+    });
     var SignedPreKey = Model.extend({ storeName: 'signedPreKeys' });
     var SignedPreKeyCollection = Backbone.Collection.extend({
         storeName: 'signedPreKeys',
@@ -229,6 +234,12 @@
                 });
             });
         },
+        clearPreKeyStore: function() {
+            return new Promise(function(resolve) {
+                var preKeys = new PreKeyCollection();
+                preKeys.sync('delete', preKeys, {}).always(resolve);
+            });
+        },
 
         /* Returns a signed keypair object or undefined */
         loadSignedPreKey: function(keyId) {
@@ -291,6 +302,12 @@
                 }
 
                 deferred.then(resolve, reject);
+            });
+        },
+        clearSignedPreKeysStore: function() {
+            return new Promise(function(resolve) {
+                var signedPreKeys = new SignedPreKeyCollection();
+                signedPreKeys.sync('delete', signedPreKeys, {}).always(resolve);
             });
         },
 
@@ -392,7 +409,6 @@
                 var sessions = new SessionCollection();
                 sessions.sync('delete', sessions, {}).always(resolve);
             });
-
         },
         isTrustedIdentity: function(identifier, publicKey, direction) {
             if (identifier === null || identifier === undefined) {


### PR DESCRIPTION
A recent log posted in https://github.com/WhisperSystems/Signal-Desktop/issues/1273#issuecomment-358386670 indicated that we weren't handling signed prekeys properly when a new account was created (either initial setup or re-link). This change does two things:

1. We clear out all local prekeys and signed prekeys as part of the account create process
2. We confirm the new signed prekey registered with the server right as part of the account create process
