### PR TITLE
Fix RTL message alignment and add RTL regression stories

### DIFF
--- a/ts/components/conversation/Message.dom.tsx
+++ b/ts/components/conversation/Message.dom.tsx
@@ -2484,7 +2484,6 @@ export class Message extends React.PureComponent<Props, State> {
 
     return (
       <div // oxlint-disable-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions
-        dir="ltr"
         className={classNames(
           'module-message__text',
           `module-message__text--${direction}`,

--- a/ts/components/conversation/TimelineMessage.dom.stories.tsx
+++ b/ts/components/conversation/TimelineMessage.dom.stories.tsx
@@ -45,6 +45,10 @@ import { BadgeCategory } from '../../badges/BadgeCategory.std.ts';
 import { PaymentEventKind } from '../../types/Payment.std.ts';
 import type { RenderAudioAttachmentProps } from '../../state/smart/renderAudioAttachment.preload.tsx';
 import type { PollVoteWithUserType } from '../../state/selectors/message.preload.ts';
+import type { IntlShape } from 'react-intl';
+
+// Pull the actual localized strings from the project's Arabic dictionary
+import arMessages from '../../../_locales/ar/messages.json';
 
 const { isBoolean, noop } = lodash;
 
@@ -271,7 +275,7 @@ const createProps = (overrideProps: Partial<Props> = {}): Props => ({
   getPreferredBadge: overrideProps.getPreferredBadge || (() => undefined),
   giftBadge: overrideProps.giftBadge,
   handleDebugMessage: action('handleDebugMessage'),
-  i18n,
+  i18n: overrideProps.i18n || i18n,
   platform: 'darwin',
   id: overrideProps.id ?? 'random-message-id',
   // renderingContext: 'storybook',
@@ -428,6 +432,12 @@ PlainMessage.args = {
 export const PlainRtlMessage = Template.bind({});
 PlainRtlMessage.args = {
   text: 'الأسانسير، علشان القطط ماتاكلش منها. وننساها، ونعود الى أوراقنا موصدين الباب بإحكام. نتنحنح، ونقول: البتاع. كلمة تدلّ على لا شيء، وعلى كلّ شيء. وهي مركز أبحاث شعبية كثيرة، تتعجّب من غرابتها والقومية المصرية الخاصة التي تعكسها، الى جانب الشيء الكثير من العفوية وحلاوة الروح. نعم، نحن قرأنا وسمعنا وعرفنا كل هذا. لكنه محلّ اهتمامنا اليوم لأسباب غير تلك الأسباب. كذلك، فإننا لعاقدون عزمنا على أن نتجاوز قضية الفصحى والعامية، وثنائية النخبة والرعاع، التي كثيراً ما ينحو نحوها الحديث عن الكلمة المذكورة. وفوق هذا كله، لسنا بصدد تفسير معاني "البتاع" كما تأتي في قصيدة الحاج أحمد فؤاد نجم، ولا التحذلق والتفذلك في الألغاز والأسرار المكنونة. هذا البتاع - أم هذه البت',
+  textDirection: TextDirection.RightToLeft,
+};
+
+export const MixedRtlAndLtrMessage = Template.bind({});
+MixedRtlAndLtrMessage.args = {
+  text: 'هذه رسالة مع بعض English text mixed in to check the directionality and spacing rules.',
   textDirection: TextDirection.RightToLeft,
 };
 
@@ -943,6 +953,59 @@ export function Deleted(): React.JSX.Element {
       {renderBothDirections(propsSending)}
     </>
   );
+}
+
+export function DeletedRtl(): React.JSX.Element {
+  // oxlint-disable-next-line typescript-eslint/no-explicit-any
+  const mockI18n = ((key: string, args?: any) => {
+    if (key === 'icu:message--deletedForEveryone--outgoing') {
+      // Use the narrowed key directly now that we've checked its value
+      return arMessages['icu:message--deletedForEveryone--outgoing']
+        .messageformat;
+    }
+    // oxlint-disable-next-line typescript-eslint/no-explicit-any
+    return i18n(key as any, args);
+  }) as typeof i18n;
+  Object.assign(mockI18n, i18n);
+
+  mockI18n.getIntl = () => {
+    const originalIntl = i18n.getIntl();
+    return {
+      ...originalIntl,
+      formatMessage: (
+        descriptor: Parameters<IntlShape['formatMessage']>[0],
+        values: Parameters<IntlShape['formatMessage']>[1]
+      ) => {
+        if (descriptor.id === 'icu:message--deletedForEveryone--incoming') {
+          // Mimic react-intl's behavior by splitting around the {name} variable
+          // and injecting the incoming React Component gracefully!
+          const formatString =
+            arMessages['icu:message--deletedForEveryone--incoming']
+              .messageformat;
+          const parts = formatString.split('{name}');
+          return (
+            <>
+              {parts[0]}
+              {values?.name as React.ReactNode}
+              {parts[1]}
+            </>
+          );
+        }
+        return originalIntl.formatMessage(descriptor, values);
+      },
+    } as unknown as IntlShape;
+  };
+
+  const propsSent = createProps({
+    conversationType: 'direct',
+    deletedForEveryone: true,
+    canForward: false,
+    status: 'sent',
+    textDirection: TextDirection.RightToLeft,
+    i18n: mockI18n,
+  });
+
+  return <>{renderBothDirections(propsSent)}</>;
 }
 
 export function DeletedByAdmin(): React.JSX.Element {


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [X ] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [ X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X ] My contribution is **not** related to translations.
- [ X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [ X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [ X] My changes are ready to be shipped to users

### Description

<!--
Describe briefly what your pull request changes. Focus on the value provided to users.

Does it address any outstanding issues in this project?
  https://github.com/signalapp/Signal-Desktop/issues?utf8=%E2%9C%93&q=is%3Aissue
  Reference an issue with the hash symbol: "#222"
  If you're fixing it, use something like "Fixes #222"

Please write a summary of your test approach:
  - What kind of manual testing did you do?
  - Did you write any new tests?
  - What operating systems did you test with? (please use specific versions: http://whatsmyos.com/)
  - What other devices did you test with? (other Desktop devices, Android, Android Simulator, iOS, iOS Simulator)
-->

Fixes issue #7819: 
This PR restores correct Right-To-Left (RTL) message alignment in the conversation view. A previous commit accidentally hardcoded `dir="ltr"` on the inner message text container, which overrode the dynamic directionality for Arabic and Hebrew messages.

What:
- Removed hardcoded `dir="ltr"` from the `.module-message__text` container in `Message.dom.tsx`.
- Updated Storybook `createProps` to allow `i18n` overrides.
- Added `MixedRtlAndLtrMessage` and `DeletedRtl` stories to `TimelineMessage.dom.stories.tsx`.

Why:
The hard-coded `dir="ltr"` attribute on the message text wrapper forced a Left-To-Right context regardless of the actual message content. Since the container uses `text-align: start`, this caused RTL messages (like Arabic or Hebrew) to incorrectly align to the left side of the bubble and broke the rendering of bidirectional punctuation.

This attribute was originally added to stabilize the "Delete for everyone" layout icon positioning. However, since those strings are now correctly wrapped in `<span dir="auto">`, the hard-coded attribute on the parent is no longer necessary and was causing wide-spread RTL regressions.

Technical Details:
OS: MacOS, but the testing was done on Storybook.

- Removing the hard-coded attribute allows the message text to properly inherit the directionality calculated by the message selectors.
- Manual Testing: Two stories were added: 
1. MixedRtlAndLtr: Mixes Arabic and English, in a similar way to the image in issue #7819's description, and verified the change. Before and after screenshots are attached.
2. The `DeletedRtl` story was added to verify that "Delete for everyone" remains stable in RTL contexts. It dynamically imports Arabic strings from `_locales/ar/messages.json` and mocks the `i18n.getIntl()` interface to simulate the production environment's usage of the `<I18n>` component. This ensures that the layout fix is verified against actual RTL text and character-order rules in automated visual tests.

## Before vs After Visual Comparison
### Before
<img width="1606" height="489" alt="Before" src="https://github.com/user-attachments/assets/978d5f07-eca8-4dd1-a923-a72a6be62b59" />
<img width="1613" height="442" alt="Deleted before" src="https://github.com/user-attachments/assets/f34fb48f-d3eb-478a-8112-9b17fa7cb391" />

### After
<img width="1611" height="535" alt="After" src="https://github.com/user-attachments/assets/39e07bc9-fc40-4ad1-b851-f763d960573d" />
<img width="1614" height="486" alt="Deleted after" src="https://github.com/user-attachments/assets/11c8a250-ee19-4ad0-a6d5-d38a5cb8ecf2" />




