### PR TITLE
OOMNoitifier:  avoid crashing when running on a restricted environement on Linux

### DIFF
--- a/ts/util/oomNotifier.node.ts
+++ b/ts/util/oomNotifier.node.ts
@@ -14,6 +14,7 @@ const HEAP_SIZE_THRESHOLD = 1024 * 1024 * 1024;
 
 export function trackHeapSize(callback?: () => void): void {
   const timer = setInterval(() => {
+    try{
     const usage = memoryUsage();
     if (usage.heapTotal < HEAP_SIZE_THRESHOLD) {
       return;
@@ -22,5 +23,12 @@ export function trackHeapSize(callback?: () => void): void {
     log.error('high memory usage', usage);
     callback?.();
     clearInterval(timer);
+    }
+     catch (error) {
+       log.error('failed to track heap size', {
+         error: error instanceof Error ? error.message : error,
+       });
+     }
+
   }, INTERVAL);
 }


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [ ] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

On certain Linux environment with some restriction the following will not work, and will make the application crash needlessly:

```
const usage = memoryUsage();
    if (usage.heapTotal < HEAP_SIZE_THRESHOLD) {
```

Adding a simple try catch will prevent the app from crashing in this case.