### PR TITLE
Add time format preference with system, 12, and 24 options

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3188,6 +3188,22 @@
     "messageformat": "System",
     "description": "Label text for system theme"
   },
+  "icu:Preferences--time-format": {
+    "messageformat": "Time format",
+    "description": "Header for time format settings"
+  },
+  "icu:timeFormatSystem": {
+    "messageformat": "System",
+    "description": "Label text for system locale based time format"
+  },
+  "icu:timeFormat12Hour": {
+    "messageformat": "12-hour",
+    "description": "Label text for 12-hour time format"
+  },
+  "icu:timeFormat24Hour": {
+    "messageformat": "24-hour",
+    "description": "Label text for 24-hour time format"
+  },
   "icu:noteToSelf": {
     "messageformat": "Note to Self",
     "description": "Name for the conversation with your own phone number"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -3216,6 +3216,22 @@
     "messageformat": "System",
     "description": "Label text for system theme"
   },
+  "icu:Preferences--time-format": {
+    "messageformat": "Time format",
+    "description": "Header for time format settings"
+  },
+  "icu:timeFormatSystem": {
+    "messageformat": "System",
+    "description": "Label text for system locale based time format"
+  },
+  "icu:timeFormat12Hour": {
+    "messageformat": "12-hour",
+    "description": "Label text for 12-hour time format"
+  },
+  "icu:timeFormat24Hour": {
+    "messageformat": "24-hour",
+    "description": "Label text for 24-hour time format"
+  },
   "icu:noteToSelf": {
     "messageformat": "Note to Self",
     "description": "Name for the conversation with your own phone number"

--- a/app/main.main.ts
+++ b/app/main.main.ts
@@ -360,6 +360,21 @@ async function getResolvedThemeSetting(
   return ThemeType[theme];
 }
 
+type HourCycleSettingType = 'system' | '12' | '24';
+
+async function getHourCycleSetting(): Promise<HourCycleSettingType> {
+  const value = ephemeralConfig.get('hour-cycle-preference');
+  if (value === '12' || value === '24' || value === 'system') {
+    log.info('got fast hour-cycle-preference value', value);
+    return value;
+  }
+
+  // Default to 'system' if setting doesn't exist or is invalid
+  ephemeralConfig.set('hour-cycle-preference', 'system');
+  log.info('initializing hour-cycle-preference setting', 'system');
+  return 'system';
+}
+
 type GetBackgroundColorOptionsType = GetThemeSettingOptionsType &
   Readonly<{
     signalColors?: boolean;
@@ -470,16 +485,28 @@ function getResolvedMessagesLocale(): LocaleType {
   return resolvedTranslationsLocale;
 }
 
-function getHourCyclePreference(): HourCyclePreference {
-  if (process.platform !== 'darwin') {
-    return HourCyclePreference.UnknownPreference;
-  }
-  if (systemPreferences.getUserDefault('AppleICUForce24HourTime', 'boolean')) {
-    return HourCyclePreference.Prefer24;
-  }
-  if (systemPreferences.getUserDefault('AppleICUForce12HourTime', 'boolean')) {
+async function getHourCyclePreference(): Promise<HourCyclePreference> {
+  const userSetting = await getHourCycleSetting();
+  if (userSetting === '12') {
     return HourCyclePreference.Prefer12;
   }
+  if (userSetting === '24') {
+    return HourCyclePreference.Prefer24;
+  }
+
+  if (OS.isMacOS()) {
+    if (
+      systemPreferences.getUserDefault('AppleICUForce24HourTime', 'boolean')
+    ) {
+      return HourCyclePreference.Prefer24;
+    }
+    if (
+      systemPreferences.getUserDefault('AppleICUForce12HourTime', 'boolean')
+    ) {
+      return HourCyclePreference.Prefer12;
+    }
+  }
+
   return HourCyclePreference.UnknownPreference;
 }
 
@@ -2108,7 +2135,7 @@ app.on('ready', async () => {
 
     localeOverride = await getLocaleOverrideSetting();
 
-    const hourCyclePreference = getHourCyclePreference();
+    const hourCyclePreference = await getHourCyclePreference();
     log.info(`app.ready: hour cycle preference: ${hourCyclePreference}`);
 
     log.info('app.ready: preferred system locales:', preferredSystemLocales);

--- a/app/main.main.ts
+++ b/app/main.main.ts
@@ -362,6 +362,21 @@ async function getResolvedThemeSetting(
   return ThemeType[theme];
 }
 
+type HourCycleSettingType = 'system' | '12' | '24';
+
+function getHourCycleSetting(): HourCycleSettingType {
+  const value = ephemeralConfig.get('hour-cycle-preference');
+  if (value === '12' || value === '24' || value === 'system') {
+    log.info('got fast hour-cycle-preference value', value);
+    return value;
+  }
+
+  // Default to 'system' if setting doesn't exist or is invalid
+  ephemeralConfig.set('hour-cycle-preference', 'system');
+  log.info('initializing hour-cycle-preference setting', 'system');
+  return 'system';
+}
+
 type GetBackgroundColorOptionsType = GetThemeSettingOptionsType &
   Readonly<{
     signalColors?: boolean;
@@ -473,15 +488,27 @@ function getResolvedMessagesLocale(): LocaleType {
 }
 
 function getHourCyclePreference(): HourCyclePreference {
-  if (process.platform !== 'darwin') {
-    return HourCyclePreference.UnknownPreference;
-  }
-  if (systemPreferences.getUserDefault('AppleICUForce24HourTime', 'boolean')) {
-    return HourCyclePreference.Prefer24;
-  }
-  if (systemPreferences.getUserDefault('AppleICUForce12HourTime', 'boolean')) {
+  const userSetting = getHourCycleSetting();
+  if (userSetting === '12') {
     return HourCyclePreference.Prefer12;
   }
+  if (userSetting === '24') {
+    return HourCyclePreference.Prefer24;
+  }
+
+  if (OS.isMacOS()) {
+    if (
+      systemPreferences.getUserDefault('AppleICUForce24HourTime', 'boolean')
+    ) {
+      return HourCyclePreference.Prefer24;
+    }
+    if (
+      systemPreferences.getUserDefault('AppleICUForce12HourTime', 'boolean')
+    ) {
+      return HourCyclePreference.Prefer12;
+    }
+  }
+
   return HourCyclePreference.UnknownPreference;
 }
 

--- a/ts/components/Preferences.dom.stories.tsx
+++ b/ts/components/Preferences.dom.stories.tsx
@@ -503,6 +503,7 @@ export default {
     sentMediaQualitySetting: 'standard',
     shouldShowUpdateDialog: false,
     themeSetting: 'system',
+    hourCyclePreference: 'system',
     theme: ThemeType.light,
     universalExpireTimer: DurationInSeconds.HOUR,
     whoCanFindMe: PhoneNumberDiscoverability.Discoverable,
@@ -602,6 +603,7 @@ export default {
     onStartUpdate: action('onStartUpdate'),
     onTextFormattingChange: action('onTextFormattingChange'),
     onThemeChange: action('onThemeChange'),
+    onHourCycleChange: action('onHourCycleChange'),
     onToggleNavTabsCollapse: action('onToggleNavTabsCollapse'),
     onTypingIndicatorsChange: action('onTypingIndicatorsChange'),
     onUniversalExpireTimerChange: action('onUniversalExpireTimerChange'),
@@ -701,6 +703,16 @@ General.args = {
 export const Appearance = Template.bind({});
 Appearance.args = {
   settingsLocation: { page: SettingsPage.Appearance },
+};
+export const Appearance12HourFormat = Template.bind({});
+Appearance12HourFormat.args = {
+  settingsLocation: { page: SettingsPage.Appearance },
+  hourCyclePreference: '12',
+};
+export const Appearance24HourFormat = Template.bind({});
+Appearance24HourFormat.args = {
+  settingsLocation: { page: SettingsPage.Appearance },
+  hourCyclePreference: '24',
 };
 export const Chats = Template.bind({});
 Chats.args = {

--- a/ts/components/Preferences.dom.stories.tsx
+++ b/ts/components/Preferences.dom.stories.tsx
@@ -503,6 +503,7 @@ export default {
     sentMediaQualitySetting: 'standard',
     shouldShowUpdateDialog: false,
     themeSetting: 'system',
+    hourCyclePreference: 'system',
     theme: ThemeType.light,
     universalExpireTimer: DurationInSeconds.HOUR,
     weArePrimaryDevice: false,
@@ -604,6 +605,7 @@ export default {
     onStartUpdate: action('onStartUpdate'),
     onTextFormattingChange: action('onTextFormattingChange'),
     onThemeChange: action('onThemeChange'),
+    onHourCycleChange: action('onHourCycleChange'),
     onToggleNavTabsCollapse: action('onToggleNavTabsCollapse'),
     onTypingIndicatorsChange: action('onTypingIndicatorsChange'),
     onUniversalExpireTimerChange: action('onUniversalExpireTimerChange'),
@@ -703,6 +705,16 @@ General.args = {
 export const Appearance = Template.bind({});
 Appearance.args = {
   settingsLocation: { page: SettingsPage.Appearance },
+};
+export const Appearance12HourFormat = Template.bind({});
+Appearance12HourFormat.args = {
+  settingsLocation: { page: SettingsPage.Appearance },
+  hourCyclePreference: '12',
+};
+export const Appearance24HourFormat = Template.bind({});
+Appearance24HourFormat.args = {
+  settingsLocation: { page: SettingsPage.Appearance },
+  hourCyclePreference: '24',
 };
 export const Chats = Template.bind({});
 Chats.args = {

--- a/ts/components/Preferences.dom.tsx
+++ b/ts/components/Preferences.dom.tsx
@@ -79,6 +79,7 @@ import type {
   SentMediaQualityType,
   ThemeType,
 } from '../types/Util.std.ts';
+import type { HourCycleSettingType } from '../util/preload.preload.ts';
 import type {
   BackupMediaDownloadStatusType,
   BackupsSubscriptionType,
@@ -172,6 +173,7 @@ export type PropsDataType = {
   selectedSpeaker?: AudioDevice;
   sentMediaQualitySetting: SentMediaQualitySettingType;
   themeSetting: ThemeSettingType | undefined;
+  hourCyclePreference: HourCycleSettingType | undefined;
   universalExpireTimer: DurationInSeconds;
   whoCanFindMe: PhoneNumberDiscoverability;
   whoCanSeeMe: PhoneNumberSharingMode;
@@ -350,6 +352,7 @@ type PropsFunctionType = {
   onSpellCheckChange: CheckboxChangeHandlerType;
   onTextFormattingChange: CheckboxChangeHandlerType;
   onThemeChange: SelectChangeHandlerType<ThemeType>;
+  onHourCycleChange: SelectChangeHandlerType<HourCycleSettingType>;
   onToggleNavTabsCollapse: (navTabsCollapsed: boolean) => void;
   onTypingIndicatorsChange: CheckboxChangeHandlerType;
   onUniversalExpireTimerChange: SelectChangeHandlerType<number>;
@@ -529,6 +532,7 @@ export function Preferences({
   onSpellCheckChange,
   onTextFormattingChange,
   onThemeChange,
+  onHourCycleChange,
   onToggleNavTabsCollapse,
   onTypingIndicatorsChange,
   onUniversalExpireTimerChange,
@@ -574,6 +578,7 @@ export function Preferences({
   localeOverride,
   theme,
   themeSetting,
+  hourCyclePreference,
   universalExpireTimer,
   validateBackup,
   whoCanFindMe,
@@ -605,6 +610,7 @@ export function Preferences({
 }: PropsType): React.JSX.Element {
   const storiesId = useId();
   const themeSelectId = useId();
+  const hourCycleSelectId = useId();
   const zoomSelectId = useId();
   const languageId = useId();
 
@@ -1093,6 +1099,36 @@ export function Preferences({
             {i18n('icu:Preferences__LanguageModal__Restart__Description')}
           </ConfirmationDialog>
         )}
+        <Control
+          icon
+          left={
+            <label htmlFor={hourCycleSelectId}>
+              {i18n('icu:Preferences--time-format')}
+            </label>
+          }
+          right={
+            <Select
+              id={hourCycleSelectId}
+              disabled={hourCyclePreference === undefined}
+              onChange={onHourCycleChange}
+              options={[
+                {
+                  text: i18n('icu:timeFormatSystem'),
+                  value: 'system',
+                },
+                {
+                  text: i18n('icu:timeFormat12Hour'),
+                  value: '12',
+                },
+                {
+                  text: i18n('icu:timeFormat24Hour'),
+                  value: '24',
+                },
+              ]}
+              value={hourCyclePreference}
+            />
+          }
+        />
         <Control
           icon
           left={

--- a/ts/components/Preferences.dom.tsx
+++ b/ts/components/Preferences.dom.tsx
@@ -75,6 +75,7 @@ import type {
   SentMediaQualityType,
   ThemeType,
 } from '../types/Util.std.ts';
+import type { HourCycleSettingType } from '../util/preload.preload.ts';
 import type {
   BackupMediaDownloadStatusType,
   BackupsSubscriptionType,
@@ -172,6 +173,7 @@ export type PropsDataType = {
   selectedSpeaker?: AudioDevice;
   sentMediaQualitySetting: SentMediaQualitySettingType;
   themeSetting: ThemeSettingType | undefined;
+  hourCyclePreference: HourCycleSettingType | undefined;
   universalExpireTimer: DurationInSeconds;
   whoCanFindMe: PhoneNumberDiscoverability;
   whoCanSeeMe: PhoneNumberSharingMode;
@@ -351,6 +353,7 @@ type PropsFunctionType = {
   onSpellCheckChange: CheckboxChangeHandlerType;
   onTextFormattingChange: CheckboxChangeHandlerType;
   onThemeChange: SelectChangeHandlerType<ThemeType>;
+  onHourCycleChange: SelectChangeHandlerType<HourCycleSettingType>;
   onToggleNavTabsCollapse: (navTabsCollapsed: boolean) => void;
   onTypingIndicatorsChange: CheckboxChangeHandlerType;
   onUniversalExpireTimerChange: SelectChangeHandlerType<number>;
@@ -531,6 +534,7 @@ export function Preferences({
   onSpellCheckChange,
   onTextFormattingChange,
   onThemeChange,
+  onHourCycleChange,
   onToggleNavTabsCollapse,
   onTypingIndicatorsChange,
   onUniversalExpireTimerChange,
@@ -576,6 +580,7 @@ export function Preferences({
   localeOverride,
   theme,
   themeSetting,
+  hourCyclePreference,
   universalExpireTimer,
   validateBackup,
   whoCanFindMe,
@@ -608,6 +613,7 @@ export function Preferences({
 }: PropsType): JSX.Element {
   const storiesId = useId();
   const themeSelectId = useId();
+  const hourCycleSelectId = useId();
   const zoomSelectId = useId();
   const languageId = useId();
 
@@ -1095,6 +1101,38 @@ export function Preferences({
             </AxoConfirmDialog.Action>
           </AxoConfirmDialog.Root>
         )}
+        <Control
+          icon
+          left={
+            <label htmlFor={hourCycleSelectId}>
+              {i18n('icu:Preferences--time-format')}
+            </label>
+          }
+          right={
+            <Select
+              id={hourCycleSelectId}
+              disabled={hourCyclePreference === undefined}
+              onChange={value => {
+                onHourCycleChange(value as HourCycleSettingType);
+              }}
+              options={[
+                {
+                  text: i18n('icu:timeFormatSystem'),
+                  value: 'system',
+                },
+                {
+                  text: i18n('icu:timeFormat12Hour'),
+                  value: '12',
+                },
+                {
+                  text: i18n('icu:timeFormat24Hour'),
+                  value: '24',
+                },
+              ]}
+              value={hourCyclePreference}
+            />
+          }
+        />
         <Control
           icon
           left={

--- a/ts/main/settingsChannel.main.ts
+++ b/ts/main/settingsChannel.main.ts
@@ -21,6 +21,7 @@ const EPHEMERAL_NAME_MAP = new Map([
   ['themeSetting', 'theme-setting'],
   ['localeOverride', 'localeOverride'],
   ['contentProtection', 'contentProtection'],
+  ['hourCyclePreference', 'hour-cycle-preference'],
 ]);
 
 export class SettingsChannel extends EventEmitter {
@@ -49,6 +50,7 @@ export class SettingsChannel extends EventEmitter {
     this.#installEphemeralSetting('localeOverride');
     this.#installEphemeralSetting('spellCheck');
     this.#installEphemeralSetting('contentProtection');
+    this.#installEphemeralSetting('hourCyclePreference');
 
     installPermissionsHandler({ session: session.defaultSession, userConfig });
 

--- a/ts/state/smart/Preferences.preload.tsx
+++ b/ts/state/smart/Preferences.preload.tsx
@@ -102,7 +102,10 @@ import {
 
 import type { SettingsLocation } from '../../types/Nav.std.ts';
 import type { StorageAccessType } from '../../types/Storage.d.ts';
-import type { ThemeType } from '../../util/preload.preload.ts';
+import type {
+  ThemeType,
+  HourCycleSettingType,
+} from '../../util/preload.preload.ts';
 import type { WidthBreakpoint } from '../../components/_util.std.ts';
 import { DialogType } from '../../types/Dialogs.std.ts';
 import { promptOSAuth } from '../../util/promptOSAuth.preload.ts';
@@ -403,6 +406,8 @@ export function SmartPreferences(): React.JSX.Element | null {
     React.useState<boolean>();
   const [hasSpellCheck, setSpellCheck] = React.useState<boolean>();
   const [themeSetting, setThemeSetting] = React.useState<ThemeType>();
+  const [hourCyclePreference, setHourCyclePreference] =
+    React.useState<HourCycleSettingType>();
 
   useEffect(() => {
     let canceled = false;
@@ -449,6 +454,15 @@ export function SmartPreferences(): React.JSX.Element | null {
     };
     drop(loadThemeSetting());
 
+    const loadHourCyclePreference = async () => {
+      const value = await window.Events.getHourCyclePreference();
+      if (canceled) {
+        return;
+      }
+      setHourCyclePreference(value);
+    };
+    drop(loadHourCyclePreference());
+
     return () => {
       canceled = true;
     };
@@ -488,6 +502,10 @@ export function SmartPreferences(): React.JSX.Element | null {
     setThemeSetting(value);
     drop(window.Events.setThemeSetting(value));
     drop(themeChanged());
+  };
+  const onHourCycleChange = (value: HourCycleSettingType) => {
+    setHourCyclePreference(value);
+    drop(window.Events.setHourCyclePreference(value));
   };
 
   // Async IPC for electron configuration, all can be modified
@@ -1012,6 +1030,7 @@ export function SmartPreferences(): React.JSX.Element | null {
           onSpellCheckChange={onSpellCheckChange}
           onTextFormattingChange={onTextFormattingChange}
           onThemeChange={onThemeChange}
+          onHourCycleChange={onHourCycleChange}
           onToggleNavTabsCollapse={toggleNavTabsCollapse}
           onTypingIndicatorsChange={onTypingIndicatorsChange}
           onUniversalExpireTimerChange={onUniversalExpireTimerChange}
@@ -1062,6 +1081,7 @@ export function SmartPreferences(): React.JSX.Element | null {
           startPlaintextExport={startPlaintextExport}
           theme={theme}
           themeSetting={themeSetting}
+          hourCyclePreference={hourCyclePreference}
           universalExpireTimer={universalExpireTimer}
           validateBackup={validateBackup}
           whoCanFindMe={whoCanFindMe}

--- a/ts/state/smart/Preferences.preload.tsx
+++ b/ts/state/smart/Preferences.preload.tsx
@@ -102,7 +102,10 @@ import {
 
 import type { SettingsLocation } from '../../types/Nav.std.ts';
 import type { StorageAccessType } from '../../types/Storage.d.ts';
-import type { ThemeType } from '../../util/preload.preload.ts';
+import type {
+  ThemeType,
+  HourCycleSettingType,
+} from '../../util/preload.preload.ts';
 import type { WidthBreakpoint } from '../../components/_util.std.ts';
 import { DialogType } from '../../types/Dialogs.std.ts';
 import { promptOSAuth } from '../../util/promptOSAuth.preload.ts';
@@ -405,6 +408,8 @@ export function SmartPreferences(): JSX.Element | null {
   const [hasContentProtection, setContentProtection] = useState<boolean>();
   const [hasSpellCheck, setSpellCheck] = useState<boolean>();
   const [themeSetting, setThemeSetting] = useState<ThemeType>();
+  const [hourCyclePreference, setHourCyclePreference] =
+    useState<HourCycleSettingType>();
 
   useEffect(() => {
     let canceled = false;
@@ -451,6 +456,15 @@ export function SmartPreferences(): JSX.Element | null {
     };
     drop(loadThemeSetting());
 
+    const loadHourCyclePreference = async () => {
+      const value = await window.Events.getHourCyclePreference();
+      if (canceled) {
+        return;
+      }
+      setHourCyclePreference(value);
+    };
+    drop(loadHourCyclePreference());
+
     return () => {
       canceled = true;
     };
@@ -490,6 +504,10 @@ export function SmartPreferences(): JSX.Element | null {
     setThemeSetting(value);
     drop(window.Events.setThemeSetting(value));
     drop(themeChanged());
+  };
+  const onHourCycleChange = (value: HourCycleSettingType) => {
+    setHourCyclePreference(value);
+    drop(window.Events.setHourCyclePreference(value));
   };
 
   // Async IPC for electron configuration, all can be modified
@@ -1028,6 +1046,7 @@ export function SmartPreferences(): JSX.Element | null {
         onSpellCheckChange={onSpellCheckChange}
         onTextFormattingChange={onTextFormattingChange}
         onThemeChange={onThemeChange}
+        onHourCycleChange={onHourCycleChange}
         onToggleNavTabsCollapse={toggleNavTabsCollapse}
         onTypingIndicatorsChange={onTypingIndicatorsChange}
         onUniversalExpireTimerChange={onUniversalExpireTimerChange}
@@ -1078,6 +1097,7 @@ export function SmartPreferences(): JSX.Element | null {
         startPlaintextExport={startPlaintextExport}
         theme={theme}
         themeSetting={themeSetting}
+        hourCyclePreference={hourCyclePreference}
         universalExpireTimer={universalExpireTimer}
         validateBackup={validateBackup}
         whoCanFindMe={whoCanFindMe}

--- a/ts/test-node/util/hourCyclePreference_test.std.ts
+++ b/ts/test-node/util/hourCyclePreference_test.std.ts
@@ -1,0 +1,29 @@
+// Copyright 2025 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+import { HourCyclePreference } from '../../types/I18N.std.ts';
+
+describe('HourCyclePreference', () => {
+  describe('enum values', () => {
+    it('should have Prefer24 value', () => {
+      assert.equal(HourCyclePreference.Prefer24, 'Prefer24');
+    });
+
+    it('should have Prefer12 value', () => {
+      assert.equal(HourCyclePreference.Prefer12, 'Prefer12');
+    });
+
+    it('should have UnknownPreference value', () => {
+      assert.equal(HourCyclePreference.UnknownPreference, 'UnknownPreference');
+    });
+
+    it('should only contain three values', () => {
+      const values = Object.values(HourCyclePreference);
+      assert.lengthOf(values, 3);
+      assert.include(values, HourCyclePreference.Prefer24);
+      assert.include(values, HourCyclePreference.Prefer12);
+      assert.include(values, HourCyclePreference.UnknownPreference);
+    });
+  });
+});

--- a/ts/test-node/util/hourCycleSetting_test.std.ts
+++ b/ts/test-node/util/hourCycleSetting_test.std.ts
@@ -1,0 +1,24 @@
+// Copyright 2025 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+import type { HourCycleSettingType } from '../../util/preload.preload.ts';
+
+describe('HourCycleSettingType', () => {
+  describe('valid setting values', () => {
+    it('should accept "system" as a valid setting', () => {
+      const setting: HourCycleSettingType = 'system';
+      assert.equal(setting, 'system');
+    });
+
+    it('should accept "12" as a valid setting', () => {
+      const setting: HourCycleSettingType = '12';
+      assert.equal(setting, '12');
+    });
+
+    it('should accept "24" as a valid setting', () => {
+      const setting: HourCycleSettingType = '24';
+      assert.equal(setting, '24');
+    });
+  });
+});

--- a/ts/util/createIPCEvents.preload.ts
+++ b/ts/util/createIPCEvents.preload.ts
@@ -30,6 +30,7 @@ import { fromWebSafeBase64 } from './webSafeBase64.std.ts';
 import { showConfirmationDialog } from './showConfirmationDialog.dom.tsx';
 import type {
   EphemeralSettings,
+  HourCycleSettingType,
   SettingsValuesType,
   ThemeType,
 } from './preload.preload.ts';
@@ -92,6 +93,7 @@ type ValuesWithGetters = Omit<
   | 'contentProtection'
   | 'systemTraySetting'
   | 'themeSetting'
+  | 'hourCyclePreference'
   | 'zoomFactor'
 >;
 
@@ -126,6 +128,7 @@ export type IPCEventsGettersType = {
   getContentProtection: () => Promise<boolean>;
   getSystemTraySetting: () => Promise<SystemTraySetting>;
   getThemeSetting: () => Promise<ThemeType>;
+  getHourCyclePreference: () => Promise<HourCycleSettingType>;
   getZoomFactor: () => Promise<ZoomFactorType>;
   // Events
   onZoomFactorChange: (callback: ZoomFactorChangeCallback) => void;
@@ -235,6 +238,13 @@ export function createIPCEvents(
     },
     setThemeSetting: async (value: ThemeType) => {
       await setEphemeralSetting('themeSetting', value);
+    },
+    getHourCyclePreference: async () => {
+      return (await getEphemeralSetting('hourCyclePreference')) ?? 'system';
+    },
+    setHourCyclePreference: async (value: HourCycleSettingType) => {
+      await setEphemeralSetting('hourCyclePreference', value);
+      window.SignalContext.restartApp();
     },
 
     // From IPCEventsCallbacksType

--- a/ts/util/preload.preload.ts
+++ b/ts/util/preload.preload.ts
@@ -20,12 +20,15 @@ export type SettingType<Value> = Readonly<{
 
 export type ThemeType = 'light' | 'dark' | 'system';
 
+export type HourCycleSettingType = 'system' | '12' | '24';
+
 export type EphemeralSettings = {
   localeOverride: string | null;
   spellCheck: boolean;
   contentProtection: boolean;
   systemTraySetting: SystemTraySetting;
   themeSetting: ThemeType;
+  hourCyclePreference: HourCycleSettingType;
 };
 
 export type SettingsValuesType = IPCEventsValuesType & EphemeralSettings;

--- a/ts/windows/preload.preload.ts
+++ b/ts/windows/preload.preload.ts
@@ -8,3 +8,4 @@ installEphemeralSetting('localeOverride');
 installEphemeralSetting('spellCheck');
 installEphemeralSetting('systemTraySetting');
 installEphemeralSetting('themeSetting');
+installEphemeralSetting('hourCyclePreference');


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users - Cannot say yes until I've seen the preference in a local build.

### Description

This pull request aims to add a `Time format` preference with `system`, `12`, and `24` options so that users can either leave it up to their locale to specify the time format (`system`) or manually select either `12` or `24` themselves. The preference should appears directly below `Language` and above `Theme`.

<img width="500" height="533" alt="Screenshot From 2025-11-24 18-13-37" src="https://github.com/user-attachments/assets/1ddb1f5f-29f8-4703-9a9c-4ea3381eb61c" />

As for the implementation, the one thing that is currently bothering me a bit is the existence of both `HourCyclePreference` and `HourCycleSetting`. Unfortunately as the former is already in use for the original 24 hour macOS support implementation, shown below, we cannot settle on just one without refactoring the existing code. :thinking:

https://github.com/signalapp/Signal-Desktop/blob/90c0fc7da9236db9498e81e4fd604b2808a71da1/ts/types/I18N.std.ts#L37-L41

Sort of a follow up to https://github.com/signalapp/Signal-Desktop/commit/1143c0e9ba13293b3478742f3f4f95e7f3bbee51, which added 24 hour time format for macOS.

Resolves https://github.com/signalapp/Signal-Desktop/issues/4079 (exactly)
Resolves https://github.com/signalapp/Signal-Desktop/issues/4252 (sort of, not exactly)

### Testing

I added test coverage for this new preference. Additionally I tried running the app locally on my Fedora Workstation 43 (GNOME 49) system but unfortunately I'm seeing some GTK error with the local build. Not sure if that's due to an issue on my end or not.

https://github.com/user-attachments/assets/909d2a9b-bc27-479f-8dec-9fe8be8d88d6