### PR TITLE
Show jumbomoji for space-separated emoji

### DIFF
--- a/ts/axo/emoji.std.ts
+++ b/ts/axo/emoji.std.ts
@@ -660,7 +660,13 @@ export namespace Emoji {
     // oxlint-disable-next-line typescript/no-unnecessary-qualifier
     for (const segment of Emoji.getSegments(input)) {
       if (segment.kind === 'text') {
-        return 0; // found other text
+        // tolerate spaces between/around emoji
+        for (const char of segment.value) {
+          if (char !== ' ') {
+            return 0; // found non-space text
+          }
+        }
+        continue; // ignore space-only segments
       }
       if (segment.kind === 'emoji') {
         count += 1;

--- a/ts/components/conversation/MessageBody.dom.stories.tsx
+++ b/ts/components/conversation/MessageBody.dom.stories.tsx
@@ -106,6 +106,22 @@ export function JumbomojiDisabledByText(): JSX.Element {
   return <MessageBody {...props} />;
 }
 
+export function JumbomojiSeparatedBySpaces(): JSX.Element {
+  const props = createProps({
+    text: '😹 😹 😹',
+  });
+
+  return <MessageBody {...props} />;
+}
+
+export function JumbomojiDisabledByNewline(): JSX.Element {
+  const props = createProps({
+    text: '😹\n😹',
+  });
+
+  return <MessageBody {...props} />;
+}
+
 export function TextPending(): JSX.Element {
   const props = createProps({
     text: 'Check out https://www.signal.org',

--- a/ts/test-node/axo/emoji_test.node.ts
+++ b/ts/test-node/axo/emoji_test.node.ts
@@ -690,6 +690,14 @@ describe('Emoji', () => {
       check('😀 a', false);
     });
 
+    it('returns true for a single emoji with surrounding spaces', () => {
+      check(' 😀 ', true);
+    });
+
+    it('returns false for multiple emoji separated by spaces', () => {
+      check('😀   😀', false);
+    });
+
     describe('EMOJI_EDGE_CASES', () => {
       for (const test of EMOJI_EDGE_CASES) {
         it(test.label, () => {
@@ -733,6 +741,30 @@ describe('Emoji', () => {
     it('returns null for mixed text and emoji', () => {
       check('😀a', null);
       check('a😀', null);
+    });
+
+    it('returns count of emoji separated by spaces', () => {
+      check('😀 😀 😀', 3);
+      check('😀 😀', 2);
+      check(' 😀 ', 1);
+      check('😀   😀', 2);
+    });
+
+    it('returns count of max emojis separated by spaces', () => {
+      check('😀 😀 😀 😀 😀', MAX);
+    });
+
+    it('returns null over max emojis separated by spaces', () => {
+      check('😀 😀 😀 😀 😀 😀', null);
+    });
+
+    it('returns null for mixed text and spaced emoji', () => {
+      check('😀 a 😀', null);
+    });
+
+    it('returns null for emoji separated by non-space whitespace', () => {
+      check('😀\n😀', null);
+      check('😀\t😀', null);
     });
   });
 


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
<img width="330" height="274" alt="image" src="https://github.com/user-attachments/assets/3060568d-e87e-4dc0-aa99-2fae3a4b36f2" />

On Desktop emoji-only messages only get enlarged when there are no spaces between the emoji.
In this case `😀😀😀` is big, but `😀 😀 😀` shows up as a normal text bubble, and on Android both are enlarged.
For now I only tested it via storybook, but I also added some tests.

I first reported this inconsistency on the forums over a year ago: https://community.signalusers.org/t/beta-feedback-for-the-upcoming-desktop-7-55-release/69132/4