### PR TITLE
[codex] Fix saving edited draft images

### DIFF
--- a/ts/components/CompositionArea.dom.tsx
+++ b/ts/components/CompositionArea.dom.tsx
@@ -1148,7 +1148,7 @@ export const CompositionArea = memo(function CompositionArea({
               convertDraftBodyRangesIntoHydrated
             }
             onClose={() => setAttachmentToEdit(undefined)}
-            onDone={({
+            onDone={async ({
               caption,
               captionBodyRanges,
               data,
@@ -1165,7 +1165,7 @@ export const CompositionArea = memo(function CompositionArea({
                 size: data.byteLength,
               };
 
-              addAttachment(conversationId, newAttachment);
+              await addAttachment(conversationId, newAttachment);
               setAttachmentToEdit(undefined);
 
               if (

--- a/ts/components/MediaEditor.dom.tsx
+++ b/ts/components/MediaEditor.dom.tsx
@@ -1459,8 +1459,6 @@ export function MediaEditor({
                     setEditMode(undefined);
                     setIsSaving(true);
 
-                    let data: Uint8Array<ArrayBuffer>;
-                    let blurHash: string;
                     try {
                       const renderFabricCanvas =
                         await cloneFabricCanvas(fabricCanvas);
@@ -1499,29 +1497,29 @@ export function MediaEditor({
                       const renderedCanvas =
                         renderFabricCanvas.toCanvasElement();
 
-                      data = await canvasToBytes(renderedCanvas);
+                      const data = await canvasToBytes(renderedCanvas);
 
                       const blob = new Blob([data], {
                         type: IMAGE_PNG,
                       });
 
-                      blurHash = await imageToBlurHash(blob);
+                      const blurHash = await imageToBlurHash(blob);
+
+                      await onDone({
+                        contentType: IMAGE_PNG,
+                        data,
+                        caption: caption !== '' ? caption : undefined,
+                        captionBodyRanges: captionBodyRanges ?? undefined,
+                        blurHash,
+                        isViewOnce: localIsViewOnce,
+                        isHighQuality: localIsHighQuality,
+                      });
                     } catch (err) {
                       onTryClose();
                       throw err;
                     } finally {
                       setIsSaving(false);
                     }
-
-                    onDone({
-                      contentType: IMAGE_PNG,
-                      data,
-                      caption: caption !== '' ? caption : undefined,
-                      captionBodyRanges: captionBodyRanges ?? undefined,
-                      blurHash,
-                      isViewOnce: localIsViewOnce,
-                      isHighQuality: localIsHighQuality,
-                    });
                   }}
                 >
                   {doneButtonLabel || i18n('icu:save')}

--- a/ts/test-node/util/writeDraftAttachment_test.preload.ts
+++ b/ts/test-node/util/writeDraftAttachment_test.preload.ts
@@ -1,0 +1,33 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+import { v4 as generateUuid } from 'uuid';
+
+import type { InMemoryAttachmentDraftType } from '../../types/Attachment.std.ts';
+import { APPLICATION_OCTET_STREAM } from '../../types/MIME.std.ts';
+import { deleteDraftAttachment } from '../../util/deleteDraftAttachment.preload.ts';
+import { writeDraftAttachment } from '../../util/writeDraftAttachment.preload.ts';
+
+describe('writeDraftAttachment', () => {
+  it('does not persist stale object URLs from in-memory draft edits', async () => {
+    const attachment: InMemoryAttachmentDraftType & { url: string } = {
+      clientUuid: generateUuid(),
+      contentType: APPLICATION_OCTET_STREAM,
+      data: new Uint8Array([1, 2, 3]),
+      pending: false,
+      path: 'old-draft-path',
+      size: 3,
+      url: 'attachment://stale-draft-url',
+    };
+
+    const result = await writeDraftAttachment(attachment);
+
+    try {
+      assert.notProperty(result, 'url');
+      assert.notEqual(result.path, attachment.path);
+    } finally {
+      await deleteDraftAttachment(result);
+    }
+  });
+});

--- a/ts/util/writeDraftAttachment.preload.ts
+++ b/ts/util/writeDraftAttachment.preload.ts
@@ -54,7 +54,7 @@ export async function writeDraftAttachment(
   }
 
   return {
-    ...omit(attachment, ['data', 'screenshotData']),
+    ...omit(attachment, ['data', 'screenshotData', 'url', 'incrementalUrl']),
     ...local,
     screenshot: localScreenshot
       ? {


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

This fixes edited draft images being able to reopen from stale object URLs instead of the newly written draft file. That could make a saved paint/text/crop edit appear lost on a later edit because the media editor loaded the previous draft URL.

The media editor now waits for the parent save handler to finish before dismissing, so the draft rewrite completes before the user can continue with a stale attachment. Draft attachment writes also drop transient `url` and `incrementalUrl` fields; draft URLs are regenerated from the saved draft path when attachments are resolved for display.

Validation:

- Added `writeDraftAttachment` regression coverage for stale draft URLs.
- `pnpm exec cross-env NODE_ENV=test NODE_OPTIONS='--import=tsx' LANG=en-us electron-mocha --timeout 10000 --extension ts,tsx,js,mjs --file ts/test-node/setup.preload.ts ts/test-node/util/writeDraftAttachment_test.preload.ts`
- `pnpm exec oxlint ts/components/CompositionArea.dom.tsx ts/components/MediaEditor.dom.tsx ts/util/writeDraftAttachment.preload.ts ts/test-node/util/writeDraftAttachment_test.preload.ts`
- `pnpm run check:types`
- `pnpm run ready`

Note: local commands emitted the repo engine warning because this machine is on Node v25.2.1 while the repo requests Node 24.15.0. `pnpm run ready` passed after installing the nested `sticker-creator` dependencies from its own lockfile.
