### PR TITLE
Fix dim metadata on outgoing sticker messages

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -1206,6 +1206,11 @@ $message-padding-horizontal: 12px;
     color: light-dark(variables.$color-gray-60, variables.$color-gray-25);
   }
 
+  &--sticker#{&}--outgoing,
+  &--outline-only-bubble#{&}--outgoing {
+    color: variables.$color-white-alpha-80;
+  }
+
   &--with-image-no-caption {
     color: light-dark(variables.$color-white, variables.$color-white-alpha-80);
   }


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7654 — Read receipt indicators, timestamps, and status icons on outgoing sticker messages are very dim/hard to read in dark mode.

**Root cause:** The `.module-message__metadata--sticker` CSS rule overrides the bright outgoing color (`white-alpha-80`) with a dim gray (`gray-25` in dark mode). Both `--outgoing` and `--sticker` modifiers have equal specificity, but `--sticker` appears later in the stylesheet, so it always wins.

**Fix:** Added a higher-specificity combined selector for elements with both `--sticker` + `--outgoing` (and `--outline-only-bubble` + `--outgoing`) that restores the bright outgoing color. Status icons already use `currentColor`, so they inherit the fix automatically.

**Test approach:**
- Manual testing: sent sticker messages, verified timestamps and read receipts are bright/visible in dark mode for outgoing stickers
- Verified incoming sticker metadata remains dim (correct behavior - no background bubble)