### PR TITLE
Fix window input offset after tray restore on Wayland/GNOME

### DIFF
--- a/app/SystemTrayService.main.ts
+++ b/app/SystemTrayService.main.ts
@@ -354,7 +354,13 @@ export function focusAndForceToTop(browserWindow: BrowserWindow): void {
   // On some versions of GNOME the window may not be on top when restored.
   // This trick should fix it.
   // Thanks to: https://github.com/Enrico204/Whatsapp-Desktop/commit/6b0dc86b64e481b455f8fce9b4d797e86d000dc1
-  browserWindow.setAlwaysOnTop(true);
+  // On Wayland, setAlwaysOnTop causes the compositor to misalign input hit-testing
+  // coordinates after restore (title bar drag jumps; click offset ~1 inch from corner).
+  if (!process.env.WAYLAND_DISPLAY) {
+    browserWindow.setAlwaysOnTop(true);
+  }
   browserWindow.focus();
-  browserWindow.setAlwaysOnTop(false);
+  if (!process.env.WAYLAND_DISPLAY) {
+    browserWindow.setAlwaysOnTop(false);
+  }
 }


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [\`main\`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A \`pnpm run ready\` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7640.

After hiding Signal to the system tray and clicking "Show" on Wayland/GNOME, attempting to drag the title bar causes the window to jump to the right, and mouse input is offset by approximately one inch from the actual top-left corner of the window.

**Root cause:** \`focusAndForceToTop\` uses a \`setAlwaysOnTop(true) → focus() → setAlwaysOnTop(false)\` sequence as a workaround for X11/GNOME window stacking. On Wayland, toggling \`setAlwaysOnTop\` causes the compositor to adjust the window's input hit-testing surface, creating a mismatch between where the window renders and where it accepts input events.

**Fix:** Gate the \`setAlwaysOnTop\` calls behind \`!process.env.WAYLAND_DISPLAY\` — the same env var check used elsewhere in the codebase (e.g. \`isWaylandEnabled()\`). On Wayland, \`focus()\` alone is sufficient to bring the window to the front.

**Testing:**
- \`test-node\`: 2157 passing, 0 failing
- \`test-electron\`: 1349 passing, 2 failing — both failures (\`scrollUtil\` floating-point precision) are pre-existing on \`main\` and unrelated to this change
- \`lint-prettier\`, \`lint-css\`, \`lint-deps\`, \`lint-intl\`: all pass
- \`lint-knip\`: pre-existing failure on \`main\` (missing \`vite\` in sticker-creator workspace), unrelated to this change
- X11 behavior is unchanged (guard is off when \`WAYLAND_DISPLAY\` is unset)