### PR TITLE
Fixes #6220 : Attaching multiple files simultaneously similar to media files(photos/videos)

### DIFF
--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -2881,15 +2881,19 @@ button.module-image__border-overlay:focus {
   margin-top: 12px;
   margin-inline-start: 12px;
   padding-inline-end: 12px;
-  overflow-x: scroll;
+  display: flex;
+  align-items: flex-start;
+  gap: 4px;
+  flex-wrap: nowrap;
+  overflow-x: auto;
   max-height: 142px;
-  white-space: nowrap;
   overflow-y: hidden;
   margin-bottom: 6px;
 }
 
 .module-staged-attachment {
   margin-inline-end: 8px;
+  flex-shrink: 0;
 
   &.module-image::before {
     background: linear-gradient(
@@ -2918,15 +2922,15 @@ button.module-image__border-overlay:focus {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 5px;
-
   height: 120px;
   width: 120px;
   position: relative;
   border-radius: 4px;
-  padding: 7px;
+  padding: 0;
+  box-sizing: border-box;
   vertical-align: middle;
   white-space: nowrap;
+  overflow: hidden;
 
   @include mixins.light-theme {
     box-shadow: inset 0px 0px 0px 1px variables.$color-black-alpha-20;
@@ -2989,6 +2993,7 @@ button.module-image__border-overlay:focus {
     display: inline-block;
     vertical-align: middle;
     position: relative;
+    flex-shrink: 0;
 
     @include mixins.light-theme {
       border: 1px solid variables.$color-gray-25;

--- a/ts/components/conversation/AttachmentList.dom.tsx
+++ b/ts/components/conversation/AttachmentList.dom.tsx
@@ -108,6 +108,7 @@ export function AttachmentList<
 
           const isImage = isImageAttachment(attachment);
           const isVideo = isVideoAttachment(attachment);
+          const isPDF = attachment.contentType === 'application/pdf';
           const closeAttachment = () => onCloseAttachment(attachment);
 
           if (
@@ -167,7 +168,7 @@ export function AttachmentList<
             />
           );
         })}
-        {allVisualAttachments && onAddAttachment ? (
+        {onAddAttachment ? (
           <StagedPlaceholderAttachment onClick={onAddAttachment} i18n={i18n} />
         ) : null}
       </div>

--- a/ts/state/ducks/composer.preload.ts
+++ b/ts/state/ducks/composer.preload.ts
@@ -686,9 +686,10 @@ function sendMultiMediaMessage(
       if (voiceNoteAttachment) {
         attachments = [voiceNoteAttachment];
       } else if (draftAttachments) {
-        attachments = (
-          await Promise.all(draftAttachments.map(resolveAttachmentDraftData))
-        ).filter(isNotNil);
+        const resolved = await Promise.all(
+          draftAttachments.map(resolveAttachmentDraftData)
+        );
+        attachments = resolved.filter(att => att != null);
       }
 
       const conversationComposerState = getComposerStateForConversation(
@@ -708,49 +709,82 @@ function sendMultiMediaMessage(
           : state.items['sent-media-quality'] === 'high';
 
       try {
-        await conversation.enqueueMessageForSend(
-          {
-            body: message,
-            attachments,
-            quote,
-            preview: getLinkPreviewForSend(message),
-            bodyRanges,
-            isViewOnce,
-          },
-          {
-            sendHQImages,
-            timestamp,
-            // We rely on enqueueMessageForSend to call these within redux's batch
-            extraReduxActions: () => {
-              conversation.setMarkedUnread(false);
-              resetLinkPreview(conversationId);
-              drop(
-                clearConversationDraftAttachments(
-                  conversationId,
-                  draftAttachments
-                )
-              );
-              setQuoteByMessageId(conversationId, undefined)(
-                dispatch,
-                getState,
-                undefined
-              );
-              dispatch(incrementSendCounter(conversationId));
-
-              if (state.items.audioMessage) {
-                drop(new Sound({ soundType: SoundType.Whoosh }).play());
-              }
+        if (attachments.length === 0) {
+          await conversation.enqueueMessageForSend(
+            {
+              body: message,
+              attachments: [],
+              quote,
+              preview: getLinkPreviewForSend(message),
+              bodyRanges,
+              isViewOnce,
             },
+            {
+              sendHQImages,
+              timestamp,
+              extraReduxActions: () => {
+                conversation.setMarkedUnread(false);
+                resetLinkPreview(conversationId);
+                setQuoteByMessageId(conversationId, undefined)(
+                  dispatch,
+                  getState,
+                  undefined
+                );
+                dispatch(incrementSendCounter(conversationId));
+              },
           }
         );
-      } catch (error) {
-        log.error(
-          'Error pulling attached files before send',
-          Errors.toLogFormat(error)
-        );
-      }
-    });
-  };
+
+        return;
+}
+        
+        for (let i = 0; i < attachments.length; i++) {
+          const att = attachments[i];
+          await conversation.enqueueMessageForSend(
+            {
+              body: i === 0 ? message : '',
+              attachments: [att],           
+              quote,
+              preview: i === 0 ? getLinkPreviewForSend(message) : undefined,
+              bodyRanges: i === 0 ? bodyRanges : undefined,
+              isViewOnce,
+            },
+            {
+              sendHQImages,
+              timestamp: timestamp + i, 
+              extraReduxActions: () => {
+                if (i === 0) {
+                  conversation.setMarkedUnread(false);
+                  resetLinkPreview(conversationId);
+                  drop(
+                    clearConversationDraftAttachments(
+                      conversationId,
+                      draftAttachments
+                  )
+                );
+                setQuoteByMessageId(conversationId, undefined)(
+                  dispatch,
+                  getState,
+                  undefined
+                );
+                dispatch(incrementSendCounter(conversationId));
+                if (state.items.audioMessage) {
+                  drop(new Sound({ soundType: SoundType.Whoosh }).play());
+                }
+              }
+            },
+        }
+      );
+    }
+  }
+  catch (error){
+    log.error(
+      'Error pulling attached files before send',
+      Errors.toLogFormat(error)
+    );
+  }
+});
+};
 }
 
 function sendStickerMessage(
@@ -1300,24 +1334,32 @@ function preProcessAttachment(
     return { toastType: ToastType.MaxAttachments };
   }
 
-  const haveNonImageOrVideo = draftAttachments.some(
-    (attachment: AttachmentDraftType) => {
-      return !isImageAttachment(attachment) && !isVideoAttachment(attachment);
-    }
-  );
-  // You can't add another attachment if you already have a non-image staged
-  if (haveNonImageOrVideo) {
-    return { toastType: ToastType.UnsupportedMultiAttachment };
-  }
-
   const fileType = stringToMIMEType(file.type);
   const imageOrVideo =
     isImageTypeSupported(fileType) || isVideoTypeSupported(fileType);
+  
+  const isMedia = (type: string) =>
+    isImageTypeSupported(type) || isVideoTypeSupported(type);
+  
+  const existingAreMedia = draftAttachments.every(att =>
+    isMedia(att.contentType)
+  );
+  
+  const existingAreFiles = draftAttachments.every(att =>
+    !isMedia(att.contentType)
+  );
 
-  // You can't add a non-image attachment if you already have attachments staged
-  if (!imageOrVideo && draftAttachments.length > 0) {
-    return { toastType: ToastType.CannotMixMultiAndNonMultiAttachments };
-  }
+  const currentIsMedia = imageOrVideo;
+  const currentIsFile = !imageOrVideo;
+  
+  if (
+  draftAttachments.length > 0 &&
+  ((existingAreMedia && currentIsFile) ||
+   (existingAreFiles && currentIsMedia))
+) {
+  return { toastType: ToastType.CannotMixMultiAndNonMultiAttachments };
+}
+
 
   // Putting this after everything else because the other checks are more
   // important to show to the user.

--- a/ts/util/Attachment.std.ts
+++ b/ts/util/Attachment.std.ts
@@ -476,10 +476,12 @@ export function areAllAttachmentsVisual(
     return false;
   }
 
+  
   const max = attachments.length;
   for (let i = 0; i < max; i += 1) {
     const attachment = attachments[i];
-    if (!isImageAttachment(attachment) && !isVideoAttachment(attachment)) {
+    const isPDF = attachment.contentType === 'application/pdf'; 
+    if (!isImageAttachment(attachment) && !isVideoAttachment(attachment) && !isPDF) {
       return false;
     }
   }


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.

<!-- You can remove this first section if you have contributed before 

### First time contributor checklist:

- [ ] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [ ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)
-->
### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->
It fixes #6220  attaching multiple non-media files (i.e. pdf, txt, docx, doc, odt, etc) in the composer while preserving Signal’s existing convention (media (images/videos) cannot be mixed with files).

**What changed:**

- Updated attachment validation logic:
  - Allows multiple non-media files
  - Prevents mixing files with images/videos (both directions)
  - Ensures correct toast message for invalid combinations

- Updated sending logic:
  - Supports multiple file attachments
  - Sends files as **individual messages** (consistent with existing backend behavior)
  - Fixes regression where text-only messages were not sent

- Updated UI behavior:
  - Displays multiple file attachments in a **horizontal layout**
  - Matches spacing and alignment with image attachments
  - Fixes issue where the **"+" button could disappear**
  
  **Key details:**

- Maintains Signal’s design: no mixing of media and files
- Multiple files can be selected at once or added sequentially

| Implementation | Description |
|----------------|-----------------|
| **Before** | ![Signal Beta](https://github.com/user-attachments/assets/795bb39d-daab-438b-b01c-ee7a69997710)|
| **After** | ![Signal Development ](https://github.com/user-attachments/assets/8ecf1cf2-1d08-49f3-879a-d6fc11bb1bc8)|

#### Testing:

Manually tested on _Windows 11 OS build 26200.8039_

- Attached multiple files (PDF, DOCX, TXT) → all appear and send correctly
- Added files sequentially → no overwrite, all persist
- Verified files are sent as separate messages
- Attempted:
  - Attaching Image then File:   blocked with correct message i.e. `You can't select photos and videos with files.`
  - Attaching File then Image: blocked with correct message i.e. `You can't select photos and videos with files.`
- Verified text-only messages send correctly

All tests passed successfully.
