### PR TITLE
Disable drag region when Axo menus are open

### DIFF
--- a/ts/axo/AxoContextMenu.dom.tsx
+++ b/ts/axo/AxoContextMenu.dom.tsx
@@ -93,6 +93,14 @@ export namespace AxoContextMenu {
       [onOpenChange]
     );
 
+    useEffect(() => {
+      if (open) {
+        document.body.classList.add('context-menu-open');
+        return () => document.body.classList.remove('context-menu-open');
+      }
+      return undefined;
+    }, [open]);
+
     const context = useMemo(() => {
       return { open };
     }, [open]);

--- a/ts/axo/AxoDropdownMenu.dom.tsx
+++ b/ts/axo/AxoDropdownMenu.dom.tsx
@@ -113,6 +113,14 @@ export namespace AxoDropdownMenu {
       [onOpenChange]
     );
 
+    useEffect(() => {
+      if (open) {
+        document.body.classList.add('context-menu-open');
+        return () => document.body.classList.remove('context-menu-open');
+      }
+      return undefined;
+    }, [open]);
+
     const context = useMemo((): RootContextType => {
       return { open };
     }, [open]);


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7798 — When the window is small, the message context menu (opened via three dots) can overlap with the conversation header. Menu items in the overlap area are not clickable because the header's `-webkit-app-region: drag` intercepts mouse events at the Electron/Chromium level, before CSS z-index ordering applies.

**Root cause:** The `draggable-region` SCSS mixin already has a `body.context-menu-open` rule that disables drag, but only the legacy `ContextMenu` component was toggling this class. The newer `AxoDropdownMenu` and `AxoContextMenu` (radix-ui based) were not.

**Fix:** Added a `useEffect` in both `AxoDropdownMenu.Root` and `AxoContextMenu.Root` that toggles `body.context-menu-open` when the menu opens/closes, matching the pattern used by the legacy `ContextMenu` component.

**Test approach:**
- Manual testing: opened context menu on messages near the top of the conversation, verified all items (including Reply, React) are clickable when overlapping the header