### PR TITLE
Remove hover buttons and move react and reply options to context menu

### DIFF
--- a/ts/axo/AxoContextMenu.dom.tsx
+++ b/ts/axo/AxoContextMenu.dom.tsx
@@ -235,7 +235,7 @@ export namespace AxoContextMenu {
     return (
       <ContextMenu.Portal>
         <ContextMenu.Content
-          className={AxoBaseMenu.menuContentStyles}
+          className={tw(AxoBaseMenu.menuContentStyles, props.className)}
           alignOffset={-6}
           collisionPadding={6}
           onCloseAutoFocus={props.onCloseAutoFocus}
@@ -272,7 +272,10 @@ export namespace AxoContextMenu {
         disabled={props.disabled}
         textValue={props.textValue}
         onSelect={props.onSelect}
-        className={AxoBaseMenu.menuItemStyles}
+        className={tw(
+          AxoBaseMenu.menuItemStyles,
+          props.variant === 'destructive' && 'text-color-label-destructive'
+        )}
       >
         {props.symbol && (
           <AxoBaseMenu.ItemLeadingSlot>

--- a/ts/axo/AxoDropdownMenu.dom.tsx
+++ b/ts/axo/AxoDropdownMenu.dom.tsx
@@ -199,7 +199,7 @@ export namespace AxoDropdownMenu {
             sideOffset={4}
             align="start"
             collisionPadding={6}
-            className={AxoBaseMenu.menuContentStyles}
+            className={tw(AxoBaseMenu.menuContentStyles, props.className)}
             aria-labelledby={labelId}
             aria-describedby={descriptionId}
             onCloseAutoFocus={props.onCloseAutoFocus}
@@ -222,7 +222,7 @@ export namespace AxoDropdownMenu {
 
   export type CustomItemProps = Pick<
     AxoBaseMenu.MenuItemProps,
-    'disabled' | 'textValue' | 'keyboardShortcut' | 'onSelect'
+    'disabled' | 'textValue' | 'keyboardShortcut' | 'onSelect' | 'variant'
   > &
     Readonly<{
       leading?: ReactNode;
@@ -238,7 +238,10 @@ export namespace AxoDropdownMenu {
         disabled={props.disabled}
         textValue={props.textValue}
         onSelect={props.onSelect}
-        className={AxoBaseMenu.menuItemStyles}
+        className={tw(
+          AxoBaseMenu.menuItemStyles,
+          props.variant === 'destructive' && 'text-color-label-destructive'
+        )}
       >
         {props.leading && (
           <AxoBaseMenu.ItemLeadingSlot>

--- a/ts/axo/_internal/AxoBaseMenu.dom.tsx
+++ b/ts/axo/_internal/AxoBaseMenu.dom.tsx
@@ -60,6 +60,10 @@ export namespace AxoBaseMenu {
      */
     disabled?: boolean;
     /**
+     * The visual style of the item.
+     */
+    variant?: 'default' | 'destructive';
+    /**
      * Optional text used for typeahead purposes. By default the typeahead
      * behavior will use the .textContent of the item. Use this when the
      * content is complex, or you have non-textual content inside.
@@ -128,10 +132,20 @@ export namespace AxoBaseMenu {
 
   export type ItemTextProps = Readonly<{
     children: ReactNode;
+    variant?: 'default' | 'destructive';
   }>;
 
   export function ItemText(props: ItemTextProps): React.JSX.Element {
-    return <span className={itemTextStyles}>{props.children}</span>;
+    return (
+      <span
+        className={tw(
+          itemTextStyles,
+          props.variant === 'destructive' && 'text-color-label-destructive'
+        )}
+      >
+        {props.children}
+      </span>
+    );
   }
 
   export type ItemCheckPlaceholderProps = Readonly<{
@@ -207,6 +221,7 @@ export namespace AxoBaseMenu {
   export type MenuContentProps = Readonly<{
     onCloseAutoFocus?: (e: Event) => void;
     children: ReactNode;
+    className?: string;
   }>;
 
   export const menuContentStyles = tw(

--- a/ts/components/CompositionArea.dom.tsx
+++ b/ts/components/CompositionArea.dom.tsx
@@ -42,6 +42,7 @@ import { isImageAttachment, isVoiceMessage } from '../util/Attachment.std.js';
 import { isViewOnceEligible } from '../util/viewOnceEligibility.std.js';
 import type { AciString } from '../types/ServiceId.std.js';
 import { AudioCapture } from './conversation/AudioCapture.dom.js';
+import { getEmojiVariantByKey } from './fun/data/emojis.std.js';
 import { CompositionUpload } from './CompositionUpload.dom.js';
 import type {
   ConversationRemovalStage,
@@ -232,6 +233,10 @@ export type OwnProps = Readonly<{
 
   onSelectEmoji: (emojiSelection: FunEmojiSelection) => void;
   emojiSkinToneDefault: EmojiSkinTone | null;
+  reactToMessage: (
+    id: string,
+    { emoji, remove }: { emoji: string; remove: boolean }
+  ) => void;
 }>;
 
 export type Props = Pick<
@@ -362,6 +367,7 @@ export const CompositionArea = memo(function CompositionArea({
   toggleForwardMessagesModal,
   // DraftGifMessageSendModal
   toggleDraftGifMessageSendModal,
+  reactToMessage,
 }: Props): React.JSX.Element | null {
   const [dirty, setDirty] = useState(false);
   const [large, setLarge] = useState(false);
@@ -645,6 +651,35 @@ export const CompositionArea = memo(function CompositionArea({
   }
 
   const [funPickerOpen, setFunPickerOpen] = useState(false);
+  const [reactionMessageId, setReactionMessageId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handleOpenReactionPicker = (event: Event) => {
+      const customEvent = event as CustomEvent<{
+        messageId: string;
+        conversationId: string;
+      }>;
+      const { messageId, conversationId: eventConversationId } =
+        customEvent.detail;
+
+      if (eventConversationId === conversationId) {
+        setReactionMessageId(messageId);
+        setFunPickerOpen(true);
+      }
+    };
+
+    window.addEventListener(
+      'signal:open-reaction-picker',
+      handleOpenReactionPicker
+    );
+
+    return () => {
+      window.removeEventListener(
+        'signal:open-reaction-picker',
+        handleOpenReactionPicker
+      );
+    };
+  }, [conversationId]);
 
   const handleToggleViewOnce = useCallback(() => {
     setFunPickerOpen(false);
@@ -659,6 +694,7 @@ export const CompositionArea = memo(function CompositionArea({
     (open: boolean) => {
       setFunPickerOpen(open);
       if (!open) {
+        setReactionMessageId(null);
         setComposerFocus(conversationId);
       }
     },
@@ -667,11 +703,23 @@ export const CompositionArea = memo(function CompositionArea({
 
   const handleFunPickerSelectEmoji = useCallback(
     (emojiSelection: FunEmojiSelection) => {
+      if (reactionMessageId) {
+        const variant = getEmojiVariantByKey(emojiSelection.variantKey);
+        reactToMessage(reactionMessageId, {
+          emoji: variant.value,
+          remove: false, // For now, assume we're adding. 
+          // We could potentially check the existing reaction if we had access to the message object here.
+        });
+        setReactionMessageId(null);
+        setFunPickerOpen(false);
+        return;
+      }
+
       if (inputApiRef.current) {
         inputApiRef.current.insertEmoji(emojiSelection);
       }
     },
-    []
+    [reactionMessageId, reactToMessage]
   );
   const handleFunPickerSelectSticker = useCallback(
     (stickerSelection: FunStickerSelection) => {

--- a/ts/components/conversation/MessageContextMenu.dom.tsx
+++ b/ts/components/conversation/MessageContextMenu.dom.tsx
@@ -5,6 +5,9 @@ import React, { useRef, type ReactNode } from 'react';
 import type { LocalizerType } from '../../types/I18N.std.js';
 import { AxoMenuBuilder } from '../../axo/AxoMenuBuilder.dom.js';
 import { isInternalFeaturesEnabled } from '../../util/isInternalFeaturesEnabled.dom.js';
+import type { EmojiVariantKey } from '../fun/data/emojis.std.js';
+import { tw } from '../../axo/tw.dom.js';
+import type { SmartReactionPicker } from '../../state/smart/ReactionPicker.dom.js';
 
 type MessageContextMenuProps = Readonly<{
   i18n: LocalizerType;
@@ -15,7 +18,7 @@ type MessageContextMenuProps = Readonly<{
   onDownload: (() => void) | null;
   onEdit: (() => void) | null;
   onReplyToMessage: (() => void) | null;
-  onReact: (() => void) | null;
+  onReact?: (() => void) | null;
   onEndPoll: (() => void) | null;
   onRetryMessageSend: (() => void) | null;
   onRetryDeleteForEveryone: (() => void) | null;
@@ -26,6 +29,13 @@ type MessageContextMenuProps = Readonly<{
   onUnpinMessage: (() => void) | null;
   onMoreInfo: (() => void) | null;
   onSelect: (() => void) | null;
+  onPickEmoji: (emoji: string) => void;
+  onShowFullPicker: () => void;
+  renderReactionPicker: (
+    props: React.ComponentProps<typeof SmartReactionPicker>
+  ) => React.JSX.Element;
+  selectedReaction?: string;
+  messageEmojis?: ReadonlyArray<EmojiVariantKey>;
   children: ReactNode;
 }>;
 
@@ -38,17 +48,21 @@ export function MessageContextMenu({
   onDownload,
   onEdit,
   onReplyToMessage,
-  onReact,
-  onEndPoll,
-  onMoreInfo,
-  onCopy,
-  onSelect,
   onRetryMessageSend,
   onRetryDeleteForEveryone,
   onForward,
   onDeleteMessage,
   onPinMessage,
   onUnpinMessage,
+  onEndPoll,
+  onMoreInfo,
+  onCopy,
+  onSelect,
+  onPickEmoji,
+  onShowFullPicker,
+  renderReactionPicker,
+  selectedReaction,
+  messageEmojis,
   children,
 }: MessageContextMenuProps): React.JSX.Element {
   const shouldReturnFocusToTrigger = useRef(true);
@@ -59,12 +73,44 @@ export function MessageContextMenu({
         {children}
       </AxoMenuBuilder.Trigger>
       <AxoMenuBuilder.Content
+        className={tw('!overflow-visible')}
         onCloseAutoFocus={e => {
           if (!shouldReturnFocusToTrigger.current) {
             e.preventDefault();
           }
         }}
       >
+        <div className={tw('col-span-full border-b-[0.5px] border-border-primary pb-0.5 pt-0.5 px-0 overflow-visible')}>
+          {renderReactionPicker({
+            onPick: (emoji: string) => {
+              onPickEmoji(emoji);
+              // Trigger escape to close the menu
+              document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+            },
+            onMore: () => {
+              onShowFullPicker();
+              // Trigger escape to close the menu
+              document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+            },
+            onClose: () => {
+              document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+            },
+            selected: selectedReaction,
+            messageEmojis,
+            style: { 
+              borderRadius: 'var(--curved-xl)',
+              width: '100%',
+              boxShadow: 'none',
+              backgroundColor: 'transparent',
+              overflow: 'visible',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              border: 'none',
+              paddingInline: 0,
+            }
+          })}
+        </div>
         {onDownload && (
           <AxoMenuBuilder.Item symbol="download" onSelect={onDownload}>
             {i18n('icu:MessageContextMenu__download')}
@@ -80,11 +126,6 @@ export function MessageContextMenu({
             }}
           >
             {i18n('icu:MessageContextMenu__reply')}
-          </AxoMenuBuilder.Item>
-        )}
-        {onReact && (
-          <AxoMenuBuilder.Item symbol="heart-plus" onSelect={onReact}>
-            {i18n('icu:MessageContextMenu__react')}
           </AxoMenuBuilder.Item>
         )}
         {onEndPoll && (
@@ -142,7 +183,11 @@ export function MessageContextMenu({
           </AxoMenuBuilder.Item>
         )}
         {onDeleteMessage && (
-          <AxoMenuBuilder.Item symbol="trash" onSelect={onDeleteMessage}>
+          <AxoMenuBuilder.Item
+            symbol="trash"
+            onSelect={onDeleteMessage}
+            variant="destructive"
+          >
             {i18n('icu:MessageContextMenu__deleteMessage')}
           </AxoMenuBuilder.Item>
         )}

--- a/ts/components/conversation/ReactionPicker.dom.tsx
+++ b/ts/components/conversation/ReactionPicker.dom.tsx
@@ -14,12 +14,14 @@ import type { EmojiVariantKey } from '../fun/data/emojis.std.js';
 import { getEmojiVariantByKey } from '../fun/data/emojis.std.js';
 import { FunEmojiPicker } from '../fun/FunEmojiPicker.dom.js';
 import type { FunEmojiSelection } from '../fun/panels/FunPanelEmojis.dom.js';
+import { tw } from '../../axo/tw.dom.js';
 
 export type OwnProps = {
   i18n: LocalizerType;
   selected?: string;
   onClose?: () => unknown;
   onPick: (emoji: string) => unknown;
+  onMore?: () => void;
   preferredReactionEmoji: ReadonlyArray<string>;
   theme?: ThemeType;
   messageEmojis?: ReadonlyArray<EmojiVariantKey>;
@@ -33,6 +35,7 @@ export const ReactionPicker = React.forwardRef<HTMLDivElement, Props>(
       i18n,
       onClose,
       onPick,
+      onMore,
       preferredReactionEmoji,
       selected,
       style,
@@ -110,6 +113,16 @@ export const ReactionPicker = React.forwardRef<HTMLDivElement, Props>(
             }}
             isSelected
             title={i18n('icu:Reactions--remove')}
+          />
+        ) : onMore ? (
+          <Button
+            aria-label={i18n('icu:Reactions--more')}
+            className={tw(
+              'module-ReactionPickerPicker__button',
+              'module-ReactionPickerPicker__button--more',
+              'flex-shrink-0'
+            )}
+            onPress={onMore}
           />
         ) : (
           <FunEmojiPicker

--- a/ts/components/conversation/TimelineMessage.dom.tsx
+++ b/ts/components/conversation/TimelineMessage.dom.tsx
@@ -1,15 +1,9 @@
 // Copyright 2019 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import lodash from 'lodash';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { createPortal } from 'react-dom';
-import { Manager, Popper, Reference } from 'react-popper';
-import type { PreventOverflowModifier } from '@popperjs/core/lib/modifiers/preventOverflow.js';
 import { isDownloaded } from '../../util/Attachment.std.js';
-import { handleOutsideClick } from '../../util/handleOutsideClick.dom.js';
-import { offsetDistanceModifier } from '../../util/popperUtil.std.js';
 import { Message, MessageInteractivity } from './Message.dom.js';
 import type { SmartReactionPicker } from '../../state/smart/ReactionPicker.dom.js';
 import type {
@@ -24,7 +18,6 @@ import type {
   DeleteMessagesPropsType,
   ForwardMessagesPayload,
 } from '../../state/ducks/globalModals.preload.js';
-import { useScrollerLock } from '../../hooks/useScrollLock.dom.js';
 import { MessageContextMenu } from './MessageContextMenu.dom.js';
 import { ForwardMessagesModalType } from '../ForwardMessagesModal.dom.js';
 import { useGroupedAndOrderedReactions } from '../../util/groupAndOrderReactions.dom.js';
@@ -35,7 +28,6 @@ import { useDocumentKeyDown } from '../../hooks/useDocumentKeyDown.dom.js';
 
 const { useAxoContextMenuOutsideKeyboardTrigger } = AxoContextMenu;
 
-const { noop } = lodash;
 
 export type PropsData = {
   canDownload: boolean;
@@ -108,7 +100,6 @@ export function TimelineMessage(props: Props): React.JSX.Element {
     canRetry,
     canRetryDeleteForEveryone,
     canPinMessage,
-    containerElementRef,
     conversationId,
     i18n,
     id,
@@ -138,79 +129,6 @@ export function TimelineMessage(props: Props): React.JSX.Element {
     toggleForwardMessagesModal,
     toggleSelectMessage,
   } = props;
-
-  const [reactionPickerRoot, setReactionPickerRoot] = useState<
-    HTMLDivElement | undefined
-  >(undefined);
-
-
-  const popperPreventOverflowModifier =
-    useCallback((): Partial<PreventOverflowModifier> => {
-      return {
-        name: 'preventOverflow',
-        options: {
-          altAxis: true,
-          boundary: containerElementRef.current || undefined,
-          padding: {
-            bottom: 16,
-            left: 8,
-            right: 8,
-            top: 16,
-          },
-        },
-      };
-    }, [containerElementRef]);
-
-  const toggleReactionPicker = useCallback(
-    (onlyRemove = false): void => {
-      if (reactionPickerRoot) {
-        document.body.removeChild(reactionPickerRoot);
-        setReactionPickerRoot(undefined);
-        return;
-      }
-
-      if (!onlyRemove) {
-        const root = document.createElement('div');
-        document.body.appendChild(root);
-
-        setReactionPickerRoot(root);
-      }
-    },
-    [reactionPickerRoot]
-  );
-
-  useScrollerLock({
-    reason: 'TimelineMessage reactionPicker',
-    lockScrollWhen: reactionPickerRoot != null,
-    onUserInterrupt() {
-      toggleReactionPicker(true);
-    },
-  });
-
-  useEffect(() => {
-    let cleanUpHandler: (() => void) | undefined;
-    if (reactionPickerRoot) {
-      cleanUpHandler = handleOutsideClick(
-        target => {
-          if (
-            target instanceof Element &&
-            target.closest('[data-fun-overlay]') != null
-          ) {
-            return true;
-          }
-          toggleReactionPicker(true);
-          return true;
-        },
-        {
-          containerElements: [reactionPickerRoot],
-          name: 'Message.reactionPicker',
-        }
-      );
-    }
-    return () => {
-      cleanUpHandler?.();
-    };
-  });
 
   const openGenericAttachment = useCallback(
     (event?: React.MouseEvent): void => {
@@ -267,11 +185,17 @@ export function TimelineMessage(props: Props): React.JSX.Element {
     setQuoteByMessageId(conversationId, id);
   }, [canReply, conversationId, id, setQuoteByMessageId]);
 
-  const handleReact = useCallback(() => {
-    if (canReact) {
-      toggleReactionPicker();
-    }
-  }, [canReact, toggleReactionPicker]);
+  const handleReact = useCallback(
+    (emoji: string) => {
+      if (canReact) {
+        reactToMessage(id, {
+          emoji,
+          remove: emoji === selectedReaction,
+        });
+      }
+    },
+    [canReact, id, reactToMessage, selectedReaction]
+  );
 
   const isDisappearingMessage = expirationLength != null;
 
@@ -283,9 +207,16 @@ export function TimelineMessage(props: Props): React.JSX.Element {
     onPinnedMessageRemove(id);
   }, [onPinnedMessageRemove, id]);
 
-  const toggleReactionPickerKeyboard = useToggleReactionPicker(
-    handleReact || noop
-  );
+  const toggleReactionPickerKeyboard = useToggleReactionPicker(() => {
+    window.dispatchEvent(
+      new CustomEvent('signal:open-reaction-picker', {
+        detail: {
+          messageId: id,
+          conversationId,
+        },
+      })
+    );
+  });
 
   useDocumentKeyDown(event => {
     if (isTargeted) {
@@ -320,7 +251,20 @@ export function TimelineMessage(props: Props): React.JSX.Element {
             canEditMessage ? () => setMessageToEdit(conversationId, id) : null
           }
           onReplyToMessage={handleReplyToMessage}
-          onReact={handleReact}
+          onPickEmoji={handleReact}
+          onShowFullPicker={() => {
+            window.dispatchEvent(
+              new CustomEvent('signal:open-reaction-picker', {
+                detail: {
+                  messageId: id,
+                  conversationId,
+                },
+              })
+            );
+          }}
+          renderReactionPicker={renderReactionPicker}
+          selectedReaction={selectedReaction}
+          messageEmojis={messageEmojis as any}
           onEndPoll={canEndPoll ? () => endPoll(id) : null}
           onRetryMessageSend={canRetry ? () => retryMessageSend(id) : null}
           onRetryDeleteForEveryone={
@@ -377,6 +321,9 @@ export function TimelineMessage(props: Props): React.JSX.Element {
       handleDebugMessage,
       handleDownload,
       handleReact,
+      renderReactionPicker,
+      selectedReaction,
+      messageEmojis,
       handleOpenPinMessageDialog,
       handleUnpinMessage,
       endPoll,
@@ -398,52 +345,16 @@ export function TimelineMessage(props: Props): React.JSX.Element {
   const handleWrapperKeyDown = useAxoContextMenuOutsideKeyboardTrigger();
 
   return (
-    <Manager>
-      <Reference>
-        {({ ref: popperRef }) => (
-          <div ref={popperRef}>
-            <Message
-              {...props}
-              renderingContext="conversation/TimelineItem"
-              renderMessageContextMenu={renderMessageContextMenu}
-              onToggleSelect={(selected, shift) => {
-                toggleSelectMessage(conversationId, id, shift, selected);
-              }}
-              onReplyToMessage={handleReplyToMessage}
-              onWrapperKeyDown={handleWrapperKeyDown}
-            />
-          </div>
-        )}
-      </Reference>
-      {reactionPickerRoot &&
-        createPortal(
-          <Popper
-            placement="top"
-            modifiers={[
-              offsetDistanceModifier(4),
-              popperPreventOverflowModifier(),
-            ]}
-          >
-            {({ ref, style }) =>
-              renderReactionPicker({
-                ref,
-                style,
-                selected: selectedReaction,
-                onClose: toggleReactionPicker,
-                onPick: emoji => {
-                  toggleReactionPicker(true);
-                  reactToMessage(id, {
-                    emoji,
-                    remove: emoji === selectedReaction,
-                  });
-                },
-                messageEmojis,
-              })
-            }
-          </Popper>,
-          reactionPickerRoot
-        )}
-    </Manager>
+    <Message
+      {...props}
+      renderingContext="conversation/TimelineItem"
+      renderMessageContextMenu={renderMessageContextMenu}
+      onToggleSelect={(selected, shift) => {
+        toggleSelectMessage(conversationId, id, shift, selected);
+      }}
+      onReplyToMessage={handleReplyToMessage}
+      onWrapperKeyDown={handleWrapperKeyDown}
+    />
   );
 }
 

--- a/ts/state/smart/CompositionArea.preload.tsx
+++ b/ts/state/smart/CompositionArea.preload.tsx
@@ -210,6 +210,7 @@ export const SmartCompositionArea = memo(function SmartCompositionArea({
     sendMultiMediaMessage,
     sendPoll,
     setComposerFocus,
+    reactToMessage,
   } = useComposerActions();
   const {
     discardEditMessage,
@@ -371,6 +372,7 @@ export const SmartCompositionArea = memo(function SmartCompositionArea({
       setComposerFocus={setComposerFocus}
       setMessageToEdit={setMessageToEdit}
       showConversation={showConversation}
+      reactToMessage={reactToMessage}
     />
   );
 });


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

- Moved the react and reply options which appear on hovering through a text to the context menu.
- Removed the 3 dot option that appears on hovering through a text. The context menu can now be accessed only by right-clicking.
This update removes unnecessary clutter from the UI. Later plans include replacing the react option from the context menu with the emoji picker directly integrated to the top of the context menu.