### PR TITLE
Apply skin tone preference to quick reaction emoji

### DIFF
--- a/ts/reactions/preferredReactionEmoji.std.ts
+++ b/ts/reactions/preferredReactionEmoji.std.ts
@@ -7,6 +7,9 @@ import { DEFAULT_PREFERRED_REACTION_EMOJI_PARENT_KEYS } from './constants.std.js
 import { isValidReactionEmoji } from './isValidReactionEmoji.std.js';
 import {
   getEmojiVariantByParentKeyAndSkinTone,
+  getEmojiVariantKeyByValue,
+  getEmojiParentKeyByVariantKey,
+  isEmojiVariantValue,
   type EmojiSkinTone,
 } from '../components/fun/data/emojis.std.js';
 
@@ -31,7 +34,7 @@ export function getPreferredReactionEmoji(
   return times(PREFERRED_REACTION_EMOJI_COUNT, index => {
     const storedItem: unknown = storedValueAsArray[index];
     if (isValidReactionEmoji(storedItem)) {
-      return storedItem;
+      return applyEmojiSkinTone(storedItem, emojiSkinToneDefault);
     }
 
     const fallbackParentKey =
@@ -56,6 +59,22 @@ export function getPreferredReactionEmoji(
 
     return fallbackEmoji.value;
   });
+}
+
+function applyEmojiSkinTone(
+  emoji: string,
+  skinTone: EmojiSkinTone
+): string {
+  if (!isEmojiVariantValue(emoji)) {
+    return emoji;
+  }
+  const variantKey = getEmojiVariantKeyByValue(emoji);
+  const parentKey = getEmojiParentKeyByVariantKey(variantKey);
+  const newVariant = getEmojiVariantByParentKeyAndSkinTone(
+    parentKey,
+    skinTone
+  );
+  return newVariant.value;
 }
 
 export const canBeSynced = (value: unknown): value is Array<string> =>

--- a/ts/test-node/reactions/preferredReactionEmoji_test.std.ts
+++ b/ts/test-node/reactions/preferredReactionEmoji_test.std.ts
@@ -55,6 +55,24 @@ describe('preferred reaction emoji utilities', () => {
       );
     });
 
+    it('applies skin tone to stored emoji that support skin tones', () => {
+      const input = ['❤️', '👍', '👎', '😂', '😮', '😢'];
+      const expected = ['❤️', '👍🏼', '👎🏼', '😂', '😮', '😢'];
+      assert.deepStrictEqual(
+        getPreferredReactionEmoji(input, EmojiSkinTone.Type2),
+        expected
+      );
+    });
+
+    it('updates skin tone when stored emoji already have a different skin tone', () => {
+      const input = ['❤️', '👍🏻', '👎🏻', '😂', '😮', '😢'];
+      const expected = ['❤️', '👍🏿', '👎🏿', '😂', '😮', '😢'];
+      assert.deepStrictEqual(
+        getPreferredReactionEmoji(input, EmojiSkinTone.Type5),
+        expected
+      );
+    });
+
     it('only returns the first few emoji if passed a value that is too long', () => {
       const expected = ['✨', '❇️', '🎇', '🦈', '💖', '🅿️'];
       const input = [...expected, '💅', '💅', '💅', '💅'];


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7612 — The quick reaction emoji menu (thumbs up, thumbs down) does not respect the user's preferred emoji skin tone setting. The skin tone preference works correctly in the full emoji picker but not in the quick reaction bar.

**Root cause:** In `getPreferredReactionEmoji()`, stored emoji values (synced from phone or saved via customization) were returned as-is without re-applying the current skin tone preference. Only fallback (default) emoji had the skin tone applied.

**Fix:** Added an `applyEmojiSkinTone()` helper that converts any stored emoji to the current skin tone variant by resolving its parent key and looking up the correct variant. Emoji without skin tone support (hearts, face emoji) pass through unchanged.

**Test approach:**
- Added two new unit tests to `preferredReactionEmoji_test.std.ts`:
  - Verifies skin tone is applied to stored emoji that support skin tones
  - Verifies skin tone is updated when stored emoji already have a different skin tone
- Existing tests continue to pass (emoji without skin tone variants are returned unchanged)