### PR TITLE
Skip `edit-previous` shortcut during IME composition

### DIFF
--- a/ts/hooks/useKeyboardShortcuts.dom.tsx
+++ b/ts/hooks/useKeyboardShortcuts.dom.tsx
@@ -305,6 +305,13 @@ export function useEditLastMessageSent(
         return false;
       }
 
+      // Ignore keys that are part of an active IME composition (e.g. when
+      // navigating the Japanese transliteration candidate menu with ArrowUp).
+      // keyCode 229 covers Safari/older browsers that don't set `isComposing`.
+      if (ev.isComposing || ev.keyCode === 229) {
+        return false;
+      }
+
       const key = KeyboardLayout.lookup(ev);
 
       // None of the modifiers should be pressed


### PR DESCRIPTION
### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

When in an IME composition (i.e. selecting a Japanese transliteration), Signal's `edit-previous` shortcut will still be callable, as described in the #7898 issue (with a video example)

This PR fixes #7898 and was tested locally:

https://github.com/user-attachments/assets/3c328c6c-ae99-4cdd-8323-1e3529c1dc1b

