### PR TITLE
Added filename display for audio, non-voice attachments, and filename display when playing audio files

### DIFF
--- a/ts/components/MiniPlayer.tsx
+++ b/ts/components/MiniPlayer.tsx
@@ -107,6 +107,8 @@ export function MiniPlayer({
             )}
           </span>
         )}
+        <span className="MiniPlayer__middot">&middot;</span>
+        <span >&middot;</span>
       </div>
 
       <PlaybackRateButton

--- a/ts/components/MiniPlayer.tsx
+++ b/ts/components/MiniPlayer.tsx
@@ -18,6 +18,7 @@ export enum PlayerState {
 export type Props = Readonly<{
   i18n: LocalizerType;
   title: string;
+  fileName: string | undefined
   currentTime: number;
   // not available until audio has loaded
   duration: number | undefined;
@@ -34,6 +35,7 @@ export type Props = Readonly<{
 export function MiniPlayer({
   i18n,
   title,
+  fileName,
   state,
   currentTime,
   duration,
@@ -100,15 +102,14 @@ export function MiniPlayer({
       <div className="MiniPlayer__state">
         <UserText text={title} />
         <span className="MiniPlayer__middot">&middot;</span>
+        <span>{fileName}</span>
         {duration !== undefined && (
-          <span>
+          <span style={{marginLeft: fileName && '6px' || '0px'}}>
             {durationToPlaybackText(
               state === PlayerState.loading ? duration : currentTime
             )}
           </span>
         )}
-        <span className="MiniPlayer__middot">&middot;</span>
-        <span >&middot;</span>
       </div>
 
       <PlaybackRateButton

--- a/ts/components/MiniPlayer.tsx
+++ b/ts/components/MiniPlayer.tsx
@@ -8,6 +8,7 @@ import { durationToPlaybackText } from '../util/durationToPlaybackText';
 import { PlaybackButton } from './PlaybackButton';
 import { PlaybackRateButton } from './PlaybackRateButton';
 import { UserText } from './UserText';
+import { shortenFileName } from '../util/attachments';
 
 export enum PlayerState {
   loading = 'loading',
@@ -102,7 +103,7 @@ export function MiniPlayer({
       <div className="MiniPlayer__state">
         <UserText text={title} />
         <span className="MiniPlayer__middot">&middot;</span>
-        <span>{fileName}</span>
+        <span>{shortenFileName(fileName, true)}</span>
         {duration !== undefined && (
           <span style={{marginLeft: fileName && '6px' || '0px'}}>
             {durationToPlaybackText(

--- a/ts/components/conversation/MessageAudio.tsx
+++ b/ts/components/conversation/MessageAudio.tsx
@@ -23,6 +23,7 @@ import { WaveformScrubber } from './WaveformScrubber';
 import { useComputePeaks } from '../../hooks/useComputePeaks';
 import { durationToPlaybackText } from '../../util/durationToPlaybackText';
 import { shouldNeverBeCalled } from '../../util/shouldNeverBeCalled';
+import { shortenFileName } from '../../util/attachments';
 
 export type OwnProps = Readonly<{
   active:
@@ -167,7 +168,7 @@ export function MessageAudio(props: Props): JSX.Element {
   const [isPlayedDotVisible, setIsPlayedDotVisible] = React.useState(!played);
 
   const audioUrl = isDownloaded(attachment) ? attachment.url : undefined;
-  const fileName = (attachment.fileName && !attachment.isVoiceMessage) ? attachment.fileName : undefined;
+  const fileName = (attachment.fileName && !attachment.isVoiceMessage) ? shortenFileName(attachment.fileName) : undefined;
   const { duration, hasPeaks, peaks } = useComputePeaks({
     audioUrl,
     activeDuration: active?.duration,

--- a/ts/components/conversation/MessageAudio.tsx
+++ b/ts/components/conversation/MessageAudio.tsx
@@ -167,7 +167,7 @@ export function MessageAudio(props: Props): JSX.Element {
   const [isPlayedDotVisible, setIsPlayedDotVisible] = React.useState(!played);
 
   const audioUrl = isDownloaded(attachment) ? attachment.url : undefined;
-
+  const fileName = (attachment.fileName && !attachment.isVoiceMessage) ? attachment.fileName : undefined;
   const { duration, hasPeaks, peaks } = useComputePeaks({
     audioUrl,
     activeDuration: active?.duration,
@@ -369,7 +369,6 @@ export function MessageAudio(props: Props): JSX.Element {
       )}
     </div>
   );
-
   return (
     <div
       className={classNames(
@@ -381,7 +380,14 @@ export function MessageAudio(props: Props): JSX.Element {
     >
       <div className={`${CSS_BASE}__button-and-waveform`}>
         {button}
-        {waveform}
+        <div>
+          <span className={`module-message__text module-message__text--${direction}`} style={{
+            fontSize: '12px',
+          }}>
+            {fileName}
+          </span>
+          {waveform}
+        </div>
       </div>
       {metadata}
     </div>

--- a/ts/state/selectors/audioPlayer.ts
+++ b/ts/state/selectors/audioPlayer.ts
@@ -34,6 +34,7 @@ export type VoiceNoteForPlayback = {
   id: string;
   // undefined if download is pending
   url: string | undefined;
+  fileName: string | undefined;
   type: 'incoming' | 'outgoing';
   source: string | undefined;
   sourceServiceId: ServiceIdString | undefined;
@@ -96,11 +97,13 @@ export function extractVoiceNoteForPlayback(
   const voiceNoteUrl = attachment.path
     ? getAttachmentUrlForPath(attachment.path)
     : undefined;
+  const fileName = attachment.fileName;
   const status = getMessagePropStatus(message, ourConversationId);
 
   return {
     id: message.id,
     url: voiceNoteUrl,
+    fileName,
     type,
     isPlayed: isPlayed(type, status, message.readStatus),
     messageIdForLogging: getMessageIdForLogging(message),

--- a/ts/state/smart/MiniPlayer.tsx
+++ b/ts/state/smart/MiniPlayer.tsx
@@ -41,6 +41,9 @@ export function SmartMiniPlayer({ shouldFlow }: Props): JSX.Element | null {
   const url = AudioPlayerContent.isVoiceNote(content)
     ? content.current.url
     : content.url;
+    const fileName = AudioPlayerContent.isVoiceNote(content)
+    ? content.current.fileName
+    : undefined
 
   let state = PlayerState.loading;
   if (url) {
@@ -55,6 +58,7 @@ export function SmartMiniPlayer({ shouldFlow }: Props): JSX.Element | null {
           ? i18n('icu:you')
           : getVoiceNoteTitle(content.current)
       }
+      fileName={fileName}
       onPlay={handlePlay}
       onPause={handlePause}
       onPlaybackRate={setPlaybackRate}

--- a/ts/util/attachments.ts
+++ b/ts/util/attachments.ts
@@ -116,7 +116,7 @@ export function copyCdnFields(
  * @param fileName - The original file name.
  * @param isPlaying - If true, truncate the file name to maxLength characters and add '...' at the end.
  *                  - If false, show the first 15 characters, add '...', and the last 15 characters.
- * @param maxLength - The maximum length of the file name when isPlaying is true (default: 30).
+ * @param maxLength - The maximum length of the file name (default: 30).
  * @returns The shortened file name.
  */
 export function shortenFileName(
@@ -139,7 +139,7 @@ export function shortenFileName(
 
     return `${shortenedFileName}.${extension}`;
   } else {
-    const truncatedFileName = fileName.slice(0, maxLength - 3) + '...';
+    const truncatedFileName = `${fileName.slice(0, maxLength - 3)}...`;
     return truncatedFileName;
   }
 }

--- a/ts/util/attachments.ts
+++ b/ts/util/attachments.ts
@@ -111,3 +111,35 @@ export function copyCdnFields(
     plaintextHash: uploaded.plaintextHash,
   };
 }
+/**
+ * Shortens a file name based on specified conditions.
+ * @param fileName - The original file name.
+ * @param isPlaying - If true, truncate the file name to maxLength characters and add '...' at the end.
+ *                  - If false, show the first 15 characters, add '...', and the last 15 characters.
+ * @param maxLength - The maximum length of the file name when isPlaying is true (default: 30).
+ * @returns The shortened file name.
+ */
+export function shortenFileName(
+  fileName: string | undefined,
+  isPlaying: boolean = false,
+  maxLength: number = 30
+): string {
+  if (fileName === undefined) return '';
+  if (fileName.length <= maxLength) {
+    return fileName;
+  }
+
+  if (!isPlaying) {
+    const fileNameWithoutExtension = fileName.split('.').slice(0, -1).join('.');
+    const extension = fileName.split('.').pop();
+    const shortenedFileName = `${fileNameWithoutExtension.slice(
+      0,
+      15
+    )}...${fileNameWithoutExtension.slice(-15)}`;
+
+    return `${shortenedFileName}.${extension}`;
+  } else {
+    const truncatedFileName = fileName.slice(0, maxLength - 3) + '...';
+    return truncatedFileName;
+  }
+}


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

As mentioned in the title, which is also the need of our team, there are many files that need to be tested every day, so a file name is needed for identification.
If accepted, hopefully it will help the community.
Thanks for review.
![Screenshot_10](https://github.com/signalapp/Signal-Desktop/assets/145103204/10afde92-1c86-4f30-abcc-4b6a18ba1677)

add images with shortened names
![Screenshot_14](https://github.com/signalapp/Signal-Desktop/assets/145103204/a0c1ac68-77f2-466a-a700-274b8b03b9a0)



