### PR TITLE
Enable emoji search by pasting emoji characters

### DIFF
--- a/ts/components/fun/useFunEmojiSearch.dom.tsx
+++ b/ts/components/fun/useFunEmojiSearch.dom.tsx
@@ -113,7 +113,14 @@ export function _createFunEmojiSearch(
   const fuseExact = new Fuse(emojiSearchIndex, FuseExactOptions, fuseIndex);
 
   return function emojiSearch(rawQuery, limit = 200) {
-    const query = normalizeShortNameCompletionQuery(rawQuery);
+    const trimmed = rawQuery.trim();
+    let resolvedQuery = rawQuery;
+    if (isEmojiParentValue(trimmed)) {
+      const parentKey = getEmojiParentKeyByValue(trimmed);
+      const entry = emojiSearchIndex.find(e => e.key === parentKey);
+      resolvedQuery = entry?.shortName ?? rawQuery;
+    }
+    const query = normalizeShortNameCompletionQuery(resolvedQuery);
 
     // Prefer exact matches at 2 characters
     const fuse = query.length < 2 ? fuseExact : fuseFuzzy;


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description:
Allow searching for emojis in the emoji picker using the emoji itself  on the Desktop version similar to what's already been implemented in Android/iOS counterpart.

**What changed:**
- `ts/components/fun/useFunEmojiSearch.dom.tsx`: 4 lines added to the search logic layer, so emoji character search works automatically across all emoji pickers in the app. 

|Implementation | Screenshots |
| -- | ------- |
| **Before** |<img width="1005" height="547" alt="image" src="https://github.com/user-attachments/assets/c2ba6073-23c2-438d-ab07-6ed0e7a0371f" /> |
| **After** |<img width="1007" height="560" alt="image" src="https://github.com/user-attachments/assets/29071508-26af-4e18-b11f-64cb31f2a429" />|

**Testing:**
- Manually tested on _Windows 11 (OS build 26200.8037)_
- Typed as well as pasted an emoji character into the reaction picker search box: both return correct results
- Verified existing text-based search still works normally
- No new automated tests added as this is a search input handling change

**References:**
- This mirrors the same feature already implemented on [Signal-Android](https://github.com/signalapp/Signal-Android/commit/117a497341477869c4c9ff4625801dc572bd1dbf) as well as [Signal-iOS.](https://github.com/signalapp/Signal-iOS/commit/61b3d1c9725693e70c8863737bf2dea54df55490)

- Idea of this PR was highlighted by the [community's feature request](https://community.signalusers.org/t/emoji-search-allow-searching-for-emojis-using-the-emoji-itself/75057)



