### PR TITLE
Fix issue #7552: Using app locale in sticker creator

### DIFF
--- a/app/main.main.ts
+++ b/app/main.main.ts
@@ -2947,6 +2947,12 @@ ipc.on('locale-data', event => {
 });
 
 // Ingested in preload.js via a sendSync call
+ipc.on('art-creator:locale', event => {
+  // eslint-disable-next-line no-param-reassign
+  event.returnValue = getResolvedMessagesLocale().name;
+});
+
+// Ingested in preload.js via a sendSync call
 ipc.on('locale-display-names', event => {
   // eslint-disable-next-line no-param-reassign
   event.returnValue = getResolvedMessagesLocale().localeDisplayNames;

--- a/sticker-creator/src/util/api.ts
+++ b/sticker-creator/src/util/api.ts
@@ -14,6 +14,7 @@ declare global {
     ): Promise<string>;
     installStickerPack(packId: string, key: string): void;
     getFilePath(file: File): string;
+    getResolvedMessagesLocale?(): string;
   }
 }
 
@@ -55,4 +56,8 @@ export async function upload(
 
 export function getFilePath(file: File): string {
   return window.getFilePath(file);
+}
+
+export function getResolvedMessagesLocale(): string | undefined {
+  return window.getResolvedMessagesLocale?.();
 }

--- a/sticker-creator/src/util/i18n.ts
+++ b/sticker-creator/src/util/i18n.ts
@@ -12,6 +12,7 @@ import type {
   LocaleMessagesType,
 } from '../types.d';
 import englishMessages from '../assets/locales/en/messages.json';
+import { getResolvedMessagesLocale } from './api';
 import { assert } from './assert';
 
 const debug = createDebug('signal:i18n');
@@ -98,7 +99,7 @@ export type LoadLocaleResult = Readonly<{
 }>;
 
 export async function loadLocale(
-  language = navigator.language
+  language = getResolvedMessagesLocale() ?? navigator.language
 ): Promise<LoadLocaleResult> {
   // Remove region. "en-US" might not be supported, but "en" is.
   const languageWithoutRegion = removeRegion(language);

--- a/ts/windows/sticker-creator/preload.preload.ts
+++ b/ts/windows/sticker-creator/preload.preload.ts
@@ -34,3 +34,7 @@ contextBridge.exposeInMainWorld(
 contextBridge.exposeInMainWorld('getFilePath', (file: File) =>
   webUtils.getPathForFile(file)
 );
+
+contextBridge.exposeInMainWorld('getResolvedMessagesLocale', () =>
+  ipcRenderer.sendSync('art-creator:locale')
+);


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Fixes issue #7552 by using the app's resolved locale in the sticker creator.

A IPC plus preload bridge has been added,  so the sticker creator can read `getResolvedMessagesLocale().name` from the main process. `loadLocale()` now uses that value obtained from the main process, before falling back to `navigator.language`, which keeps sticker creator localization in sync with the rest of the app.

The change has been manually verified, by configuring the Signal Desktop app with different languages and afterwards starting the sticker creator. Language did match in each test run. Verified on (Arch) Linux 64-bit.

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
