### PR TITLE
Use an absolute filename for the file save dialog on Linux

### DIFF
--- a/app/main.ts
+++ b/app/main.ts
@@ -1,7 +1,7 @@
 // Copyright 2017 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { join, normalize, extname, dirname, basename } from 'path';
+import { join, normalize, extname, dirname, basename, isAbsolute } from 'path';
 import { pathToFileURL } from 'url';
 import * as os from 'os';
 import { chmod, realpath, writeFile } from 'fs-extra';
@@ -3019,6 +3019,30 @@ ipc.handle('show-save-dialog', async (_event, { defaultPath }) => {
     getLogger().warn('show-save-dialog: no main window');
 
     return { canceled: true };
+  }
+
+  if (
+    process.platform === 'linux' &&
+    defaultPath &&
+    !isAbsolute(defaultPath)
+  ) {
+    // On Linux the defaultPath should be an absolute path, otherwise the save dialog will have an empty filename on KDE/Plasma
+    let downloadsPath = '';
+    try {
+      downloadsPath = app.getPath('downloads');
+      getLogger().info(
+        'show-save-dialog: saving to user downloads directory: ' + downloadsPath
+      );
+    } catch (e) {
+      // If we cannot get Downloads path, fall back to the user's home directory
+      downloadsPath = app.getPath('home');
+      getLogger().info(
+        'show-save-dialog: saving to user home directory: ' + downloadsPath
+      );
+    }
+    if (downloadsPath) {
+      defaultPath = join(downloadsPath, defaultPath)
+    }
   }
 
   const { canceled, filePath: selectedFilePath } = await dialog.showSaveDialog(


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `npm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This fixes #6912.
On Gnome the save dialog works with any filename, on KDE Plasma the save dialog opens with an empty filename input field, unless the application uses an absolute file path instead of only the filename. This commit will use the ~/Downloads directory as the default path, which seems like a better choice then dumping files into the user's home dir.
