### PR TITLE
Fix overflow in AttachmentSection

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -2420,9 +2420,14 @@ button.ConversationDetails__action-button {
 .module-document-list-item__metadata {
   display: inline-flex;
   flex-direction: column;
-  flex-grow: 1;
-  flex-shrink: 0;
   margin-inline: 8px;
+  flex: 1;
+  min-width: 0;
+  .module-document-list-item__file-name {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 }
 
 .module-document-list-item__file-size {


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/).
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch.
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests)).
- [x] My changes are ready to be shipped to users.

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

This commit will truncate long titles of documents in attachment section.
To reproduce, just upload a document with a long title and open attachments, then resize window.

<details>
  <summary>Screenshots</summary>
  
  Before
  ![1](https://github.com/signalapp/Signal-Desktop/assets/70171475/bc6d9c1c-6192-417d-bb30-ce004f89d467)
  
  After
  ![2](https://github.com/signalapp/Signal-Desktop/assets/70171475/ec46a521-ee7c-409a-9e90-932c4e5b1be5)
</details>