### PR TITLE
Fix #7513: Fix onBackspace handling of multiline messages with emojis or mentions

### DIFF
--- a/ts/components/CompositionInput.dom.tsx
+++ b/ts/components/CompositionInput.dom.tsx
@@ -548,7 +548,7 @@ export function CompositionInput(props: Props): React.ReactElement {
     let blotToDelete = leaf[0];
     const offset = leaf[1];
 
-    if (!blotToDelete) {
+    if (!blotToDelete || offset === 0) {
       return true;
     }
 


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

When onBackspace occurs with the cursor at the beginning of a later line in a multiline message, it now short-circuits out to the default backspace handler. This prevents bespoke handling of emoji and mention deletions to erroneously be executed as described in #7513.

Fixes #7513

### Testing Approach

Only manual testing was done on macOS 15.6.1 with a local `pnpm start`, filled with my production data.
- I tested the scenario described in #7513 and verified expected behavior (the second new line was backspaced instead)
- I tested an additional scenario with `Test 1\n Test 2\n@usernameMention` and also verified expected behavior (instead of an extra `@` sign being inserted after backspacing, no extra `@` was generated)
- I tested macOS option-delete and verified that nothing changed.

I tried writing an automated `test-electron` test for the CompositionInput component, but got stuck on getting the `quillRef` to simulate events to. I think writing an automated test would include a refactoring of the component to expose it, or I am not savvy enough to figure it out, so I only went with my manual testing.
