### PR TITLE
improve content type to extension logic

### DIFF
--- a/ts/util/Attachment.std.ts
+++ b/ts/util/Attachment.std.ts
@@ -772,7 +772,7 @@ export const getFileExtension = (
     case 'audio/mpeg':
       return 'mp3';
     default:
-      return attachment.contentType.split('/')[1];
+      return attachment.contentType.split('/')[1].split(/[+;\s]/)[0];
   }
 };
 


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Some MIME types, like `image/svg+xml` include more data than just the file extension past the slash. This PR fixes the extension-picking logic so it won't try to name files things like `signal-xxxxxxxxxxxx.svg+xml`