### PR TITLE
Fix duplicate word in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -21,7 +21,7 @@ body:
       label: "Using a supported version?"
       description: "Search issues here: https://github.com/signalapp/Signal-Desktop/issues"
       options:
-        - label: I have searched searched open and closed issues for duplicates.
+        - label: I have searched open and closed issues for duplicates.
           required: true
         - label: I am using Signal-Desktop as provided by the Signal team, not a 3rd-party package.
           required: true


### PR DESCRIPTION
<!--

Thanks for contributing to the project!

Please help us keep this project in good shape by going through this checklist.

Replace the empty checkboxes [ ] below with checked ones [X] as they are completed

Remember, you can preview this before saving it.

-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Noticed the bug report template had a typo - "I have searched searched" - fixed it by removing the duplicate word.

Tested by viewing the template file. This is a docs-only change.