### PR TITLE
fix: don't ask to become the default client if we already are

### DIFF
--- a/app/main.main.ts
+++ b/app/main.main.ts
@@ -2639,8 +2639,18 @@ app.on(
   }
 );
 
-app.setAsDefaultProtocolClient('sgnl');
-app.setAsDefaultProtocolClient('signalcaptcha');
+if (!app.isDefaultProtocolClient('sgnl')) {
+  log.info('setting signal as the default app for the sgnl url scheme')
+  app.setAsDefaultProtocolClient('sgnl');
+} else {
+  log.info('signal is already registered as the default app for the sgnl url scheme.');
+}
+if (!app.isDefaultProtocolClient('signalcaptcha')) {
+  log.info('setting signal as the default app for the signalcaptcha url scheme')
+  app.setAsDefaultProtocolClient('signalcaptcha');
+} else {
+  log.info('signal is already registered as the default app for the sgnl url scheme.');
+}
 
 ipc.on(
   'set-badge',


### PR DESCRIPTION
Fixes https://github.com/signalapp/Signal-Desktop/issues/7736

<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Instead of always requesting to be the default app for the `sgnl` and `signalcaptcha` url schemes, this change makes Signal only do so if it's not already the default.