### PR TITLE
Draft sync pr

### DIFF
--- a/protos/SignalService.proto
+++ b/protos/SignalService.proto
@@ -540,6 +540,13 @@ message Verified {
 }
 
 message SyncMessage {
+  message DraftAttachment {
+    optional string destinationServiceId = 1;
+    optional AttachmentPointer attachment = 2;
+    optional uint64 timestamp = 3;
+    optional bool clear = 4; // tombstone: draft removed on another device
+  }
+  
   message Sent {
     message UnidentifiedDeliveryStatus {
       reserved /*destinationE164*/ 1;
@@ -874,6 +881,7 @@ message SyncMessage {
     AttachmentBackfillRequest attachmentBackfillRequest = 24;
     AttachmentBackfillResponse attachmentBackfillResponse = 25;
     UsernameChange usernameChange = 26;
+    DraftAttachment draftAttachment = 27;
   }
 
   reserved /*groups*/ 3;

--- a/ts/background.preload.ts
+++ b/ts/background.preload.ts
@@ -112,6 +112,7 @@ import type {
   InvalidPlaintextEvent,
   KeysEvent,
   DeleteForMeSyncEvent,
+  DraftSyncEvent,
   MessageEvent,
   MessageEventData,
   MessageRequestResponseEvent,
@@ -128,6 +129,7 @@ import type {
   ViewOnceOpenSyncEvent,
   ViewSyncEvent,
 } from './textsecure/messageReceiverEvents.std.ts';
+import { applyDraftSync } from './messageModifiers/DraftSyncs.preload.ts';
 import {
   cancelInflightRequests,
   checkSockets,
@@ -654,6 +656,10 @@ async function startApp(): Promise<void> {
     messageReceiver.addEventListener(
       'viewSync',
       queuedEventListener(onViewSync)
+    );
+    messageReceiver.addEventListener(
+      'draftSync',
+      queuedEventListener(onDraftSync)
     );
     messageReceiver.addEventListener(
       'read',
@@ -3839,6 +3845,16 @@ async function startApp(): Promise<void> {
     await queueSyncTasks(syncTasks, DataWriter.removeSyncTaskById);
 
     log.info(`${logId}: Done`);
+  }
+
+  async function onDraftSync(ev: DraftSyncEvent): Promise<void> {
+    try {
+      await applyDraftSync(ev.draft);
+    } catch (error) {
+      log.error('onDraftSync error', Errors.toLogFormat(error));
+    } finally {
+      ev.confirm();
+    }
   }
 
   async function onViewSync(ev: ViewSyncEvent): Promise<void> {

--- a/ts/messageModifiers/DraftSyncs.preload.ts
+++ b/ts/messageModifiers/DraftSyncs.preload.ts
@@ -88,7 +88,11 @@ export async function applyDraftSync(
 
   // Last-writer-wins: ignore syncs not newer than the local draft.
   const localTimestamp = conversation.get('draftTimestamp') ?? 0;
-  if (timestamp != null && timestamp <= localTimestamp) {
+  if (timestamp == null) {
+    log.warn(`${logId}: draft sync missing timestamp, dropping`);
+    return;
+  }
+  if (timestamp <= localTimestamp) {
     log.info(`${logId}: ignoring stale draft sync`);
     return;
   }

--- a/ts/messageModifiers/DraftSyncs.preload.ts
+++ b/ts/messageModifiers/DraftSyncs.preload.ts
@@ -1,0 +1,136 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import lodash from 'lodash';
+import { v4 as generateUuid } from 'uuid';
+
+import { createLogger } from '../logging/log.std.ts';
+import { clearConversationDraftAttachments } from '../util/clearConversationDraftAttachments.preload.ts';
+import { deleteDraftAttachment } from '../util/deleteDraftAttachment.preload.ts';
+import { writeDraftAttachment } from '../util/writeDraftAttachment.preload.ts';
+import { downloadAttachment } from '../textsecure/downloadAttachment.preload.ts';
+import {
+  readAttachmentData,
+  maybeDeleteAttachmentFile,
+} from '../util/migrations.preload.ts';
+import {
+  getAttachment,
+  getAttachmentFromBackupTier,
+} from '../textsecure/WebAPI.preload.ts';
+import { DataWriter } from '../sql/Client.preload.ts';
+import { AttachmentVariant } from '../types/Attachment.std.ts';
+import { MediaTier } from '../types/AttachmentDownload.std.ts';
+import { SECOND } from '../util/durations/index.std.ts';
+import type { ReencryptedAttachmentV2 } from '../AttachmentCrypto.node.ts';
+import type { ProcessedAttachment } from '../textsecure/Types.d.ts';
+import type { DraftSyncEventData } from '../textsecure/messageReceiverEvents.std.ts';
+
+const { noop } = lodash;
+
+const log = createLogger('DraftSyncs');
+
+// Downloads the synced attachment from the CDN and returns its plaintext bytes
+// (draft storage is a separate store, so we re-write via writeDraftAttachment).
+// Mirrors downloadAndParseContactAttachment in services/contactSync.preload.ts.
+async function fetchDraftAttachmentData(
+  attachment: ProcessedAttachment
+): Promise<Uint8Array<ArrayBuffer>> {
+  const abortController = new AbortController();
+  let downloaded: ReencryptedAttachmentV2 | undefined;
+  try {
+    downloaded = await downloadAttachment(
+      { getAttachment, getAttachmentFromBackupTier },
+      { attachment, mediaTier: MediaTier.STANDARD },
+      {
+        variant: AttachmentVariant.Default,
+        onSizeUpdate: noop,
+        disableRetries: true,
+        timeout: 90 * SECOND,
+        abortSignal: abortController.signal,
+        logId: 'DraftSyncs.fetchDraftAttachmentData',
+      }
+    );
+    return await readAttachmentData(downloaded);
+  } finally {
+    if (downloaded?.path) {
+      await maybeDeleteAttachmentFile(downloaded.path);
+    }
+  }
+}
+
+// Applies an incoming draft-attachment sync to the target 1:1 conversation.
+// Unlike read/view syncs, a draft sync references a conversation (not a message
+// that may still be in flight), so there's no out-of-order matching — we apply
+// immediately, guarded by draftTimestamp for last-writer-wins.
+//
+// `fetchData` is a seam: it defaults to the real CDN download but is injected in
+// tests so the write+apply path can run without a network/CDN.
+export async function applyDraftSync(
+  data: DraftSyncEventData,
+  fetchData: (
+    attachment: ProcessedAttachment
+  ) => Promise<Uint8Array<ArrayBuffer>> = fetchDraftAttachmentData
+): Promise<void> {
+  const { destinationServiceId, timestamp, clear, attachment } = data;
+  const logId = `DraftSyncs.applyDraftSync(envelope=${data.envelopeTimestamp})`;
+
+  if (!destinationServiceId) {
+    log.error(`${logId}: missing destinationServiceId`);
+    return;
+  }
+
+  // 1:1 only: draft attachments are keyed by the other party's serviceId.
+  const conversation = window.ConversationController.get(destinationServiceId);
+  if (!conversation) {
+    log.warn(`${logId}: no conversation for destinationServiceId`);
+    return;
+  }
+
+  // Last-writer-wins: ignore syncs not newer than the local draft.
+  const localTimestamp = conversation.get('draftTimestamp') ?? 0;
+  if (timestamp != null && timestamp <= localTimestamp) {
+    log.info(`${logId}: ignoring stale draft sync`);
+    return;
+  }
+
+  if (clear) {
+    log.info(`${logId}: clearing draft attachments`);
+    conversation.set({ draftTimestamp: timestamp ?? null });
+    // clearConversationDraftAttachments persists conversation.attributes, so the
+    // draftTimestamp set above is written in the same update.
+    await clearConversationDraftAttachments(
+      conversation.id,
+      conversation.get('draftAttachments')
+    );
+    return;
+  }
+
+  if (!attachment) {
+    log.warn(`${logId}: non-clear draft sync without attachment, dropping`);
+    return;
+  }
+
+  const bytes = await fetchData(attachment);
+  const written = await writeDraftAttachment({
+    data: bytes,
+    clientUuid: generateUuid(),
+    pending: false,
+    contentType: attachment.contentType,
+    size: attachment.size,
+    fileName: attachment.fileName,
+  });
+
+  // Whatever we replace must have its files deleted, or they orphan on disk.
+  const replaced = conversation.get('draftAttachments') ?? [];
+
+  conversation.set({
+    draftAttachments: [written],
+    draftChanged: true,
+    draftTimestamp: timestamp ?? null,
+  });
+  window.reduxActions.composer.replaceAttachments(conversation.id, [written]);
+  await DataWriter.updateConversation(conversation.attributes);
+
+  await Promise.all(replaced.map(item => deleteDraftAttachment(item)));
+  log.info(`${logId}: applied synced draft attachment`);
+}

--- a/ts/state/ducks/composer.preload.ts
+++ b/ts/state/ducks/composer.preload.ts
@@ -94,6 +94,10 @@ import type {
 } from './conversations.preload.ts';
 import { longRunningTaskWrapper } from '../../util/longRunningTaskWrapper.dom.tsx';
 import { drop } from '../../util/drop.std.ts';
+import {
+  sendDraftAttachmentSync,
+  uploadAndSendDraftAttachment,
+} from '../../util/sendDraftAttachmentSync.preload.ts';
 import { strictAssert } from '../../util/assert.std.ts';
 import { makeQuote } from '../../util/makeQuote.preload.ts';
 import { sendEditedMessage as doSendEditedMessage } from '../../util/sendEditedMessage.preload.ts';
@@ -1057,9 +1061,13 @@ function addAttachment(
 
     const conversation = window.ConversationController.get(conversationId);
     if (conversation) {
+      // Record the same timestamp we broadcast, so our local last-writer-wins
+      // guard matches what other devices were told.
+      const draftTimestamp = Date.now();
       conversation.set({
         draftAttachments: nextAttachments,
         draftChanged: true,
+        draftTimestamp,
       });
 
       // if the conversation has already unloaded
@@ -1074,6 +1082,18 @@ function addAttachment(
       }
 
       await DataWriter.updateConversation(conversation.attributes);
+
+      // Sync the added draft attachment to our other devices (1:1 only).
+      const serviceId = conversation.getServiceId();
+      if (serviceId != null && !attachment.pending) {
+        drop(
+          uploadAndSendDraftAttachment({
+            conversationServiceId: serviceId,
+            attachment,
+            timestamp: draftTimestamp,
+          })
+        );
+      }
     }
   };
 }
@@ -1424,11 +1444,28 @@ function removeAttachment(
 
     const conversation = window.ConversationController.get(conversationId);
     if (conversation) {
+      // Record the same timestamp we broadcast, so our local last-writer-wins
+      // guard matches what other devices were told.
+      const draftTimestamp = Date.now();
       conversation.set({
         draftAttachments: nextAttachments,
         draftChanged: true,
+        draftTimestamp,
       });
       await DataWriter.updateConversation(conversation.attributes);
+
+      // Sync draft-attachment removal to our other devices (1:1 only). Removing
+      // the last draft attachment is a clear tombstone.
+      const serviceId = conversation.getServiceId();
+      if (serviceId != null && nextAttachments.length === 0) {
+        drop(
+          sendDraftAttachmentSync({
+            conversationServiceId: serviceId,
+            clear: true,
+            timestamp: draftTimestamp,
+          })
+        );
+      }
     }
 
     replaceAttachments(conversationId, nextAttachments)(

--- a/ts/test-electron/messageModifiers/DraftSyncs_test.preload.ts
+++ b/ts/test-electron/messageModifiers/DraftSyncs_test.preload.ts
@@ -1,0 +1,188 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+import { v4 as uuid } from 'uuid';
+
+import type { AciString } from '../../types/ServiceId.std.ts';
+import type { AttachmentDraftType } from '../../types/Attachment.std.ts';
+import type { DraftSyncEventData } from '../../textsecure/messageReceiverEvents.std.ts';
+import type { ProcessedAttachment } from '../../textsecure/Types.d.ts';
+import { DataWriter } from '../../sql/Client.preload.ts';
+import { itemStorage } from '../../textsecure/Storage.preload.ts';
+import { generateAci } from '../../test-helpers/serviceIdUtils.std.ts';
+import { applyDraftSync } from '../../messageModifiers/DraftSyncs.preload.ts';
+import { writeDraftAttachment } from '../../util/writeDraftAttachment.preload.ts';
+import { readDraftData } from '../../util/migrations.preload.ts';
+import { APPLICATION_OCTET_STREAM, IMAGE_JPEG } from '../../types/MIME.std.ts';
+
+describe('DraftSyncs', () => {
+  beforeEach(async () => {
+    const ourAci = generateAci();
+    await itemStorage.put('uuid_id', `${ourAci}.1`);
+    await window.ConversationController.load();
+  });
+
+  afterEach(async () => {
+    await DataWriter.removeAll();
+    await itemStorage.fetch();
+  });
+
+  // A minimal, fileless pending draft entry: enough to make draftAttachments
+  // non-empty, while clearConversationDraftAttachments -> deleteDraftAttachment
+  // no-ops without a path. These tests assert state, not disk I/O.
+  function seededDraft(): AttachmentDraftType {
+    return {
+      clientUuid: uuid(),
+      contentType: IMAGE_JPEG,
+      pending: true,
+      size: 123,
+    };
+  }
+
+  function seedConversationWithDraft(
+    serviceId: AciString,
+    draftTimestamp: number
+  ) {
+    const conversation = window.ConversationController.getOrCreate(
+      serviceId,
+      'private'
+    );
+    conversation.set({
+      draftAttachments: [seededDraft()],
+      draftChanged: true,
+      draftTimestamp,
+    });
+    return conversation;
+  }
+
+  function clearSync(
+    destinationServiceId: AciString,
+    timestamp: number
+  ): DraftSyncEventData {
+    return {
+      envelopeId: uuid(),
+      envelopeTimestamp: Date.now(),
+      destinationServiceId,
+      timestamp,
+      clear: true,
+    };
+  }
+
+  it('clears the draft on a newer tombstone', async () => {
+    const friendAci = generateAci();
+    const conversation = seedConversationWithDraft(friendAci, 1000);
+    assert.lengthOf(conversation.get('draftAttachments') ?? [], 1);
+
+    await applyDraftSync(clearSync(friendAci, 2000));
+
+    assert.lengthOf(conversation.get('draftAttachments') ?? [], 0);
+    assert.strictEqual(conversation.get('draftTimestamp'), 2000);
+  });
+
+  it('ignores a stale tombstone (not newer than the local draft)', async () => {
+    const friendAci = generateAci();
+    const conversation = seedConversationWithDraft(friendAci, 5000);
+
+    await applyDraftSync(clearSync(friendAci, 4000));
+
+    assert.lengthOf(conversation.get('draftAttachments') ?? [], 1);
+    assert.strictEqual(conversation.get('draftTimestamp'), 5000);
+  });
+
+  it('is a no-op when the conversation is unknown', async () => {
+    const unknownAci = generateAci();
+    assert.isUndefined(window.ConversationController.get(unknownAci));
+
+    // Must not throw.
+    await applyDraftSync(clearSync(unknownAci, 2000));
+  });
+
+  it('writes and applies a synced draft attachment (non-clear path)', async () => {
+    const friendAci = generateAci();
+    const conversation = window.ConversationController.getOrCreate(
+      friendAci,
+      'private'
+    );
+    assert.lengthOf(conversation.get('draftAttachments') ?? [], 0);
+
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const attachment: ProcessedAttachment = {
+      contentType: APPLICATION_OCTET_STREAM,
+      size: bytes.length,
+      fileName: 'sunset.bin',
+    };
+
+    await applyDraftSync(
+      {
+        envelopeId: uuid(),
+        envelopeTimestamp: Date.now(),
+        destinationServiceId: friendAci,
+        timestamp: 3000,
+        clear: false,
+        attachment,
+      },
+      // seam: skip the CDN, hand back the plaintext directly
+      async () => bytes
+    );
+
+    const drafts = conversation.get('draftAttachments') ?? [];
+    assert.lengthOf(drafts, 1);
+    assert.strictEqual(drafts[0].contentType, APPLICATION_OCTET_STREAM);
+    assert.strictEqual(drafts[0].fileName, 'sunset.bin');
+    assert.strictEqual(conversation.get('draftTimestamp'), 3000);
+  });
+
+  it('deletes the replaced draft attachment file (no orphan on disk)', async () => {
+    const friendAci = generateAci();
+    const conversation = window.ConversationController.getOrCreate(
+      friendAci,
+      'private'
+    );
+
+    // Seed a real on-disk draft attachment that the sync will replace.
+    const old = await writeDraftAttachment({
+      data: new Uint8Array([9, 9, 9]),
+      clientUuid: uuid(),
+      pending: false,
+      contentType: APPLICATION_OCTET_STREAM,
+      size: 3,
+      fileName: 'old.bin',
+    });
+    conversation.set({
+      draftAttachments: [old],
+      draftChanged: true,
+      draftTimestamp: 1000,
+    });
+
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    await applyDraftSync(
+      {
+        envelopeId: uuid(),
+        envelopeTimestamp: Date.now(),
+        destinationServiceId: friendAci,
+        timestamp: 2000,
+        clear: false,
+        attachment: {
+          contentType: APPLICATION_OCTET_STREAM,
+          size: bytes.length,
+          fileName: 'new.bin',
+        },
+      },
+      async () => bytes
+    );
+
+    const drafts = conversation.get('draftAttachments') ?? [];
+    assert.lengthOf(drafts, 1);
+    assert.strictEqual(drafts[0].fileName, 'new.bin');
+
+    // The replaced draft's file must be gone, not orphaned on disk.
+    let stillReadable = true;
+    try {
+      await readDraftData(old);
+    } catch {
+      stillReadable = false;
+    }
+    assert.isFalse(stillReadable, 'replaced draft file should be deleted');
+  });
+});

--- a/ts/test-electron/sendDraftAttachmentSync_test.preload.ts
+++ b/ts/test-electron/sendDraftAttachmentSync_test.preload.ts
@@ -1,0 +1,112 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+
+import { generateAci } from '../test-helpers/serviceIdUtils.std.ts';
+import { itemStorage } from '../textsecure/Storage.preload.ts';
+import { DataWriter } from '../sql/Client.preload.ts';
+import { SignalService as Proto } from '../protobuf/index.std.ts';
+import * as Bytes from '../Bytes.std.ts';
+import { singleProtoJobQueue } from '../jobs/singleProtoJobQueue.preload.ts';
+import { sendDraftAttachmentSync } from '../util/sendDraftAttachmentSync.preload.ts';
+
+describe('sendDraftAttachmentSync', () => {
+  const sandbox = sinon.createSandbox();
+
+  beforeEach(async () => {
+    const ourAci = generateAci();
+    await itemStorage.put('uuid_id', `${ourAci}.1`);
+    await window.ConversationController.load();
+  });
+
+  afterEach(async () => {
+    sandbox.restore();
+    await DataWriter.removeAll();
+    await itemStorage.fetch();
+  });
+
+  it('queues a clear draft tombstone (field 27) to our other devices', async () => {
+    sandbox
+      .stub(window.ConversationController, 'doWeHaveOtherDevices')
+      .returns(true);
+    const addStub = sandbox.stub(singleProtoJobQueue, 'add').resolves();
+
+    const friendAci = generateAci();
+    await sendDraftAttachmentSync({
+      conversationServiceId: friendAci,
+      clear: true,
+      timestamp: 1730000000000,
+    });
+
+    assert.isTrue(addStub.calledOnce);
+    const job = addStub.firstCall.args[0];
+    assert.strictEqual(job.type, 'draftSync');
+    assert.isTrue(job.isSyncMessage);
+
+    const content = Proto.Content.decode(Bytes.fromBase64(job.protoBase64));
+    const draft = content.content?.syncMessage?.content?.draftAttachment;
+    assert.strictEqual(draft?.clear, true);
+    assert.strictEqual(draft?.destinationServiceId, friendAci);
+    assert.strictEqual(String(draft?.timestamp), '1730000000000');
+  });
+
+  it('does nothing when there are no other linked devices', async () => {
+    sandbox
+      .stub(window.ConversationController, 'doWeHaveOtherDevices')
+      .returns(false);
+    const addStub = sandbox.stub(singleProtoJobQueue, 'add').resolves();
+
+    await sendDraftAttachmentSync({
+      conversationServiceId: generateAci(),
+      clear: true,
+      timestamp: 1730000000000,
+    });
+
+    assert.isTrue(addStub.notCalled);
+  });
+
+  it('queues a draft attachment pointer (field 27) to our other devices', async () => {
+    sandbox
+      .stub(window.ConversationController, 'doWeHaveOtherDevices')
+      .returns(true);
+    const addStub = sandbox.stub(singleProtoJobQueue, 'add').resolves();
+
+    const friendAci = generateAci();
+    const attachment: Proto.AttachmentPointer.Params = {
+      attachmentIdentifier: { cdnKey: 'draft-cdn' },
+      contentType: 'image/jpeg',
+      fileName: 'sunset.jpg',
+      size: 10,
+      key: null,
+      digest: null,
+      thumbnail: null,
+      clientUuid: null,
+      incrementalMac: null,
+      chunkSize: null,
+      flags: null,
+      width: null,
+      height: null,
+      caption: null,
+      blurHash: null,
+      uploadTimestamp: null,
+      cdnNumber: null,
+    };
+
+    await sendDraftAttachmentSync({
+      conversationServiceId: friendAci,
+      clear: false,
+      timestamp: 1730000000000,
+      attachment,
+    });
+
+    assert.isTrue(addStub.calledOnce);
+    const content = Proto.Content.decode(
+      Bytes.fromBase64(addStub.firstCall.args[0].protoBase64)
+    );
+    const draft = content.content?.syncMessage?.content?.draftAttachment;
+    assert.strictEqual(draft?.destinationServiceId, friendAci);
+    assert.strictEqual(draft?.attachment?.fileName, 'sunset.jpg');
+  });
+});

--- a/ts/test-node/processDraftAttachment_test.preload.ts
+++ b/ts/test-node/processDraftAttachment_test.preload.ts
@@ -1,0 +1,125 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+import { SignalService as Proto } from '../protobuf/index.std.ts';
+import { generateAci } from '../test-helpers/serviceIdUtils.std.ts';
+import { strictAssert } from '../util/assert.std.ts';
+import { processDraftAttachment } from '../textsecure/processDraftAttachment.preload.ts';
+
+// The codec's encode `Params` require every field present; only cdnKey /
+// contentType / fileName / size / cdnNumber matter for these tests.
+function draftAttachmentPointer(): Proto.AttachmentPointer.Params {
+  return {
+    attachmentIdentifier: { cdnKey: 'draft-test' },
+    cdnNumber: 2,
+    contentType: 'image/jpeg',
+    fileName: 'sunset.jpg',
+    size: 12345,
+    clientUuid: null,
+    key: null,
+    thumbnail: null,
+    digest: null,
+    incrementalMac: null,
+    chunkSize: null,
+    flags: null,
+    width: null,
+    height: null,
+    caption: null,
+    blurHash: null,
+    uploadTimestamp: null,
+  };
+}
+
+// Encode a full Content around the draftAttachment, decode it back, and return
+// the round-tripped DraftAttachment (proving field 27 survives the wire).
+function roundTrip(
+  draftAttachment: Proto.SyncMessage.DraftAttachment.Params
+): Proto.SyncMessage.DraftAttachment {
+  const bytes = Proto.Content.encode({
+    content: {
+      syncMessage: {
+        content: { draftAttachment },
+        read: null,
+        stickerPackOperation: null,
+        viewed: null,
+        padding: null,
+      },
+    },
+    senderKeyDistributionMessage: null,
+    pniSignatureMessage: null,
+  });
+
+  const decoded = Proto.Content.decode(bytes);
+  const result = decoded.content?.syncMessage?.content?.draftAttachment;
+  strictAssert(result, 'draftAttachment missing after decode');
+  return result;
+}
+
+describe('draftAttachment sync', () => {
+  it('encodes and decodes a draftAttachment sync message with field 27 intact', () => {
+    const destinationServiceId = generateAci();
+
+    const draft = roundTrip({
+      destinationServiceId,
+      timestamp: 1730000000000n,
+      clear: null,
+      attachment: draftAttachmentPointer(),
+    });
+
+    assert.strictEqual(draft.attachment?.fileName, 'sunset.jpg');
+    assert.strictEqual(draft.destinationServiceId, destinationServiceId);
+    assert.strictEqual(String(draft.timestamp), '1730000000000');
+  });
+
+  it('round-trips a clear tombstone (draft removed on another device)', () => {
+    const destinationServiceId = generateAci();
+
+    const draft = roundTrip({
+      destinationServiceId,
+      timestamp: 1730000000001n,
+      clear: true,
+      attachment: null,
+    });
+
+    assert.strictEqual(draft.clear, true);
+    assert.strictEqual(draft.destinationServiceId, destinationServiceId);
+    // a tombstone carries no attachment payload
+    assert.isNotOk(draft.attachment);
+  });
+
+  it('processDraftAttachment normalizes an incoming draft', () => {
+    const destinationServiceId = generateAci();
+
+    const processed = processDraftAttachment(
+      roundTrip({
+        destinationServiceId,
+        timestamp: 1730000000000n,
+        clear: null,
+        attachment: draftAttachmentPointer(),
+      })
+    );
+
+    assert.strictEqual(processed.destinationServiceId, destinationServiceId);
+    assert.strictEqual(processed.attachment?.fileName, 'sunset.jpg');
+    assert.strictEqual(processed.attachment?.cdnKey, 'draft-test');
+    assert.strictEqual(processed.timestamp, 1730000000000);
+    assert.strictEqual(processed.clear, false);
+  });
+
+  it('processDraftAttachment maps a tombstone to clear=true with no attachment', () => {
+    const destinationServiceId = generateAci();
+
+    const processed = processDraftAttachment(
+      roundTrip({
+        destinationServiceId,
+        timestamp: 1730000000001n,
+        clear: true,
+        attachment: null,
+      })
+    );
+
+    assert.strictEqual(processed.clear, true);
+    assert.isUndefined(processed.attachment);
+  });
+});

--- a/ts/textsecure/MessageReceiver.preload.ts
+++ b/ts/textsecure/MessageReceiver.preload.ts
@@ -83,6 +83,7 @@ import {
   processPreview,
 } from './processDataMessage.preload.ts';
 import { processSent } from './processSyncMessage.node.ts';
+import { processDraftAttachment } from './processDraftAttachment.preload.ts';
 import type { EventHandler } from './EventTarget.std.ts';
 import EventTarget from './EventTarget.std.ts';
 import type { IncomingWebSocketRequest } from './WebsocketResources.preload.ts';
@@ -121,6 +122,7 @@ import {
   DeleteForMeSyncEvent,
   DeliveryEvent,
   DeviceNameChangeSyncEvent,
+  DraftSyncEvent,
   EmptyEvent,
   EnvelopeQueuedEvent,
   EnvelopeUnsealedEvent,
@@ -653,6 +655,11 @@ export default class MessageReceiver
   public override addEventListener(
     name: 'viewSync',
     handler: (ev: ViewSyncEvent) => void
+  ): void;
+
+  public override addEventListener(
+    name: 'draftSync',
+    handler: (ev: DraftSyncEvent) => void
   ): void;
 
   public override addEventListener(
@@ -3142,6 +3149,12 @@ export default class MessageReceiver
     if (syncMessage.content?.usernameChange) {
       return this.#handleUsernameChangeSync(envelope);
     }
+    if (syncMessage.content?.draftAttachment) {
+      return this.#handleDraftAttachment(
+        envelope,
+        syncMessage.content.draftAttachment
+      );
+    }
 
     this.#removeFromCache(envelope);
     const envelopeId = getEnvelopeId(envelope);
@@ -3487,6 +3500,30 @@ export default class MessageReceiver
         views,
         envelope.id,
         envelope.timestamp,
+        this.#removeFromCache.bind(this, envelope)
+      )
+    );
+  }
+
+  async #handleDraftAttachment(
+    envelope: ProcessedEnvelope,
+    draftAttachment: Proto.SyncMessage.DraftAttachment
+  ): Promise<void> {
+    const logId = getEnvelopeId(envelope);
+    log.info('handleDraftAttachment', logId);
+
+    logUnexpectedUrgentValue(envelope, 'draftSync');
+
+    const processed = processDraftAttachment(draftAttachment);
+
+    await this.#dispatchAndWait(
+      logId,
+      new DraftSyncEvent(
+        {
+          envelopeId: envelope.id,
+          envelopeTimestamp: envelope.timestamp,
+          ...processed,
+        },
         this.#removeFromCache.bind(this, envelope)
       )
     );

--- a/ts/textsecure/messageReceiverEvents.std.ts
+++ b/ts/textsecure/messageReceiverEvents.std.ts
@@ -530,6 +530,24 @@ export class ViewSyncEvent extends ConfirmableEvent {
   }
 }
 
+export type DraftSyncEventData = Readonly<{
+  envelopeId: string;
+  envelopeTimestamp: number;
+  destinationServiceId?: ServiceIdString;
+  attachment?: ProcessedAttachment;
+  timestamp?: number;
+  clear: boolean;
+}>;
+
+export class DraftSyncEvent extends ConfirmableEvent {
+  public readonly draft: DraftSyncEventData;
+
+  constructor(draft: DraftSyncEventData, confirm: ConfirmCallback) {
+    super('draftSync', confirm);
+    this.draft = draft;
+  }
+}
+
 export type CallEventSyncEventData = Readonly<{
   callEventDetails: CallEventDetails;
   receivedAtCounter: number;

--- a/ts/textsecure/processDraftAttachment.preload.ts
+++ b/ts/textsecure/processDraftAttachment.preload.ts
@@ -1,0 +1,34 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import type { SignalService as Proto } from '../protobuf/index.std.ts';
+import type { ServiceIdString } from '../types/ServiceId.std.ts';
+import type { ProcessedAttachment } from './Types.d.ts';
+import { fromServiceIdBinaryOrString } from '../util/ServiceId.node.ts';
+import { toNumber } from '../util/toNumber.std.ts';
+import { processAttachment } from './processDataMessage.preload.ts';
+
+export type ProcessedDraftAttachment = Readonly<{
+  destinationServiceId?: ServiceIdString;
+  attachment?: ProcessedAttachment;
+  timestamp?: number;
+  clear: boolean;
+}>;
+
+export function processDraftAttachment(
+  draftAttachment: Proto.SyncMessage.DraftAttachment
+): ProcessedDraftAttachment {
+  return {
+    destinationServiceId: fromServiceIdBinaryOrString(
+      undefined,
+      draftAttachment.destinationServiceId,
+      'processDraftAttachment'
+    ),
+    attachment: processAttachment(draftAttachment.attachment),
+    timestamp:
+      draftAttachment.timestamp != null
+        ? toNumber(draftAttachment.timestamp)
+        : undefined,
+    clear: draftAttachment.clear ?? false,
+  };
+}

--- a/ts/util/handleMessageSend.preload.ts
+++ b/ts/util/handleMessageSend.preload.ts
@@ -70,6 +70,7 @@ export const sendTypesEnum = z.enum([
   'fetchLocalProfileSync',
   'messageRequestSync',
   'readSync', // urgent
+  'draftSync',
   'sentSync',
   'stickerPackSync',
   'verificationSync',

--- a/ts/util/sendDraftAttachmentSync.preload.ts
+++ b/ts/util/sendDraftAttachmentSync.preload.ts
@@ -1,0 +1,100 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { ContentHint } from '@signalapp/libsignal-client';
+
+import * as Bytes from '../Bytes.std.ts';
+import * as Errors from '../types/errors.std.ts';
+import { createLogger } from '../logging/log.std.ts';
+import { SignalService as Proto } from '../protobuf/index.std.ts';
+import { singleProtoJobQueue } from '../jobs/singleProtoJobQueue.preload.ts';
+import { MessageSender } from '../textsecure/SendMessage.preload.ts';
+import { itemStorage } from '../textsecure/Storage.preload.ts';
+import { uploadAttachment } from './uploadAttachment.preload.ts';
+import type { AttachmentWithHydratedData } from '../types/Attachment.std.ts';
+import type { ServiceIdString } from '../types/ServiceId.std.ts';
+
+const log = createLogger('sendDraftAttachmentSync');
+
+// Emits a SyncMessage.DraftAttachment (proto field 27) to our other linked
+// devices: either a `clear` tombstone or a draft attachment pointer.
+// Mirrors sendCallLinkUpdateSync.preload.ts.
+export async function sendDraftAttachmentSync({
+  conversationServiceId,
+  timestamp,
+  clear,
+  attachment,
+}: {
+  conversationServiceId: ServiceIdString;
+  timestamp: number;
+  clear: boolean;
+  attachment?: Proto.AttachmentPointer.Params | null;
+}): Promise<void> {
+  if (!window.ConversationController.doWeHaveOtherDevices()) {
+    log.info('We have no other devices; not sending draft sync');
+    return;
+  }
+
+  try {
+    const ourAci = itemStorage.user.getCheckedAci();
+
+    const draftAttachment: Proto.SyncMessage.DraftAttachment.Params = {
+      destinationServiceId: conversationServiceId,
+      timestamp: BigInt(timestamp),
+      clear,
+      attachment: attachment ?? null,
+    };
+
+    const syncMessage = MessageSender.padSyncMessage({
+      content: { draftAttachment },
+    });
+
+    await singleProtoJobQueue.add({
+      contentHint: ContentHint.Resendable,
+      serviceId: ourAci,
+      isSyncMessage: true,
+      protoBase64: Bytes.toBase64(
+        Proto.Content.encode({
+          content: { syncMessage },
+          senderKeyDistributionMessage: null,
+          pniSignatureMessage: null,
+        })
+      ),
+      type: 'draftSync',
+      urgent: false,
+    });
+  } catch (error) {
+    log.error('Failed to queue draft sync:', Errors.toLogFormat(error));
+  }
+}
+
+// Uploads a draft attachment to the CDN, then syncs the resulting pointer.
+// `UploadedAttachmentType` is structurally an AttachmentPointer.Params.
+export async function uploadAndSendDraftAttachment({
+  conversationServiceId,
+  attachment,
+  timestamp,
+}: {
+  conversationServiceId: ServiceIdString;
+  attachment: AttachmentWithHydratedData;
+  timestamp: number;
+}): Promise<void> {
+  if (!window.ConversationController.doWeHaveOtherDevices()) {
+    return;
+  }
+
+  try {
+    const uploaded = await uploadAttachment(attachment);
+    await sendDraftAttachmentSync({
+      conversationServiceId,
+      timestamp,
+      clear: false,
+      attachment: uploaded,
+    });
+  } catch (error) {
+    log.error(
+      'Failed to upload+send draft attachment:',
+      Errors.toLogFormat(error)
+    );
+  }
+}


### PR DESCRIPTION
<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x ] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x ] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [ ] My changes are ready to be shipped to users

### Description

Syncs **draft attachments** between a user's linked devices over the existing sync-message
channel. Attach a photo to a draft on one device and it appears in that conversation's composer
on another; remove it and the other device clears it. Drafts are currently per-device, so a
draft started on desktop is invisible everywhere else.

### The part I'd most like feedback on

This needs a new `SyncMessage` field, which isn't Desktop's to allocate. I used field **27**
locally, but:

1. Field numbers are assigned centrally across Desktop/iOS/Android/server — if 27 is spoken for,
   this conflicts.
2. A sync message does nothing unless other linked devices implement it. Since most primaries are
   phones, a Desktop-only change delivers ~no user value alone.
3. Attaching now uploads to the CDN *before* the message is sent — attach-then-delete still
   uploaded the blob. That changes what leaves the device, and feels like a decision Signal
   should own.

So: **is cross-device draft sync directionally interesting, and if so is a `SyncMessage` field the
right mechanism?** "No" or "not now" is a useful answer and I'll close this.

### Implementation summary

Follows existing patterns rather than inventing new ones:

- `processDraftAttachment` normalizes the proto, mirroring `processSent`.
- `DraftSyncEvent` + a `MessageReceiver` oneof branch, mirroring `readSync`.
- The applier lives in `ts/messageModifiers/DraftSyncs.preload.ts` beside `ReadSyncs`/`ViewSyncs`
  - minus their in-memory map and `forMessage` matching, since a draft sync targets a
  conversation that already exists rather than a message still in flight.
- Sending mirrors `sendCallLinkUpdateSync` (`singleProtoJobQueue`); download mirrors `contactSync`.
- `draftTimestamp` gives last-writer-wins; each send records the timestamp it broadcasts so the
  local guard matches what peers were told.
- Send triggers sit on the composer duck's `addAttachment`/`removeAttachment` - paths the receive
  side never takes so an applied sync can't echo back out.

### Known limitations

- **1:1 only** - the proto carries `destinationServiceId`, no `groupId`.
- **One attachment** - `attachment` isn't `repeated`; multi-attachment drafts sync only the most
  recent, and removing one of several sends nothing.
- **Draft text isn't synced.**
- **Drafts upload before send** (above).
- **A failed download silently drops the sync** - the envelope is confirmed either way.
- `maybeUpdateDraftPreview` nulls `draftTimestamp` on empty drafts, so the clear-path guard resets
  and an older sync can briefly resurrect a stale draft.

### Test approach

**New tests (12):**
- `test-node/processDraftAttachment_test` — field-27 round trip, `clear` tombstone, normalizer (4).
- `test-electron/messageModifiers/DraftSyncs_test` — clear path, timestamp guard, unknown
  conversation, write-and-apply, and that a replaced draft's file is deleted rather than orphaned (5).
- `test-electron/sendDraftAttachmentSync_test` — clear payload, pointer payload, no-op without
  linked devices (3).

**Manual testing:** two Signal Desktop instances (separate storage profiles via
`NODE_APP_INSTANCE`) both linked as secondary devices to the same account. Attaching a photo to a
draft in a 1:1 on one instance made it appear in the other's composer; removing it cleared the
other side.

Worth noting: that manual pass caught a real bug the entire suite missed. I had the sender behind
a dynamic `import()`, which rolldown emits as a chunk that `require`s `bundles/preload/main.js`
and calls its module-init functions while that bundle is still initializing 
`TypeError: r.t is not a function` on first use. The tests never saw it because they load the
module directly rather than through the bundle. It's a static import now.

**No `test-mock` e2e, and I don't believe one can be written yet.** `@signalapp/mock-server@24.0.3`
can't send this message: its proto's `SyncMessage.content` oneof ends at `usernameChange` (26),
`sendRaw` re-encodes through that proto so field 27 is dropped, there's no public
raw-`Content`-bytes path, and the forward-compat route (decode into `$unknown`, re-encode) fails
because that codec only populates `$unknown` on decode and never re-emits it. If there's an
intended way to exercise a new protocol field at that layer I'd like to know  that's the main
thing I couldn't work out.

**OS:** Windows 11 (10.0.26200)

**Other devices:** None. This is the significant gap  the feature only becomes useful once iOS
and Android implement the counterpart, and I haven't tested against a mobile primary.