### PR TITLE
accessibility: silence relative timestamp screen reader announcements

### DIFF
--- a/ts/components/conversation/MessageMetadata.dom.tsx
+++ b/ts/components/conversation/MessageMetadata.dom.tsx
@@ -309,7 +309,7 @@ export const MessageMetadata = forwardRef<HTMLDivElement, Readonly<PropsType>>(
       return (
         <SizeObserver onSizeChange={onResize}>
           {measureRef => (
-            <div className={className} ref={refMerger(measureRef, ref)}>
+            <div className={className} ref={refMerger(measureRef, ref)} aria-live="off">
               {children}
             </div>
           )}
@@ -318,7 +318,7 @@ export const MessageMetadata = forwardRef<HTMLDivElement, Readonly<PropsType>>(
     }
 
     return (
-      <div className={className} ref={ref}>
+      <div className={className} ref={ref} aria-live="off">
         {children}
       </div>
     );


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [X] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

This PR addresses the excessive screen reader verbosity issue caused by automatic background message timestamp updates.

Fixes #7368
Fixes #7745

#### Issues Addressed & Steps to Replicate
- **The Problem:** Relative timestamps of sent messages (e.g., "now", "1m ago") are announced repeatedly by screen readers as time passes in the background, interrupting the user while reading or typing other messages.
- **Steps to Replicate:**
  1. Turn on NVDA.
  2. Open a chat with recently sent messages and remain idle.
  3. As time passes, notice that the screen reader automatically announces "1 minute", "2 minutes", etc., for the messages on the screen.
- **The Fix:** Added `aria-live="off"` to the metadata containers to silence automatic background relative timestamp updates.

#### Test approach
- **Manual testing:** Navigated chats with active messages and verified that relative timestamps no longer read out loud automatically in the background as time passes, but are still read when focusing on the message metadata.
- **Operating system:** Windows 11 with NVDA (NonVisual Desktop Access).
