### PR TITLE
Update to latest Electron 1.7.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "asar": "^0.14.0",
     "bower": "^1.8.2",
     "chai": "^4.1.2",
-    "electron": "1.7.10",
+    "electron": "1.7.11",
     "electron-builder": "^19.53.7",
     "electron-icon-maker": "0.0.3",
     "electron-publisher-s3": "^19.53.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,9 +1516,9 @@ electron-updater@^2.19.0:
     semver "^5.4.1"
     source-map-support "^0.5.0"
 
-electron@1.7.10:
-  version "1.7.10"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.10.tgz#3a3e83d965fd7fafe473be8ddf8f472561b6253d"
+electron@1.7.11:
+  version "1.7.11"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.7.11.tgz#993b6aa79e0e79a7cfcc369f4c813fbd9a0b08d9"
   dependencies:
     "@types/node" "^7.0.18"
     electron-download "^3.0.1"


### PR DESCRIPTION
Fixes #1991, related to IME input on Mac.