### PR TITLE
Enable pasting images and text from clipboard in story creator

### DIFF
--- a/ts/components/StoriesTab.dom.tsx
+++ b/ts/components/StoriesTab.dom.tsx
@@ -103,6 +103,33 @@ export function StoriesTab({
   viewUserStories,
 }: PropsType): React.JSX.Element {
   const [isMyStories, setIsMyStories] = useState(false);
+  React.useEffect(() => {
+  const handlePaste = (ev: ClipboardEvent) => {
+    if (!ev.clipboardData) return;
+
+    const items = Array.from(ev.clipboardData.items);
+    
+    // Image takes priority over text
+    const imageItem = items.find(item => item.type.startsWith('image/'));
+    if (imageItem) {
+    const file = imageItem.getAsFile();
+    if (!file) return;
+    onAddStory(file);
+    return;
+    }
+
+  // Fall back to text
+  const text = ev.clipboardData.getData('text/plain');
+  if (text?.trim()) {
+    setAddStoryData({ type: 'Text', initialText: text.trim() });
+  }
+  };
+
+  document.addEventListener('paste', handlePaste);
+  return () => {
+    document.removeEventListener('paste', handlePaste);
+  };
+}, []);
 
   function onAddStory(file?: File) {
     if (file) {

--- a/ts/components/StoryCreator.dom.tsx
+++ b/ts/components/StoryCreator.dom.tsx
@@ -47,6 +47,7 @@ export type PropsType = {
     source: LinkPreviewSourceType
   ) => unknown;
   file?: File;
+  initialText?: string;
   i18n: LocalizerType;
   isSending: boolean;
   linkPreview?: LinkPreviewForUIType;
@@ -102,6 +103,7 @@ export function StoryCreator({
   debouncedMaybeGrabLinkPreview,
   distributionLists,
   file,
+  initialText,
   getPreferredBadge,
   groupConversations,
   groupStories,
@@ -301,6 +303,7 @@ export function StoryCreator({
             <TextStoryCreator
               debouncedMaybeGrabLinkPreview={debouncedMaybeGrabLinkPreview}
               i18n={i18n}
+              initialText={initialText}
               isSending={isSending}
               linkPreview={linkPreview}
               onClose={onClose}

--- a/ts/components/TextStoryCreator.dom.tsx
+++ b/ts/components/TextStoryCreator.dom.tsx
@@ -41,6 +41,7 @@ export type PropsType = {
     options?: MaybeGrabLinkPreviewOptionsType
   ) => unknown;
   i18n: LocalizerType;
+  initialText: string;
   isSending: boolean;
   linkPreview?: LinkPreviewForUIType;
   onClose: () => unknown;
@@ -133,6 +134,7 @@ function getBgButtonAriaLabel(
 export function TextStoryCreator({
   debouncedMaybeGrabLinkPreview,
   i18n,
+  initialText,
   isSending,
   linkPreview,
   onClose,
@@ -158,7 +160,7 @@ export function TextStoryCreator({
     TextBackground.None
   );
   const [sliderValue, setSliderValue] = useState<number>(100);
-  const [text, setText] = useState<string>('');
+  const [text, setText] = useState<string>(initialText ?? '');
 
   const [isColorPickerShowing, setIsColorPickerShowing] = useState(false);
   const [colorPickerPopperButtonRef, setColorPickerPopperButtonRef] =

--- a/ts/state/ducks/stories.preload.ts
+++ b/ts/state/ducks/stories.preload.ts
@@ -137,6 +137,7 @@ export type AddStoryData = ReadonlyDeep<
     }
   | {
       type: 'Text';
+      initialText?: string,
       sending?: boolean;
     }
   | undefined

--- a/ts/state/smart/StoryCreator.preload.tsx
+++ b/ts/state/smart/StoryCreator.preload.tsx
@@ -87,14 +87,19 @@ export const SmartStoryCreator = memo(function SmartStoryCreator() {
   );
 
   const addStoryData = useSelector(getAddStoryData);
-  let file: File | undefined;
-  const isSending = addStoryData?.sending || false;
+let file: File | undefined;
+let initialText: string | undefined;
+const isSending = addStoryData?.sending || false;
 
-  if (addStoryData?.type === 'Media') {
-    // Note that the source type is ReadonlyDeep<File>, but browser APIs don't
-    // support that. Hence the cast.
-    file = addStoryData.file as File;
-  }
+if (addStoryData?.type === 'Media') {
+  // Note that the source type is ReadonlyDeep<File>, but browser APIs don't
+  // support that. Hence the cast.
+  file = addStoryData.file as File;
+}
+
+if (addStoryData?.type === 'Text') {
+  initialText = addStoryData.initialText;
+}
 
   const emojiSkinToneDefault = useSelector(getEmojiSkinToneDefault);
   const { onUseEmoji } = useEmojisActions();
@@ -128,6 +133,7 @@ export const SmartStoryCreator = memo(function SmartStoryCreator() {
       groupConversations={groupConversations}
       groupStories={groupStories}
       hasFirstStoryPostExperience={!hasSetMyStoriesPrivacy}
+      initialText={initialText}
       i18n={i18n}
       imageToBlurHash={imageToBlurHash}
       isFormattingEnabled={isFormattingEnabled}


### PR DESCRIPTION
### Contributor checklist:
- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Adds the ability to paste images and text directly into the Story Creator using `Ctrl+V`, without needing to save files to disk first.

**What changed:**
- In `StoriesTab`  paste event listener that opens Story Creator directly on Ctrl+V / Cmd+V
- In `AddStoryData` added `initialText` to the Text variant for pre-filling pasted text
- In `StoryCreator` and `TextStoryCreator` wired `initialText` through the component chain

**Key details:**
- Images take priority if clipboard contains both image and text
- Reuses existing `onAddStory` handler so the full story flow works automatically

|Implementation | Screenshots |
| ----------------- | ------------- |
| **Present** |![Recording 2026-03-13 190425](https://github.com/user-attachments/assets/cf6aa80d-8fcb-4890-a8a5-2f74b42ff4df)|
| **After** |![Recording 2026-03-13 193127](https://github.com/user-attachments/assets/c1b0b8bb-b441-4143-a4b3-6a6e3e034c9e)|

#### Testing:
Manually tested on Windows 11 (OS build 26200.8037):
- Copied a screenshot → navigated to Stories tab → pressed `Ctrl+V` → Media Story Creator opened with image
- Copied text → navigated to Stories tab → pressed `Ctrl+V` → Text Story Creator opened with text pre-filled
- Verified existing "Add story" button still works normally for both media and text stories

All tests passed successfully.

**References:**
- This addresses the feature request on [community forum](https://community.signalusers.org/t/allow-creating-photo-story-from-clipboard).  Here's the [reply](https://community.signalusers.org/t/allow-creating-photo-story-from-clipboard/49909/2?u=signaluser000)
