### PR TITLE
Enable text selection starting from emoji

### DIFF
--- a/stylesheets/components/fun/FunEmoji.scss
+++ b/stylesheets/components/fun/FunEmoji.scss
@@ -161,7 +161,12 @@ $inline-emoji-container-name: inline-emoji;
   margin-bottom: round(-0.4em + 1px, 1px);
   vertical-align: baseline;
   content-visibility: auto;
-  user-select: none;
+  // We want to inherit here since most usage of <Emojify> should not be
+  // selectable, but in cases like messages, conversation titles/descriptions,
+  // etc we want emoji to be selectable within the surrounding text.
+  // If the root `.FunInlineEmoji` element isn't selectable, then selection
+  // can't start on the emoji itself.
+  user-select: inherit;
 }
 
 .FunEmojiSelectionText {

--- a/ts/components/conversation/Emojify.tsx
+++ b/ts/components/conversation/Emojify.tsx
@@ -23,6 +23,7 @@ export type Props = {
   isInvisible?: boolean;
   /** Allows you to customize now non-newlines are rendered. Simplest is just a <span>. */
   renderNonEmoji?: RenderTextCallbackType;
+  selectable?: boolean;
 };
 
 const defaultRenderNonEmoji: RenderTextCallbackType = ({ text }) => text;
@@ -31,6 +32,7 @@ export function Emojify({
   fontSizeOverride,
   text,
   renderNonEmoji = defaultRenderNonEmoji,
+  selectable = false,
 }: Props): JSX.Element {
   const emojiLocalizer = useFunEmojiLocalizer();
   return (
@@ -59,6 +61,7 @@ export function Emojify({
               aria-label={emojiLocalizer.getLocaleShortName(variantKey)}
               emoji={variant}
               size={fontSizeOverride}
+              selectable={selectable}
             />
           );
         }

--- a/ts/components/conversation/MessageTextRenderer.tsx
+++ b/ts/components/conversation/MessageTextRenderer.tsx
@@ -431,6 +431,7 @@ function renderText({
       )}
       fontSizeOverride={jumboEmojiSize}
       text={text}
+      selectable
     />
   );
 }

--- a/ts/components/fun/FunEmoji.tsx
+++ b/ts/components/fun/FunEmoji.tsx
@@ -137,6 +137,7 @@ export type FunInlineEmojiProps = FunImageAriaProps &
   Readonly<{
     size?: number | null;
     emoji: EmojiVariantData;
+    selectable?: boolean;
   }>;
 
 export function FunInlineEmoji(props: FunInlineEmojiProps): JSX.Element {
@@ -183,6 +184,7 @@ export function FunInlineEmoji(props: FunInlineEmojiProps): JSX.Element {
               '--fun-emoji-sheet-x': props.emoji.sheetX,
               '--fun-emoji-sheet-y': props.emoji.sheetY,
               '--fun-emoji-jumbo-image': jumboImage,
+              ...(props.selectable && { userSelect: 'text' }),
             } as CSSProperties
           }
         />


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Previously, text selection in conversation history would fail if selection started on an emoji, as described in #7206. This change addresses the issue with a small CSS style addition.

Manual testing - sent messages containing emojis with two standalone profiles and reproduced. Tested on other occurrences of emojis across the app such as story reactions and Chats sidebar previews to ensure unintended selection isn't possible.

No new tests, ran on OSX Sequoia 15.6.1, no other devices tested.

Look forward to contributing more, thought I'd start with a quick fix to get the hang of things :) thanks for your work Signal team.