### PR TITLE
Fix folder sync for contacts without a public phone number

### DIFF
--- a/ts/services/storageRecordOps.preload.ts
+++ b/ts/services/storageRecordOps.preload.ts
@@ -2541,7 +2541,12 @@ function recipientToConversationId(
 ): string {
   let match: ConversationModel | undefined;
   if (recipient.contact != null) {
-    match = window.ConversationController.get(recipient.contact.serviceId);
+    const serviceId = fromServiceIdBinaryOrString(
+      recipient.contact.serviceIdBinary,
+      recipient.contact.serviceId,
+      `${logPrefix}.recipientToConversationId`
+    );
+    match = window.ConversationController.get(serviceId);
     match ??= window.ConversationController.get(recipient.contact.e164);
   } else if (
     recipient.groupMasterKey != null &&


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

When adding a user without a public phone number to a folder on mobile, the contact did not sync to desktop. The `recipientToConversationId` function relied on `Recipient.contact.serviceId`, which is often (always during my testing) undefined. 
This led to all contacts falling back to being identified by their phone numbers (e164) and contacts without a public phone number caused an error and didn't get added to the folder.

This PR fixes this by identifying contacts primarily by their `serviceIdBinary` which is always present.

Tested on Android 16 -> Debian GNU/Linux 13 (trixie) x86_64 (against prod servers).

Example error raised for contacts without public phone numbers:
```
ERROR 2026-02-28T21:40:29.292Z [storage] merge(121:r5z): error with item type=8 details=Error: mergeChatFolderRecord(121:r5z, idString): Missing conversation for recipient
    at strictAssert ([REDACTED]/resources/app.asar/preload.bundle.js:23:570)
    at recipientToConversationId ([REDACTED]/resources/app.asar/preload.bundle.js:169:176953)
    at [REDACTED]/resources/app.asar/preload.bundle.js:169:177040
    at Array.map (<anonymous>)
    at recipientsToConversationIds ([REDACTED]/resources/app.asar/preload.bundle.js:169:177033)
    at mergeChatFolderRecord ([REDACTED]/resources/app.asar/preload.bundle.js:169:177561)
    at mergeRecord ([REDACTED]/resources/app.asar/preload.bundle.js:169:199496)
    at concurrency ([REDACTED]/resources/app.asar/preload.bundle.js:169:207760)
    at [REDACTED]/resources/app.asar/preload.bundle.js:54:845
    at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
```