### PR TITLE
accessibility: improve screen reader support for audio scrubber

### DIFF
--- a/ts/components/CompositionRecordingDraft.dom.tsx
+++ b/ts/components/CompositionRecordingDraft.dom.tsx
@@ -95,6 +95,7 @@ export function CompositionRecordingDraft({
       audioUrl={audioUrl}
       activeDuration={active?.duration}
       currentTime={active?.currentTime ?? 0}
+      isPlaying={active?.playing ?? false}
       width={state.width}
       onClick={onScrub}
       onScrub={onScrub}
@@ -132,6 +133,7 @@ type SizedWaveformScrubberProps = {
   // defined if we are playing
   activeDuration: number | undefined;
   currentTime: number;
+  isPlaying: boolean;
   onScrub: (progressAsRatio: number) => void;
   onClick: (progressAsRatio: number) => void;
 };
@@ -140,6 +142,7 @@ function SizedWaveformScrubber({
   audioUrl,
   activeDuration,
   currentTime,
+  isPlaying,
   onClick,
   onScrub,
   width,
@@ -165,6 +168,7 @@ function SizedWaveformScrubber({
       duration={duration}
       onClick={onClick}
       onScrub={onScrub}
+      isPlaying={isPlaying}
     />
   );
 }

--- a/ts/components/conversation/MessageAudio.dom.tsx
+++ b/ts/components/conversation/MessageAudio.dom.tsx
@@ -281,6 +281,7 @@ export function MessageAudio(props: Props): JSX.Element {
       barMaxHeight={BAR_MAX_HEIGHT}
       onClick={handleWaveformClick}
       onScrub={handleWaveformScrub}
+      isPlaying={isPlaying}
     />
   );
 

--- a/ts/components/conversation/WaveformScrubber.dom.tsx
+++ b/ts/components/conversation/WaveformScrubber.dom.tsx
@@ -5,6 +5,8 @@ import {
   useCallback,
   useRef,
   forwardRef,
+  useState,
+  useEffect,
   type JSX,
   type MouseEvent,
   type KeyboardEvent,
@@ -25,6 +27,7 @@ type Props = Readonly<{
   barMaxHeight: number;
   onClick: (positionAsRatio: number) => void;
   onScrub: (positionAsRatio: number) => void;
+  isPlaying?: boolean;
 }>;
 
 const BAR_COUNT = 47;
@@ -45,12 +48,25 @@ export const WaveformScrubber = forwardRef(function WaveformScrubber(
     duration,
     onClick,
     onScrub,
+    isPlaying = false,
   }: Props,
   ref
 ): JSX.Element {
   const refMerger = useRefMerger();
 
   const waveformRef = useRef<HTMLDivElement | null>(null);
+
+  const [announcedTime, setAnnouncedTime] = useState<number>(currentTime);
+
+  useEffect(() => {
+    if (!isPlaying) {
+      setAnnouncedTime(currentTime);
+    }
+  }, [currentTime, isPlaying]);
+
+  const handleFocus = useCallback(() => {
+    setAnnouncedTime(currentTime);
+  }, [currentTime]);
 
   // Clicking waveform moves playback head position and starts playback.
   const handleClick = useCallback(
@@ -69,9 +85,12 @@ export const WaveformScrubber = forwardRef(function WaveformScrubber(
         progress = 0;
       }
 
+      if (duration) {
+        setAnnouncedTime(progress * duration);
+      }
       onClick(progress);
     },
-    [waveformRef, onClick]
+    [waveformRef, onClick, duration]
   );
 
   // Keyboard navigation for waveform. Pressing keys moves playback head
@@ -103,6 +122,9 @@ export const WaveformScrubber = forwardRef(function WaveformScrubber(
     const positionIncrement = increment / duration;
     const newPosition = currentPosition + positionIncrement;
 
+    const targetPosition = Math.min(Math.max(0, newPosition), 1) * duration;
+    setAnnouncedTime(targetPosition);
+
     onScrub(newPosition);
   };
 
@@ -112,14 +134,15 @@ export const WaveformScrubber = forwardRef(function WaveformScrubber(
       className="WaveformScrubber"
       onClick={handleClick}
       onKeyDown={handleKeyDown}
+      onFocus={handleFocus}
       tabIndex={0}
       role="slider"
       aria-label={i18n('icu:MessageAudio--slider')}
       aria-orientation="horizontal"
-      aria-valuenow={currentTime}
+      aria-valuenow={announcedTime}
       aria-valuemin={0}
       aria-valuemax={duration}
-      aria-valuetext={durationToPlaybackText(currentTime)}
+      aria-valuetext={durationToPlaybackText(announcedTime)}
     >
       <Waveform
         peaks={peaks}


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This PR addresses the excessive screen reader verbosity issue when playing audio messages in Signal Desktop.

Fixes #7745

#### Issues Addressed & Steps to Replicate
- **The Problem:** When playing a voice message, the screen reader continuously reads the progress bar updates (elapsed time or percentage) out loud. This overlaps and completely drowns out the actual voice message, making it impossible to listen to it.
- **Steps to Replicate:**
  1. Turn on NVDA.
  2. Open a chat and play any voice message.
  3. Notice that the screen reader repeatedly announces the progress updates as the audio plays.
- **The Fix:** Added an `isPlaying` prop to track active playback. The `WaveformScrubber` now only updates `aria-valuenow` and `aria-valuetext` when the audio is paused/stopped or when the user actively interacts with the scrub controls.

#### Test approach
- **Manual testing:** Played and scrubbed voice notes and verified that progress updates are silent during playback, but correctly announced when pausing or manually navigating/scrubbing using the keyboard.
- **Operating system:** Windows 11 with NVDA (NonVisual Desktop Access).
