### PR TITLE
Do not close FunPanelEmojis on ClickEvent

### DIFF
--- a/ts/components/fun/panels/FunPanelEmojis.dom.tsx
+++ b/ts/components/fun/panels/FunPanelEmojis.dom.tsx
@@ -663,9 +663,7 @@ const Cell = memo(function Cell(props: CellProps): JSX.Element {
       const emojiSelection: FunEmojiSelection = {
         variantKey: emojiVariant.key,
       };
-      const shouldClose =
-        event.nativeEvent.pointerType !== 'mouse' &&
-        !(event.ctrlKey || event.metaKey);
+      const shouldClose = false;
       onSelectEmoji(emojiSelection, shouldClose);
     },
     [


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

On cinnamon clicking (using a mouse) on an emoji sends a PointerEvent with pointerType `pen`, causing the emoji picker to close. Fixes #7269

This check for event modifier keys and pointerType seem to be carryovers from prior implementation of this callback, which handled a PressEvent. Any of the standard ClickEvent pointer types (`pen`, `mouse`, `touch`) should trigger the same behavior: selecting an emoji, and keeping the popover open. Even an empty-string or vendor-prefixed event should probably also share this behavior.

Manually tested by opening the emoji picker and selecting an emoji. Picker does not dismiss, accepts multiple emojis until dismissed.
Long-clicked on skin-tonable emoji to bring up skin tone popover. Clicking on skin tone popover also dismisses the emoji picker, which is consistent with the behavior before this change.
Emoji in message text line include gender and skin tone.

Tested on Ubuntu 24.04.2 LTS, running cinnamon/noble (6.0.4-4)