### PR TITLE
Stickers: allow replying with stickers by including quote; clear composer quote after send.

### DIFF
--- a/ts/models/conversations.ts
+++ b/ts/models/conversations.ts
@@ -3849,7 +3849,11 @@ export class ConversationModel {
     return getQuoteAttachment(attachments, preview, sticker);
   }
 
-  async sendStickerMessage(packId: string, stickerId: number): Promise<void> {
+  async sendStickerMessage(
+    packId: string,
+    stickerId: number,
+    quote?: QuotedMessageType
+  ): Promise<void> {
     const packData = Stickers.getStickerPack(packId);
     const stickerData = Stickers.getSticker(packId, stickerId);
     if (!stickerData || !packData) {
@@ -3905,6 +3909,7 @@ export class ConversationModel {
           body: undefined,
           attachments: [],
           sticker,
+          quote,
         },
         { dontClearDraft: true }
       )


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

🇨🇴 **Hello from Colombia!**

#### Summary

This PR adds support for sending stickers as replies when a quote is active in the composer. Previously, stickers were always sent as standalone messages, even when replying to a message.

#### What changed

- **[ts/models/conversations.ts](cci:7://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/models/conversations.ts:0:0-0:0)**
  - [sendStickerMessage(packId, stickerId, quote?)](cci:1://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/state/ducks/composer.ts:640:0-708:1) now accepts an optional `quote` parameter and passes it to [enqueueMessageForSend](cci:1://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/models/conversations.ts:4008:2-4231:3).
  
- **[ts/state/ducks/composer.ts](cci:7://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/state/ducks/composer.ts:0:0-0:0)**
  - The [sendStickerMessage](cci:1://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/state/ducks/composer.ts:640:0-708:1) thunk reads the active quote from the composer state, passes it when calling [conversation.sendStickerMessage(...)](cci:1://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/state/ducks/composer.ts:640:0-708:1), and clears the quote after sending (consistent with text/GIF behavior).

#### User experience

1. User taps "Reply" on a message
2. Opens the sticker picker
3. Sends a sticker
4. **Result**: The sticker is sent with the quote reference to the original message, and the composer's reply banner is cleared

#### Testing

**Manual testing:**
- Tested on macOS (development build)
- Verified that replying with a sticker includes the quote
- Verified that the composer quote is cleared after sending
- Verified that sending a sticker without a reply still works (no quote)

**Build:**
- `pnpm run generate`: ✅ Passed
- `pnpm test`: 2130 tests passing (1 unrelated performance test failure)
- `pnpm run ready`: Some local timeouts/performance warnings unrelated to this change. Full CI validation pending.

**No protocol or schema changes.**
**No new UI strings added.**

#### Screenshots/Demo

https://github.com/user-attachments/assets/61cb75f8-1730-4447-9764-6e66b3c6b19a


---

🇨🇴 **¡Saludos desde Colombia!**

#### Resumen

Este PR agrega soporte para enviar stickers como respuesta cuando hay una cita activa en el composer. Anteriormente, los stickers siempre se enviaban como mensajes independientes, incluso al responder a un mensaje.

#### Cambios realizados

- **[ts/models/conversations.ts](cci:7://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/models/conversations.ts:0:0-0:0)**
  - [sendStickerMessage(packId, stickerId, quote?)](cci:1://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/state/ducks/composer.ts:640:0-708:1) ahora acepta un parámetro opcional `quote` y lo pasa a [enqueueMessageForSend](cci:1://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/models/conversations.ts:4008:2-4231:3).
  
- **[ts/state/ducks/composer.ts](cci:7://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/state/ducks/composer.ts:0:0-0:0)**
  - El thunk [sendStickerMessage](cci:1://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/state/ducks/composer.ts:640:0-708:1) lee la cita activa del estado del composer, la pasa al llamar [conversation.sendStickerMessage(...)](cci:1://file:///Users/yieison/Desarrollo/Signal/Signal-Desktop/ts/state/ducks/composer.ts:640:0-708:1) y limpia la cita después de enviar (consistente con el comportamiento de texto/GIF).

#### Experiencia de usuario

1. Usuario toca "Reply" en un mensaje
2. Abre el selector de stickers
3. Envía un sticker
4. **Resultado**: El sticker se envía con la referencia de cita al mensaje original, y la barra de respuesta del composer se limpia

#### Pruebas

**Pruebas manuales:**
- Probado en macOS (build de desarrollo)
- Verificado que responder con sticker incluye la cita
- Verificado que la cita del composer se limpia tras el envío
- Verificado que enviar sticker sin respuesta sigue funcionando (sin cita)

**Build:**
- `pnpm run generate`: ✅ OK
- `pnpm test`: 2130 tests pasando (1 fallo de performance no relacionado)
- `pnpm run ready`: Algunos timeouts/warnings de performance locales no relacionados con este cambio. Validación completa pendiente en CI.

**Sin cambios de protocolo o esquema.**
**Sin nuevas cadenas de UI.**

#### Capturas/Demo

https://github.com/user-attachments/assets/61cb75f8-1730-4447-9764-6e66b3c6b19a