### PR TITLE
Render URLs as clickable links in poll option text

### DIFF
--- a/ts/components/conversation/poll-message/PollMessageContents.dom.tsx
+++ b/ts/components/conversation/poll-message/PollMessageContents.dom.tsx
@@ -14,6 +14,13 @@ import { PollVotesModal } from './PollVotesModal.dom.js';
 import { SpinnerV2 } from '../../SpinnerV2.dom.js';
 import { usePrevious } from '../../../hooks/usePrevious.std.js';
 import { UserText } from '../../UserText.dom.js';
+import { Linkify } from '../Linkify.dom.js';
+import { Emojify } from '../Emojify.dom.js';
+import type { RenderTextCallbackType } from '../../../types/Util.std.js';
+
+const renderNonLink: RenderTextCallbackType = ({ key, text }) => (
+  <Emojify key={key} text={text} />
+);
 
 function VotedCheckmark({
   isIncoming,
@@ -299,7 +306,7 @@ export function PollMessageContents({
               <div className={tw('flex min-w-0 flex-1 flex-col gap-1')}>
                 <div className={tw('flex items-start justify-between gap-3')}>
                   <span className={tw('min-w-0 type-body-large break-words')}>
-                    <UserText text={option} />
+                    <Linkify text={option} renderNonLink={renderNonLink} />
                   </span>
                   <div
                     className={tw(


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7796 — URLs in poll option text are displayed as plain text and are not clickable.

**Root cause:** Poll option text was rendered using `UserText`, which only handles emoji rendering and bidi isolation, without URL detection or linkification.

**Fix:** Replaced `UserText` with `Linkify` + `Emojify` for poll option text, following the same pattern used by `GroupDescriptionText`. URLs are now detected and rendered as clickable `<a>` tags. Clicking a link opens it in the system browser via Electron's `will-navigate` handler.

The poll question continues to use `UserText` since linkifying the question text could be confusing (it's not an actionable element).

**Test approach:**
- Manual testing: created polls with URLs in option text, verified URLs render as links and open in browser