### PR TITLE
#6703: tooltip content interaction.

### DIFF
--- a/ts/components/CallsList.tsx
+++ b/ts/components/CallsList.tsx
@@ -459,7 +459,7 @@ export function CallsList({
           direction={TooltipPlacement.Bottom}
           content={i18n('icu:CallsList__ToggleFilterByMissedLabel')}
           theme={Theme.Dark}
-          delay={600}
+          showDelay={600}
         >
           <button
             className={classNames('CallsList__ToggleFilterByMissed', {

--- a/ts/components/LeftPaneDialog.tsx
+++ b/ts/components/LeftPaneDialog.tsx
@@ -180,6 +180,7 @@ export function LeftPaneDialog({
       <Tooltip
         content={message}
         direction={TooltipPlacement.Right}
+        hideDelay={100}
         className={classNames(
           TOOLTIP_CLASS_NAME,
           type && `${TOOLTIP_CLASS_NAME}--${type}`

--- a/ts/components/NavTabs.tsx
+++ b/ts/components/NavTabs.tsx
@@ -96,7 +96,7 @@ function NavTabsItem({
         content={label}
         theme={Theme.Dark}
         direction={isRTL ? TooltipPlacement.Left : TooltipPlacement.Right}
-        delay={600}
+        showDelay={600}
       >
         <span className="NavTabs__ItemButton">
           <span className="NavTabs__ItemContent">
@@ -158,7 +158,7 @@ export function NavTabsToggle({
         content={label}
         theme={Theme.Dark}
         direction={isRTL ? TooltipPlacement.Left : TooltipPlacement.Right}
-        delay={600}
+        showDelay={600}
       >
         <span className="NavTabs__ItemButton">
           <span className="NavTabs__ItemContent">
@@ -328,7 +328,7 @@ export function NavTabs({
                     content={i18n('icu:NavTabs__ItemLabel--Settings')}
                     theme={Theme.Dark}
                     direction={TooltipPlacement.Right}
-                    delay={600}
+                    showDelay={600}
                   >
                     <span className="NavTabs__ItemButton" ref={ref}>
                       <span className="NavTabs__ItemContent">
@@ -366,7 +366,7 @@ export function NavTabs({
               content={i18n('icu:NavTabs__ItemLabel--Profile')}
               theme={Theme.Dark}
               direction={isRTL ? TooltipPlacement.Left : TooltipPlacement.Right}
-              delay={600}
+              showDelay={600}
             >
               <span className="NavTabs__ItemButton">
                 <span className="NavTabs__ItemContent">

--- a/ts/components/Tooltip.stories.tsx
+++ b/ts/components/Tooltip.stories.tsx
@@ -16,6 +16,8 @@ export default {
       options: Object.values(TooltipPlacement),
     },
     sticky: { control: { type: 'boolean' } },
+    showDelay: { control: { type: 'number' } },
+    hideDelay: { control: { type: 'number' } },
     theme: {
       control: { type: 'select' },
       options: Object.keys(Theme),
@@ -26,6 +28,8 @@ export default {
     content: 'Hello World',
     direction: TooltipPlacement.Top,
     sticky: false,
+    showDelay: 0,
+    hideDelay: 0,
   },
 } satisfies Meta<PropsType>;
 
@@ -78,6 +82,30 @@ export function Left(args: PropsType): JSX.Element {
 export function Sticky(args: PropsType): JSX.Element {
   return (
     <Tooltip {...args} sticky>
+      {Trigger}
+    </Tooltip>
+  );
+}
+
+export function ShowDelay(args: PropsType): JSX.Element {
+  return (
+    <Tooltip {...args} showDelay={250}>
+      {Trigger}
+    </Tooltip>
+  );
+}
+
+export function HideDelay(args: PropsType): JSX.Element {
+  return (
+    <Tooltip {...args} hideDelay={250}>
+      {Trigger}
+    </Tooltip>
+  );
+}
+
+export function ShowHideDelay(args: PropsType): JSX.Element {
+  return (
+    <Tooltip {...args} showDelay={250} hideDelay={250}>
       {Trigger}
     </Tooltip>
   );

--- a/ts/util/lint/exceptions.json
+++ b/ts/util/lint/exceptions.json
@@ -3591,6 +3591,20 @@
     "updated": "2023-08-10T00:23:35.320Z"
   },
   {
+    "rule": "React-useRef",
+    "path": "ts/components/Tooltip.tsx",
+    "line": "  const hideDelayTimeoutRef = useRef<NodeJS.Timeout | undefined>();",
+    "reasonCategory": "usageTrusted",
+    "updated": "2023-12-25T10:53:31.583Z"
+  },
+  {
+    "rule": "React-useRef",
+    "path": "ts/components/Tooltip.tsx",
+    "line": "  const popperDelayTimeoutRef = useRef<NodeJS.Timeout | undefined>();",
+    "reasonCategory": "usageTrusted",
+    "updated": "2023-12-25T10:53:31.583Z"
+  },
+  {
     "rule": "React-createRef",
     "path": "ts/components/conversation/ConversationHeader.tsx",
     "line": "    this.menuTriggerRef = React.createRef();",


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes #6703.

- Mouse enter/leave events are now captured on the popper and taken into account when evaluating the overall tooltip hover state.
- An optional hide delay has been added. The purpose of this is to prevent the tooltip hover state from changing when the cursor transitions from the tooltip element to the popper element (or vice versa).

These changes allow the user to interact with the tooltip popper content (e.g., clicking a hyperlink to update Signal).

This was tested on MacOS 14.2.1 (23C71) using various combinations of show/hide delay values. No new tests were written. Three new storybook examples were added for the tooltip component.