### PR TITLE
fix: include quote header when sending a sticker reply

### DIFF
--- a/ts/models/conversations.preload.ts
+++ b/ts/models/conversations.preload.ts
@@ -3991,7 +3991,14 @@ export class ConversationModel {
     return getQuoteAttachment(attachments, preview, sticker);
   }
 
-  async sendStickerMessage(packId: string, stickerId: number): Promise<void> {
+  async sendStickerMessage(
+    packId: string,
+    stickerId: number,
+    options: {
+      quote?: QuoteType;
+      extraReduxActions?: () => void;
+    } = {}
+  ): Promise<void> {
     const packData = Stickers.getStickerPack(packId);
     const stickerData = Stickers.getSticker(packId, stickerId);
     if (!stickerData || !packData) {
@@ -4047,8 +4054,12 @@ export class ConversationModel {
           body: undefined,
           attachments: [],
           sticker,
+          quote: options.quote,
         },
-        { dontClearDraft: true }
+        {
+          dontClearDraft: true,
+          extraReduxActions: options.extraReduxActions,
+        }
       )
     );
     window.reduxActions.stickers.useSticker(packId, stickerId);

--- a/ts/state/ducks/composer.preload.ts
+++ b/ts/state/ducks/composer.preload.ts
@@ -772,9 +772,9 @@ function sendStickerMessage(
   void,
   RootStateType,
   unknown,
-  NoopActionType | ShowToastActionType
+  NoopActionType | ShowToastActionType | SetQuotedMessageActionType
 > {
-  return async dispatch => {
+  return async (dispatch, getState) => {
     const conversation = window.ConversationController.get(conversationId);
     if (!conversation) {
       throw new Error('sendStickerMessage: No conversation found');
@@ -803,7 +803,24 @@ function sendStickerMessage(
       }
 
       const { packId, stickerId } = options;
-      void conversation.sendStickerMessage(packId, stickerId);
+
+      const state = getState();
+      const conversationComposerState = getComposerStateForConversation(
+        state.composer,
+        conversationId
+      );
+      const quote = conversationComposerState.quotedMessage?.quote;
+
+      void conversation.sendStickerMessage(packId, stickerId, {
+        quote,
+        extraReduxActions: () => {
+          setQuoteByMessageId(conversationId, undefined)(
+            dispatch,
+            getState,
+            undefined
+          );
+        },
+      });
     } catch (error) {
       log.error('clickSend error:', Errors.toLogFormat(error));
     }


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

This PR fixes an issue where sending a sticker as a reply would drop the original message's quote header. Now, when a user replies to any message with a sticker, the quote header is successfully preserved and sent along with the sticker, matching the expected behavior of text and media replies.