### PR TITLE
Fix issue #7320: non accessible avatar colors pair

### DIFF
--- a/sticker-creator/src/colors.scss
+++ b/sticker-creator/src/colors.scss
@@ -142,8 +142,8 @@ $avatar-color-A120: (
   fg: #086da0,
 );
 $avatar-color-A130: (
-  bg: #cde4cd,
-  fg: #067906,
+  bg: #cfe8cf,
+  fg: #005a00,
 );
 $avatar-color-A140: (
   bg: #eae0fd,
@@ -167,7 +167,7 @@ $avatar-color-A180: (
 );
 $avatar-color-A190: (
   bg: #eae6d5,
-  fg: #7d6f40,
+  fg: #665930,
 );
 $avatar-color-A200: (
   bg: #d2d2dc,

--- a/stylesheets/_variables.scss
+++ b/stylesheets/_variables.scss
@@ -174,8 +174,8 @@ $avatar-color-A120: (
   fg: #086da0,
 );
 $avatar-color-A130: (
-  bg: #cde4cd,
-  fg: #067906,
+  bg: #cfe8cf,
+  fg: #005a00,
 );
 $avatar-color-A140: (
   bg: #eae0fd,
@@ -199,7 +199,7 @@ $avatar-color-A180: (
 );
 $avatar-color-A190: (
   bg: #eae6d5,
-  fg: #7d6f40,
+  fg: #665930,
 );
 $avatar-color-A200: (
   bg: #d2d2dc,

--- a/ts/types/Colors.ts
+++ b/ts/types/Colors.ts
@@ -26,8 +26,8 @@ export const AvatarColorMap = new Map([
   [
     'A130',
     {
-      bg: '#cde4cd',
-      fg: '#067906',
+      bg: '#cfe8cf',
+      fg: '#005a00',
     },
   ],
   [
@@ -69,7 +69,7 @@ export const AvatarColorMap = new Map([
     'A190',
     {
       bg: '#eae6d5',
-      fg: '#7d6f40',
+      fg: '#665930',
     },
   ],
   [


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

This pull requests fix the issue #7320 

The colors are changes as follow:

- For A130 
  - **Background**: `#cde4cd` becames `#067906`
  - **Foreground**: `#005a00` becames `#005a00`

![image](https://github.com/user-attachments/assets/123f196d-441e-43fb-a4ce-ab2ede506127)


- For A190
  - **Background**: `#eae6d5` stays the same
  - **Foreground**: `#7d6f40` becames `#665930`

![image](https://github.com/user-attachments/assets/d93bc2d3-1273-460d-953f-d8be86890934)

