### PR TITLE
Filter out SMS conversations with no messages from the contact results

### DIFF
--- a/ts/state/ducks/search.ts
+++ b/ts/state/ducks/search.ts
@@ -46,6 +46,7 @@ import { removeDiacritics } from '../../util/removeDiacritics';
 import { createLogger } from '../../logging/log';
 import { searchConversationTitles } from '../../util/searchConversationTitles';
 import { isDirectConversation } from '../../util/whatTypeOfConversation';
+import { isConversationSMSOnly } from '../../util/isConversationSMSOnly';
 import {
   countConversationUnreadStats,
   hasUnread,
@@ -568,7 +569,11 @@ async function queryConversationsAndContacts(
   const normalizedQuery = removeDiacritics(query);
 
   const visibleConversations = allConversations.filter(conversation => {
-    const { activeAt, removalStage, isBlocked, messagesDeleted } = conversation;
+    const { activeAt, removalStage, isBlocked, hasMessages, messagesDeleted } = conversation;
+
+    if (isConversationSMSOnly(conversation) && !hasMessages) {
+      return false;
+    }
 
     if (isDirectConversation(conversation)) {
       // if a conversation has messages (i.e. is not "deleted"), always show it


### PR DESCRIPTION
Previously the Signal desktop app would include SMS-only contacts in its search results under the "Contacts" section.  These contacts are not exposed to the search results on Signal Android (creating a divergence in app behavior between platforms with a suboptimal user experience).

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This addresses https://github.com/signalapp/Signal-Desktop/issues/7434 and at least one other person's outstanding confusion on https://community.signalusers.org/ (... I can't find this right now).

I did manually testing on this change against:
- [X] contacts currently using Signal with and without message history
- [X] contacts previously using Signal with message history
- [X] contacts that never used Signal but have (SMS) message history
- [X] contacts that never used Signal and I have no message history with

This was tested on Fedora Linux 42. My node is slightly newer than the specified version number (v22.17.1); I do not believe this to be particularly relevant (there are two failing test regarding scrolling that failed prior to my change).

The change has the indented effect of filtering out empty conversations that clicking upon would result in the useless empty "this person isn't on Signal" chat screen. The search behavior now matches that on my Android device.