### PR TITLE
Fix issue #7279: set selected emoji color to be transparant; set sele…

### DIFF
--- a/stylesheets/components/fun/FunEmoji.scss
+++ b/stylesheets/components/fun/FunEmoji.scss
@@ -176,6 +176,14 @@ $inline-emoji-container-name: inline-emoji;
   line-height: 64px;
   user-select: text;
 }
+.FunEmojiSelectionText::selection {
+  background-color: rgba(8, 73, 205, 255);
+  color: transparent;
+}
+.FunEmojiSelectionText::-moz-selection {
+  background-color: rgba(8, 73, 205, 255);
+  color: transparent;
+}
 
 .FunInlineEmoji__Image {
   position: relative;


### PR DESCRIPTION
…ction color to be proper blue highlight color.

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
Fixes #7279 

Simple manual testing
Before:
![before](https://github.com/user-attachments/assets/5201899b-c3a0-4186-b313-0ece710d30f5)
After:
![after](https://github.com/user-attachments/assets/677e4187-ea4f-4f83-b250-22315bf2cd2c)
Tested on Linux Mint (as where the issue was discovered)