### PR TITLE
Defer removal of empty poll options until blur

### DIFF
--- a/ts/components/PollCreateModal.dom.tsx
+++ b/ts/components/PollCreateModal.dom.tsx
@@ -95,19 +95,6 @@ export function PollCreateModal({
         }
       }
 
-      // Remove middle empty options
-      if (!isLastOption && !hasText && canRemove) {
-        resultOptions.splice(changedIndex, 1);
-        removedIndex = changedIndex;
-
-        // Ensure there's always an empty option at the end
-        const lastOption = resultOptions[resultOptions.length - 1];
-        const lastOptionEmpty = !lastOption || !lastOption.value.trim();
-        if (!lastOptionEmpty && resultOptions.length < POLL_OPTIONS_MAX_COUNT) {
-          resultOptions.push({ id: generateUuid(), value: '' });
-        }
-      }
-
       return { options: resultOptions, removedIndex };
     },
     []
@@ -151,6 +138,28 @@ export function PollCreateModal({
       }
     },
     [computeOptionsAfterChange, validationErrors, options]
+  );
+
+  const handleOptionBlur = useCallback(
+    (id: string) => {
+      setOptions(prev => {
+        const index = prev.findIndex(opt => opt.id === id);
+        if (index === -1) {
+          return prev;
+        }
+        const isLast = index === prev.length - 1;
+        const isEmpty = !prev[index].value.trim();
+        const canRemove = prev.length > POLL_OPTIONS_MIN_COUNT;
+
+        if (!isLast && isEmpty && canRemove) {
+          const updated = [...prev];
+          updated.splice(index, 1);
+          return updated;
+        }
+        return prev;
+      });
+    },
+    []
   );
 
   const handleEnterKey = useCallback(
@@ -339,6 +348,7 @@ export function PollCreateModal({
                   moduleClassName="PollCreateModalInput"
                   value={option.value}
                   onChange={value => handleOptionChange(option.id, value)}
+                  onBlur={() => handleOptionBlur(option.id)}
                   onEnter={e => handleEnterKey(e, index)}
                   placeholder={i18n('icu:PollCreateModal__optionPlaceholder', {
                     number: String(index + 1),


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7608 — Clearing all text from a poll option immediately removes it and shifts focus to the next option, making it impossible to retype the option content.

> Note: A previous PR (#7614) addressed the same issue with a similar approach but was closed by the stale bot due to inactivity, not due to any objection to the approach.

**Root cause:** In `PollCreateModal`, the `computeOptionsAfterChange` function removed non-last empty options immediately on every `onChange` event (keystroke). This meant that as soon as the last character was deleted, the option vanished.

**Fix:** Moved the empty-option cleanup from the `onChange` handler to a new `onBlur` handler. Options are only removed when the user moves focus away from an empty field. Empty options are already filtered out at send time (`nonEmptyOptions` filter on line 274), so this does not affect poll validity.

**Test approach:**
- Manual testing: created polls, cleared option text, verified option persists while focused, removed on blur
- Verified empty options are filtered at send time