### PR TITLE
Fix typos and inconsistencies in documentation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@ Remember, you can preview this before saving it.
 ### First time contributor checklist:
 
 - [ ] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
-- [ ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)
+- [ ] I have signed the [Contributor License Agreement](https://signal.org/cla/)
 
 ### Contributor checklist:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ easily reviewed changes with clear and specific intentions. See below for more
 [guidelines on pull requests](#pull-requests).
 
 It's a good idea to gauge interest in your intended work by finding the current issue
-for it or creating a new one yourself. You can use also that issue as a place to signal
+for it or creating a new one yourself. You can also use that issue as a place to signal
 your intentions and get feedback from the users most likely to appreciate your changes.
 
 Once you've spent a little bit of time planning your solution, you can go
@@ -78,9 +78,9 @@ pnpm run dev:styles    # recompiles when you change .scss files
 
 #### Known issues
 
-##### `yarn install` prints error 'Could not detect abi for version 30.0.6 and runtime electron'
+##### `pnpm install` prints error 'Could not detect abi for version 30.0.6 and runtime electron'
 
-`yarn install` may print an error like the following, but it can be ignored because the overall operation succeeds.
+`pnpm install` may print an error like the following, but it can be ignored because the overall operation succeeds.
 
 ```
 $ ./node_modules/.bin/electron-builder install-app-deps
@@ -303,7 +303,7 @@ pnpm run build
 
 Then, run the tests using `pnpm run test-release`.
 
-### Testing MacOS builds
+### Testing macOS builds
 
 macOS requires apps to be code signed with an Apple certificate. To test development builds
 you can ad-hoc sign the packaged app which will let you run it locally.

--- a/packages/mute-state-change/dist/acknowledgments.md
+++ b/packages/mute-state-change/dist/acknowledgments.md
@@ -1,6 +1,6 @@
 # Acknowledgments
 
-muted-state-change makes use of the following open source projects.
+mute-state-change makes use of the following open source projects.
 
 ## bindings
 

--- a/reproducible-builds/README.md
+++ b/reproducible-builds/README.md
@@ -19,7 +19,7 @@ Reproducible builds for macOS and Windows are not available yet.
 
 > [!IMPORTANT]
 > We are in the process of rolling out and verifying reproducible builds. As such, reproducibility is still
-> experimental and may not work on public releases yet. If you notice any inconsistencies then please file an issue [on the Github Issues page](https://github.com/signalapp/Signal-Desktop/issues). Thanks for your patience while we set it up!
+> experimental and may not work on public releases yet. If you notice any inconsistencies then please file an issue [on the GitHub Issues page](https://github.com/signalapp/Signal-Desktop/issues). Thanks for your patience while we set it up!
 
 ### Pre-requisites
 
@@ -89,7 +89,7 @@ This will automatically download the `.deb` package into the shell's working dir
 
 #### Comparing your build against the official build
 
-To verify the official `.deb` package against your build, make sure that your version is the same as the official version, and use `sha256sum` on both files to calculate the SHA-256 digest. Then compare/verify the output and verify that they match.
+To verify the official `.deb` package against your build, make sure that your version is the same as the official version, and use `sha256sum` on both files to calculate the SHA-256 digest. Then compare the output and verify that they match.
 
 If the checksums from the official build and your own build match, then the two builds are exactly the same, and you have successfully reproduced Signal Desktop!
 
@@ -111,4 +111,4 @@ $ sha256sum ../release/signal-desktop_7.45.0_amd64-OUR_BUILD.deb signal-desktop_
 - Double check you have followed the instructions correctly and are comparing the right versions.
 - Are you working from a previous checkout of Signal-Desktop? Some generated files might be inadvertently included in the build. Try to delete them before building:
   - `rm -rf bundles`
-- File an issue [on the Github Issues page](https://github.com/signalapp/Signal-Desktop/issues).
+- File an issue [on the GitHub Issues page](https://github.com/signalapp/Signal-Desktop/issues).


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor License Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fix typos, grammar errors, and inconsistencies across documentation files:

**CONTRIBUTING.md:**
- Fix misplaced adverb: "can use also" → "can also use"
- Update outdated `yarn install` references to `pnpm install` (consistent with rest of file)
- Fix "MacOS" → "macOS" to match Apple's official branding (already correct elsewhere in the file)

**.github/PULL_REQUEST_TEMPLATE.md:**
- Fix British spelling "Licence" → "License" to match the linked [signal.org/cla](https://signal.org/cla/) page

**packages/mute-state-change/dist/acknowledgments.md:**
- Fix incorrect package name "muted-state-change" → "mute-state-change"

**reproducible-builds/README.md:**
- Fix "Github" → "GitHub" (2 occurrences)
- Remove redundant "verify" in "compare/verify the output and verify that they match"

**Testing:** Documentation-only changes — no code, no tests needed.