### PR TITLE
Fix Azerbaijani reaction notification typo

### DIFF
--- a/_locales/az-AZ/messages.json
+++ b/_locales/az-AZ/messages.json
@@ -2199,7 +2199,7 @@
     "messageformat": "{sender}, {group} qrupundadır"
   },
   "icu:notificationReactionMessage": {
-    "messageformat": "{sender} {emoji} reakiyası verdi: {message} mesajı"
+    "messageformat": "{sender} {emoji} reaksiyası verdi: {message} mesajı"
   },
   "icu:notificationPollVoteMessage": {
     "messageformat": "{sender} \"{pollQuestion}\" səsverməsində iştirak etdi"


### PR DESCRIPTION
## Summary
- fix a typo in the Azerbaijani reaction notification string
- change `reakiyası` to the correct `reaksiyası`

## Testing
- not run (localization string change only)