### PR TITLE
fix: keyboard shortcut for chat menu

### DIFF
--- a/ts/services/addGlobalKeyboardShortcuts.preload.ts
+++ b/ts/services/addGlobalKeyboardShortcuts.preload.ts
@@ -223,40 +223,13 @@ export function addGlobalKeyboardShortcuts(): void {
       shiftKey &&
       (key === 'l' || key === 'L')
     ) {
-      const button = document.querySelector(
+      const trigger = document.querySelector<HTMLElement>(
         '.module-ConversationHeader__button--more'
       );
-      if (!button) {
-        return;
-      }
 
-      // Because the menu is shown at a location based on the initiating click, we need
-      //   to fake up a mouse event to get the menu to show somewhere other than (0,0).
-      const { x, y, width, height } = button.getBoundingClientRect();
-      const mouseEvent = document.createEvent('MouseEvents');
-      // Types do not match signature
-      mouseEvent.initMouseEvent(
-        'click',
-        true, // bubbles
-        false, // cancelable
-        // oxlint-disable-next-line typescript/no-explicit-any
-        null as any, // view
-        // oxlint-disable-next-line typescript/no-explicit-any
-        null as any, // detail
-        0, // screenX,
-        0, // screenY,
-        x + width / 2,
-        y + height / 2,
-        false, // ctrlKey,
-        false, // altKey,
-        false, // shiftKey,
-        false, // metaKey,
-        // oxlint-disable-next-line typescript/no-explicit-any
-        false as any, // button,
-        document.body
-      );
-
-      button.dispatchEvent(mouseEvent);
+      // The conversation header menu is a Radix DropdownMenu trigger, which
+      //   opens on pointerdown.
+      trigger?.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true }));
 
       event.preventDefault();
       event.stopPropagation();


### PR DESCRIPTION
### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7666 by updating the click handler for Radix

Duplicate of #7774 , but that includes formatting changes and hasn't been active/rebased. 
I'd love to get this change merged.

Tested on MacOS, Tahoe 26.5
