### PR TITLE
Ignore non-content nodes in copy handling

### DIFF
--- a/ts/quill/signal-clipboard/util.dom.ts
+++ b/ts/quill/signal-clipboard/util.dom.ts
@@ -4,6 +4,9 @@
 import { getFunEmojiElementValue } from '../../components/fun/FunEmoji.dom.tsx';
 
 const QUILL_EMBED_GUARD = '\uFEFF';
+const COPYABLE_TEXT_CONTAINER_SELECTOR = '.ql-editor, .module-message__text';
+const IGNORED_CLIPBOARD_SELECTOR =
+  'script, style, noscript, template, button, [hidden]';
 
 export function createEventHandler({
   deleteSelection,
@@ -35,14 +38,29 @@ export function createEventHandler({
 
     // Create synthetic html with the full selection we can put into clipboard
     const container = document.createElement('div');
+    const hasCopyableTextSelection =
+      selectionIntersectsCopyableTextContainer(selection);
     for (let i = 0, max = selection.rangeCount; i < max; i += 1) {
       const range = selection.getRangeAt(i);
+      if (rangeIsInIgnoredClipboardElement(range)) {
+        continue;
+      }
       container.appendChild(getRangeWithContainer(range));
     }
 
-    // We fail over to selection.toString() because we can't pull values from the DOM if
-    //   the selection is within an <input/> or <textarea/>. But the browser can!
-    const plaintext = getStringFromNode(container) || selection.toString();
+    removeIgnoredClipboardElements(container);
+
+    const inputSelectionText = getInputSelectionText();
+    const plaintext = inputSelectionText || getStringFromNode(container);
+    if (
+      !plaintext ||
+      (!inputSelectionText && !plaintext.trim() && !hasCopyableTextSelection)
+    ) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
     // Note: we can't leave text/plain alone and just add text/signal; if we update
     //   clipboardData at all, all other data is reset.
     event.clipboardData?.setData('text/plain', plaintext);
@@ -56,6 +74,58 @@ export function createEventHandler({
     event.preventDefault();
     event.stopPropagation();
   };
+}
+
+function removeIgnoredClipboardElements(container: HTMLElement): void {
+  for (const element of container.querySelectorAll(
+    IGNORED_CLIPBOARD_SELECTOR
+  )) {
+    element.remove();
+  }
+}
+
+function getInputSelectionText(): string {
+  const { activeElement } = document;
+  if (
+    !(
+      activeElement instanceof HTMLInputElement ||
+      activeElement instanceof HTMLTextAreaElement
+    )
+  ) {
+    return '';
+  }
+
+  const start = activeElement.selectionStart ?? 0;
+  const end = activeElement.selectionEnd ?? start;
+
+  return activeElement.value.slice(start, end);
+}
+
+function rangeIsInIgnoredClipboardElement(range: Range): boolean {
+  const { commonAncestorContainer } = range;
+  const element = isHTMLElement(commonAncestorContainer)
+    ? commonAncestorContainer
+    : commonAncestorContainer.parentElement;
+
+  return element?.closest(IGNORED_CLIPBOARD_SELECTOR) != null;
+}
+
+function selectionIntersectsCopyableTextContainer(
+  selection: Selection
+): boolean {
+  const containers = document.querySelectorAll(
+    COPYABLE_TEXT_CONTAINER_SELECTOR
+  );
+  for (let i = 0, max = selection.rangeCount; i < max; i += 1) {
+    const range = selection.getRangeAt(i);
+    for (const container of containers) {
+      if (range.intersectsNode(container)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 function isHTMLElement(node: Node): node is HTMLElement {

--- a/ts/test-electron/quill/signal-clipboard_test.dom.ts
+++ b/ts/test-electron/quill/signal-clipboard_test.dom.ts
@@ -6,6 +6,7 @@ import { Delta } from '@signalapp/quill-cjs';
 import type Quill from '@signalapp/quill-cjs';
 
 import { SignalClipboard } from '../../quill/signal-clipboard/index.dom.ts';
+import { createEventHandler } from '../../quill/signal-clipboard/util.dom.ts';
 import { QuillFormattingStyle } from '../../quill/formatting/menu.dom.tsx';
 
 class MockQuill {
@@ -86,6 +87,28 @@ function createMockClipboardEvent(
   return event;
 }
 
+function createMockCopyEvent(): {
+  clipboardData: Map<string, string>;
+  event: ClipboardEvent;
+} {
+  const clipboardData = new Map<string, string>();
+  const event = new Event('copy', {
+    bubbles: true,
+    cancelable: true,
+  }) as ClipboardEvent;
+
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      setData: (format: string, value: string) => {
+        clipboardData.set(format, value);
+      },
+    } as unknown as DataTransfer,
+    writable: false,
+  });
+
+  return { clipboardData, event };
+}
+
 function createMockQuillWithContent(
   content: string,
   hasStrike = false
@@ -105,6 +128,159 @@ function createMockQuillWithContent(
 
   return mockQuill;
 }
+
+function selectNodeContents(node: Node): void {
+  const selection = window.getSelection();
+  assert.exists(selection);
+
+  const range = document.createRange();
+  range.selectNodeContents(node);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function selectTextRange(node: Text, start: number, end: number): void {
+  const selection = window.getSelection();
+  assert.exists(selection);
+
+  const range = document.createRange();
+  range.setStart(node, start);
+  range.setEnd(node, end);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+describe('createEventHandler', () => {
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges();
+    document.body.replaceChildren();
+  });
+
+  it('does not copy non-content selections', () => {
+    const container = document.createElement('div');
+    container.innerHTML = `
+      <button type="button">Record audio</button>
+      <script>window.startApp();</script>
+    `;
+    document.body.append(container);
+    selectNodeContents(container);
+
+    const { clipboardData, event } = createMockCopyEvent();
+    createEventHandler({ deleteSelection: false })(event);
+
+    assert.isTrue(event.defaultPrevented);
+    assert.isFalse(clipboardData.has('text/plain'));
+    assert.isFalse(clipboardData.has('text/signal'));
+  });
+
+  it('does not copy text selected directly inside buttons', () => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = 'Record audio';
+    document.body.append(button);
+    selectNodeContents(button);
+
+    const { clipboardData, event } = createMockCopyEvent();
+    createEventHandler({ deleteSelection: false })(event);
+
+    assert.isTrue(event.defaultPrevented);
+    assert.isFalse(clipboardData.has('text/plain'));
+    assert.isFalse(clipboardData.has('text/signal'));
+  });
+
+  it('does not copy empty selections', () => {
+    window.getSelection()?.removeAllRanges();
+
+    const { clipboardData, event } = createMockCopyEvent();
+    createEventHandler({ deleteSelection: false })(event);
+
+    assert.isTrue(event.defaultPrevented);
+    assert.isFalse(clipboardData.has('text/plain'));
+    assert.isFalse(clipboardData.has('text/signal'));
+  });
+
+  it('omits non-content elements from copied text and html', () => {
+    const container = document.createElement('div');
+    container.innerHTML =
+      '<span>Hello </span>' +
+      '<script>window.startApp();</script>' +
+      '<style>.hidden { display: none; }</style>' +
+      '<span hidden>hidden text</span>' +
+      '<button type="button">Record audio</button>' +
+      '<span>world</span>';
+    document.body.append(container);
+    selectNodeContents(container);
+
+    const { clipboardData, event } = createMockCopyEvent();
+    createEventHandler({ deleteSelection: false })(event);
+
+    assert.strictEqual(clipboardData.get('text/plain'), 'Hello world');
+    assert.notInclude(clipboardData.get('text/signal'), 'window.startApp');
+    assert.notInclude(clipboardData.get('text/signal'), 'hidden text');
+    assert.notInclude(clipboardData.get('text/signal'), 'Record audio');
+  });
+
+  it('copies aria-hidden text from Signal message content', () => {
+    const container = document.createElement('div');
+    container.innerHTML =
+      '<div class="module-message__text">' +
+      '<span aria-hidden="true">spoiler text</span>' +
+      '</div>';
+    document.body.append(container);
+    selectNodeContents(container);
+
+    const { clipboardData, event } = createMockCopyEvent();
+    createEventHandler({ deleteSelection: false })(event);
+
+    assert.strictEqual(clipboardData.get('text/plain'), 'spoiler text\n');
+    assert.include(clipboardData.get('text/signal'), 'spoiler text');
+  });
+
+  it('copies selected text from inputs', () => {
+    const input = document.createElement('input');
+    input.value = 'hello world';
+    document.body.append(input);
+
+    input.focus();
+    input.setSelectionRange(0, 5);
+
+    const { clipboardData, event } = createMockCopyEvent();
+    createEventHandler({ deleteSelection: false })(event);
+
+    assert.strictEqual(clipboardData.get('text/plain'), 'hello');
+  });
+
+  it('copies selected whitespace from inputs', () => {
+    const input = document.createElement('input');
+    input.value = 'hello   world';
+    document.body.append(input);
+
+    input.focus();
+    input.setSelectionRange(5, 8);
+
+    const { clipboardData, event } = createMockCopyEvent();
+    createEventHandler({ deleteSelection: false })(event);
+
+    assert.strictEqual(clipboardData.get('text/plain'), '   ');
+  });
+
+  it('copies selected whitespace from Signal text containers', () => {
+    const editor = document.createElement('div');
+    editor.className = 'ql-editor';
+    const line = document.createElement('div');
+    const text = document.createTextNode('hello   world');
+    line.append(text);
+    editor.append(line);
+    document.body.append(editor);
+
+    selectTextRange(text, 5, 8);
+
+    const { clipboardData, event } = createMockCopyEvent();
+    createEventHandler({ deleteSelection: false })(event);
+
+    assert.strictEqual(clipboardData.get('text/plain'), '   ');
+  });
+});
 
 describe('SignalClipboard', () => {
   let mockQuill: MockQuill;


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

Fixes #7903

This keeps button-only and other non-content DOM selections from replacing the clipboard through Signal's copy handler.

The copy handler now filters known non-content nodes from Signal's synthetic clipboard data, including scripts, styles, templates, buttons, and hidden elements. It also keeps input and textarea selections working without using the broader DOM selection text as a fallback.

Testing:
- `pnpm run test-electron --grep "createEventHandler|SignalClipboard"`
- `pnpm run check:types`
- `pnpm run ready`

Local OS: macOS 26.5

Manual UI testing: not run on Ubuntu. This is covered with Electron DOM regression tests for the copy handler.
