### PR TITLE
fix for #7729: show system nickname instead of first name in group sidebar preview

### DIFF
--- a/ts/util/getTitle.preload.ts
+++ b/ts/util/getTitle.preload.ts
@@ -54,6 +54,7 @@ export function getTitleNoDefault(
   return (
     nicknameValue ||
     (isShort ? attributes.systemGivenName : undefined) ||
+    attributes.systemGivenName : undefined) ||
     getSystemName(attributes) ||
     (isShort ? attributes.profileName : undefined) ||
     getProfileName(attributes) ||


### PR DESCRIPTION


<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before 

### First time contributor checklist:

- [ ] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)
-->

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->


It fixes [#7729](https://github.com/signalapp/Signal-Desktop/issues/7729) where the group chat sidebar shows a contact's first name instead of their system nickname, even though the nickname is correctly shown inside the group chat. (e.g. "John: Hello" instead of "Flash: Hello")

**Root cause:** When `isShort: true` (used for sidebar previews), the code fell back to `systemGivenName` (first name) even when `systemNickname` was set. 

**Fix:** One line change in `ts/util/getTitle.preload.ts` where it prefers `systemNickname` over `systemGivenName` when `isShort: true`, making the sidebar consistent with the group chat view.

> [!NOTE]
>  I was unable to reproduce this locally as it requires macOS system contacts integration.
However, the fix is based on code analysis. It makes the short display consistent with getSystemName() which already prefers systemNickname correctly.

Happy to make changes if the maintainers spot anything wrong.