### PR TITLE
changed "Than" to "Then" in contributor instruction file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ post about your plans. That way you'll get feedback from the users most likely t
 appreciate your changes. And we may tell you not to move forward with changes, because we
 have other plans for the issue itself or that area of the code.
 
-Than, once you've spent some time planning your solution, please consider going back
+Then, once you've spent some time planning your solution, please consider going back
 to the issue and talking about your approach. We'd be happy to provide feedback.
 
 The PRs most likely to be merged are the ones that fix issues with real user impact,


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description
changed "Than" to "Then" in contributor instruction file