### PR TITLE
Enlarge Compositor on long edited messages

### DIFF
--- a/ts/components/CompositionArea.tsx
+++ b/ts/components/CompositionArea.tsx
@@ -470,6 +470,13 @@ export const CompositionArea = memo(function CompositionArea({
     setAttachmentToEdit(attachment);
   }
 
+  // enlarge the draft body on existing messages to provide better editing ux
+  function maybeEnlargeCompositor() {
+    if((draftEditMessageBody?.length ?? 0) > 256) {
+      setLarge(true)
+    }
+  }
+
   const isComposerEmpty =
     !draftAttachments.length && !draftText && !draftEditMessage;
 
@@ -577,6 +584,9 @@ export const CompositionArea = memo(function CompositionArea({
       draftBodyRanges ?? undefined,
       true
     );
+
+    maybeEnlargeCompositor()
+
   }, [draftBodyRanges, draftEditMessageBody, hasEditDraftChanged]);
 
   const previousConversationId = usePrevious(conversationId, conversationId);


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

This PR adds a tiny little feature where the CompositionArea is expanded when the user starts editing a message, if that message exceeds a certain size. (I chouse 256 as "long" since that length started to hide content on my 1080p monitor, but  that can easily be adjusted.

The reason for this is that editing longer messages usually requires opening the textfield anyway, so this skips the step.