### PR TITLE
Open file attachments in default app instead of save dialog

### DIFF
--- a/app/main.main.ts
+++ b/app/main.main.ts
@@ -3195,7 +3195,21 @@ ipc.on('show-item-in-folder', (_event, folder) => {
 });
 
 ipc.handle('open-file-path', async (_event, filePath: string) => {
-  await shell.openPath(filePath);
+  if (!mainWindow) {
+    return;
+  }
+  const fileName = basename(filePath);
+  const { response } = await dialog.showMessageBox(mainWindow, {
+    type: 'question',
+    buttons: ['Open', 'Cancel'],
+    defaultId: 0,
+    cancelId: 1,
+    message: `Open "${fileName}"?`,
+    detail: 'This file will be opened with your default application.',
+  });
+  if (response === 0) {
+    await shell.openPath(filePath);
+  }
 });
 
 ipc.handle('show-save-dialog', async (_event, { defaultPath }) => {

--- a/app/main.main.ts
+++ b/app/main.main.ts
@@ -3194,6 +3194,10 @@ ipc.on('show-item-in-folder', (_event, folder) => {
   shell.showItemInFolder(folder);
 });
 
+ipc.handle('open-file-path', async (_event, filePath: string) => {
+  await shell.openPath(filePath);
+});
+
 ipc.handle('show-save-dialog', async (_event, { defaultPath }) => {
   if (!mainWindow) {
     log.warn('show-save-dialog: no main window');

--- a/stylesheets/_modules.scss
+++ b/stylesheets/_modules.scss
@@ -671,6 +671,56 @@ $message-padding-horizontal: 12px;
   cursor: pointer;
 }
 
+.module-message__simple-attachment-container {
+  position: relative;
+  width: 100%;
+}
+
+.module-message__simple-attachment__save-button {
+  @include mixins.button-reset;
+
+  & {
+    position: absolute;
+    top: 50%;
+    inset-inline-end: 8px;
+    transform: translateY(-50%);
+    width: 20px;
+    height: 20px;
+    opacity: 0;
+    transition: opacity 150ms;
+  }
+
+  .module-message__simple-attachment-container:hover & {
+    opacity: 1;
+  }
+
+  @include mixins.light-theme {
+    @include mixins.color-svg(
+      '../images/icons/v3/save/save.svg',
+      variables.$color-gray-45
+    );
+    &:hover {
+      @include mixins.color-svg(
+        '../images/icons/v3/save/save.svg',
+        variables.$color-gray-90
+      );
+    }
+  }
+
+  @include mixins.dark-theme {
+    @include mixins.color-svg(
+      '../images/icons/v3/save/save.svg',
+      variables.$color-gray-45
+    );
+    &:hover {
+      @include mixins.color-svg(
+        '../images/icons/v3/save/save.svg',
+        variables.$color-gray-02
+      );
+    }
+  }
+}
+
 .module-message__simple-attachment {
   @include mixins.button-reset;
 

--- a/ts/components/conversation/Message.dom.tsx
+++ b/ts/components/conversation/Message.dom.tsx
@@ -1187,6 +1187,7 @@ export class Message extends React.PureComponent<Props, State> {
       shouldCollapseAbove,
       shouldCollapseBelow,
       showEditHistoryModal,
+      saveAttachment,
       showLightbox,
       showMediaNoLongerAvailableToast,
       status,
@@ -1358,6 +1359,7 @@ export class Message extends React.PureComponent<Props, State> {
     // attachment. But we don't want the user to tab here unless that text exists.
     const tabIndex = text ? 0 : -1;
     return (
+      <div className="module-message__simple-attachment-container">
       <button
         className={classNames(
           'module-message__simple-attachment',
@@ -1464,6 +1466,18 @@ export class Message extends React.PureComponent<Props, State> {
           </div>
         </div>
       </button>
+      {firstAttachment.path && !isAttachmentNotAvailable && (
+        <button
+          type="button"
+          className="module-message__simple-attachment__save-button"
+          onClick={(e: React.MouseEvent) => {
+            e.stopPropagation();
+            saveAttachment(firstAttachment, timestamp);
+          }}
+          aria-label={i18n('icu:save')}
+        />
+      )}
+      </div>
     );
   }
 

--- a/ts/components/conversation/Message.dom.tsx
+++ b/ts/components/conversation/Message.dom.tsx
@@ -19,6 +19,7 @@ import type {
   ConversationType,
   ConversationTypeType,
   InteractionModeType,
+  OpenAttachmentInDefaultAppActionCreatorType,
   PushPanelForConversationActionType,
   SaveAttachmentActionCreatorType,
   SaveAttachmentsActionCreatorType,
@@ -386,6 +387,7 @@ export type PropsActions = {
     attachment: AttachmentType;
     messageId: string;
   }) => void;
+  openAttachmentInDefaultApp: OpenAttachmentInDefaultAppActionCreatorType;
   saveAttachment: SaveAttachmentActionCreatorType;
   saveAttachments: SaveAttachmentsActionCreatorType;
   showLightbox: (options: {
@@ -3218,7 +3220,7 @@ export class Message extends React.PureComponent<Props, State> {
     const {
       id,
       attachments,
-      saveAttachment,
+      openAttachmentInDefaultApp,
       timestamp,
       kickOffAttachmentDownload,
       attachmentDroppedDueToSize,
@@ -3251,7 +3253,7 @@ export class Message extends React.PureComponent<Props, State> {
         messageId: id,
       });
     } else {
-      saveAttachment(firstAttachment, timestamp);
+      openAttachmentInDefaultApp(firstAttachment, timestamp);
     }
   };
 

--- a/ts/components/conversation/TimelineItem.dom.stories.tsx
+++ b/ts/components/conversation/TimelineItem.dom.stories.tsx
@@ -73,6 +73,7 @@ const getDefaultProps = () => ({
   messageExpanded: action('messageExpanded'),
   showConversation: action('showConversation'),
   openGiftBadge: action('openGiftBadge'),
+  openAttachmentInDefaultApp: action('openAttachmentInDefaultApp'),
   saveAttachment: action('saveAttachment'),
   saveAttachments: action('saveAttachments'),
   showPinMessageDialog: action('showPinMessageDialog'),

--- a/ts/components/conversation/TimelineMessage.dom.stories.tsx
+++ b/ts/components/conversation/TimelineMessage.dom.stories.tsx
@@ -317,6 +317,7 @@ const createProps = (overrideProps: Partial<Props> = {}): Props => ({
       : overrideProps.readStatus,
   renderReactionPicker,
   renderAudioAttachment,
+  openAttachmentInDefaultApp: action('openAttachmentInDefaultApp'),
   saveAttachment: action('saveAttachment'),
   saveAttachments: action('saveAttachments'),
   setQuoteByMessageId: action('setQuoteByMessageId'),

--- a/ts/state/ducks/conversations.preload.ts
+++ b/ts/state/ducks/conversations.preload.ts
@@ -1,6 +1,7 @@
 // Copyright 2019 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { tmpdir } from 'node:os';
 import type { ThunkAction } from 'redux-thunk';
 import lodash from 'lodash';
 import { type PhoneNumber } from 'google-libphonenumber';
@@ -1227,6 +1228,7 @@ export const actions = {
   saveAttachment,
   saveAttachments,
   saveAttachmentFromMessage,
+  openAttachmentInDefaultApp,
   saveAvatarToDisk,
   scrollToMessage,
   scrollToOldestUnreadMention,
@@ -4183,6 +4185,30 @@ function saveAttachment(
           },
         },
       });
+    }
+  };
+}
+
+export type OpenAttachmentInDefaultAppActionCreatorType = ReadonlyDeep<
+  (attachment: AttachmentType, timestamp?: number) => unknown
+>;
+
+function openAttachmentInDefaultApp(
+  attachment: AttachmentType,
+  timestamp = Date.now()
+): ThunkAction<void, RootStateType, unknown, ShowToastActionType> {
+  return async () => {
+    const fullPath = await Attachment.save({
+      attachment,
+      getUnusedFilename,
+      readAttachmentData,
+      saveAttachmentToDisk,
+      timestamp,
+      baseDir: tmpdir(),
+    });
+
+    if (fullPath) {
+      await ipcRenderer.invoke('open-file-path', fullPath);
     }
   };
 }

--- a/ts/state/smart/TimelineItem.preload.tsx
+++ b/ts/state/smart/TimelineItem.preload.tsx
@@ -166,6 +166,7 @@ export const SmartTimelineItem = memo(function SmartTimelineItem(
     markAttachmentAsCorrupted,
     messageExpanded,
     onPinnedMessageRemove,
+    openAttachmentInDefaultApp,
     openGiftBadge,
     retryDeleteForEveryone,
     retryMessageSend,
@@ -297,6 +298,7 @@ export const SmartTimelineItem = memo(function SmartTimelineItem(
       sendPollVote={sendPollVote}
       renderItem={renderItem}
       returnToActiveCall={returnToActiveCall}
+      openAttachmentInDefaultApp={openAttachmentInDefaultApp}
       saveAttachment={saveAttachment}
       saveAttachments={saveAttachments}
       scrollToPollMessage={scrollToPollMessage}


### PR DESCRIPTION
## Summary

- **Click** a downloaded file attachment → shows a confirmation dialog ("Open [filename]?"), then opens it in the system default app
- **Hover + save icon** → a save icon fades in over the attachment on hover; clicking it shows the standard save-to-disk dialog

Previously, clicking a downloaded file attachment opened a save-to-disk dialog with no way to simply open the file. This PR changes the primary click action to open-in-default-app while preserving a convenient save option via the hover icon.

## Changes

- \`app/main.main.ts\` — \`open-file-path\` IPC handler: shows a native confirmation dialog via \`dialog.showMessageBox\`, then calls \`shell.openPath\`
- \`ts/state/ducks/conversations.preload.ts\` — \`openAttachmentInDefaultApp\` Redux thunk: decrypts attachment to OS temp dir, then invokes the IPC handler
- \`ts/components/conversation/Message.dom.tsx\` — click handler on generic attachments now calls \`openAttachmentInDefaultApp\`; adds a save icon button (using existing \`save.svg\`) that fades in on hover, wired to \`saveAttachment\`
- \`stylesheets/_modules.scss\` — styles for the save icon button with light/dark theme support

## Test plan

- [ ] Click a downloaded file attachment → confirmation dialog appears
- [ ] Confirm → file opens in the system default app
- [ ] Cancel → nothing happens
- [ ] Hover over a downloaded attachment → save icon appears
- [ ] Click save icon → save-to-disk dialog appears
- [ ] Not-yet-downloaded attachments still trigger download on click
- [ ] Images, audio, and video attachments are unaffected