### PR TITLE
Remove expired message if it expired during database fetch

### DIFF
--- a/js/views/conversation_view.js
+++ b/js/views/conversation_view.js
@@ -645,8 +645,24 @@
             }
         },
         onExpiredCollection: function(message) {
-            console.log('removing message', message.get('sent_at'), 'from collection');
-            this.model.messageCollection.remove(message.id);
+            var removeMessage = function() {
+                console.log(
+                    'removing message',
+                    message.get('sent_at'),
+                    'from collection'
+                );
+                this.model.messageCollection.remove(message.id);
+            }.bind(this);
+
+            // If a fetch is in progress, then we need to wait until that's complete to
+            //   do this removal. Otherwise we could remove from messageCollection, then
+            //   the async database fetch could include the removed message.
+
+            if (this.inProgressFetch) {
+                this.inProgressFetch.then(removeMessage);
+            } else {
+                removeMessage();
+            }
         },
 
         addMessage: function(message) {

--- a/libtextsecure/message_receiver.js
+++ b/libtextsecure/message_receiver.js
@@ -595,8 +595,12 @@ MessageReceiver.prototype.extend({
         }
         if (syncMessage.sent) {
             var sentMessage = syncMessage.sent;
+            var to = sentMessage.message.group
+                ? 'group(' + sentMessage.message.group.id.toBinary() + ')'
+                : sentMessage.destination;
+
             console.log('sent message to',
-                    sentMessage.destination,
+                    to,
                     sentMessage.timestamp.toNumber(),
                     'from',
                     this.getEnvelopeId(envelope)


### PR DESCRIPTION
fixes https://github.com/WhisperSystems/Signal-Desktop/issues/1951
Likely also fixes #1957

This fixes a race condition where:
1. The user had selected to show a conversation, and that resulted in a database fetch.
2. During that fetch, a message in that conversation expired. That expiration reached out to the `ConversationView` to remove it from the UI.
3. The database fetch completed, including that expired message.

This ensures that the UI removal happens after any pending database fetch.

Note: tested with an artificially-extended `fetchMessages`, and the issue both repros reliably and is fixed with these changes.