### PR TITLE
Fix crash when switching to some chats with old attachments

### DIFF
--- a/ts/util/getLocalAttachmentUrl.std.ts
+++ b/ts/util/getLocalAttachmentUrl.std.ts
@@ -5,6 +5,7 @@ import lodash from 'lodash';
 import { strictAssert } from './assert.std.js';
 
 import type { AttachmentType } from '../types/Attachment.std.js';
+import { consoleLogger } from './consoleLogger.std.js';
 
 const { isNumber } = lodash;
 
@@ -83,9 +84,9 @@ export function getLocalAttachmentUrl(
 
   if (disposition === AttachmentDisposition.Download) {
     if (!attachment.key) {
-      throw new Error('getLocalAttachmentUrl: Missing attachment key!');
+      consoleLogger.error('getLocalAttachmentUrl: Missing attachment key!');
     }
-    url.searchParams.set('key', attachment.key);
+    url.searchParams.set('key', attachment.key || '');
 
     if (!attachment.digest) {
       throw new Error('getLocalAttachmentUrl: Missing attachment digest!');


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
When switching to older chats with old attachments, the `attachment.key` field is sometimes undefined, causing `getLocalAttachmentUrl` to throw an error, which in turn makes the entire app blank, forcing the user to fully quit and re-open Signal, essentially bricking the chat on desktop. With this patch, the user is able to open the chat and download the attachments, which sets the attachment key and makes this problem go away completely.

The app going blank after switching to a chat with this issue:
<img width="1311" height="796" alt="image" src="https://github.com/user-attachments/assets/cbf6748f-b3bd-405d-a350-0428f1e3fcb4" />

This problem was observed on `Linux rawrch 6.18.2-zen2-1-zen #1 ZEN SMP PREEMPT_DYNAMIC Thu, 18 Dec 2025 18:00:58 +0000 x86_64 GNU/Linux` on the latest Signal Desktop app.

Not sure if i should've filed this as an issue before, but considering the simplicity of the fix i decided to just fix it myself. It is kind of a bandaid fix, but i wasn't able to find any further problems with it.