### PR TITLE
docs: add staging captcha workaround for Desktop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,25 @@ and you'll see all of your contacts and messages!
 
 You'll notice a prompt to re-link, because your production credentials won't work on
 staging. Click 'Relink', then 'Standalone', then verify the phone number and click
-'Send SMS.'
+'	Send SMS.'
+
+**Note: hCaptcha callback limitation on development builds**
+
+When you register or relink in **staging**, the browser completes hCaptcha and redirects
+to a URL that begins with `signalcaptcha://…`. Development (Electron) builds do **not**
+automatically capture this custom‑scheme URI, so the desktop window may not change.
+
+If that happens:
+
+1. In the browser’s **Network** tab, copy the full `signalcaptcha://signal-hcaptcha-short-…` URL.
+2. In a separate terminal, pass the URL as a command‑line argument:
+
+```bash
+pnpm start -- "signalcaptcha://signal-hcaptcha-short-XXXXXXXX"
+```
+
+Signal‑Desktop will ingest the token and continue to the SMS verification
+screen.
 
 Once you've entered the confirmation code sent to your phone, you are registered as a
 standalone staging device with your normal phone number, and a copy of your production


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Adds a short **hCaptcha workaround** note to **CONTRIBUTING.md → The staging environment**.

Fixes #7304

### What’s changed
* Documents the current limitation where development/Electron builds do **not** capture the
  `signalcaptcha://…` callback automatically.
* Provides the exact command-line workaround:

  ```bash
  pnpm start -- "signalcaptcha://signal-hcaptcha-short-XXXXXXXX"

so new contributors can unblock registration or relinking on staging immediately.

### Value to users
Without this note, first-time builders are stuck on the phone number page and often assume the project is broken.
The added two-sentence tip saves at least 10-15 minutes of head-scratching and reduces duplicate support questions in Issues.

### Test approach
* Manual-docs test – rendered the updated markdown in preview mode; verified the new call-out appears after the Relink → Standalone step.
* Ran pnpm run ready → everythin pass (no runtime code touched).
* No new automated tests were necessary because this is a documentation-only change.
