### PR TITLE
Add import of existing packs to the sticker creator

### DIFF
--- a/app/main.main.ts
+++ b/app/main.main.ts
@@ -1091,6 +1091,26 @@ ipc.on('art-creator:onUploadProgress', () => {
   stickerCreatorWindow?.webContents.send('art-creator:onUploadProgress');
 });
 
+ipc.on('art-creator:onImportProgress', (_event, data: unknown) => {
+  stickerCreatorWindow?.webContents.send('art-creator:onImportProgress', data);
+});
+
+ipc.handle(
+  'art-creator:importStickerPack',
+  (_event: Electron.Event, data: unknown) => {
+    const { promise, resolve } = explodePromise<unknown>();
+    strictAssert(mainWindow, 'Main window did not exist');
+
+    mainWindow.webContents.send('art-creator:importStickerPack', data);
+
+    ipc.once('art-creator:importStickerPack:done', (_doneEvent, response) => {
+      resolve(response);
+    });
+
+    return promise;
+  }
+);
+
 ipc.on('show-window', () => {
   showWindow();
 });

--- a/sticker-creator/src/assets/locales/en/messages.json
+++ b/sticker-creator/src/assets/locales/en/messages.json
@@ -176,6 +176,26 @@
     "message": "View margins",
     "description": "Text for the show margins toggle on the drop stage of the sticker creator"
   },
+  "StickerCreator--DropStage--import--label": {
+    "message": "Or start from an existing pack",
+    "description": "Label for the sticker pack link input on the drop stage"
+  },
+  "StickerCreator--DropStage--import--placeholder": {
+    "message": "Sticker pack link",
+    "description": "Placeholder for the sticker pack link input on the drop stage"
+  },
+  "StickerCreator--DropStage--import--button": {
+    "message": "Import",
+    "description": "Button that imports a sticker pack from the entered link"
+  },
+  "StickerCreator--DropStage--import--loading": {
+    "message": "Importing sticker pack...",
+    "description": "Shown while a sticker pack is being imported"
+  },
+  "StickerCreator--DropStage--import--progress": {
+    "message": "$count$ of $total$ downloaded",
+    "description": "Progress text while a sticker pack is being imported"
+  },
   "StickerCreator--EmojiStage--title--sticker": {
     "message": "Add an emoji to each sticker",
     "description": "Title for the drop stage of the sticker creator"
@@ -311,6 +331,14 @@
   "StickerCreator--Toasts--unsupportedFormat": {
     "message": "Can’t add this image because the format is not supported",
     "description": "Text for the toast when an image cannot be processed because it uses an unsupported file format"
+  },
+  "StickerCreator--Toasts--invalidPackLink": {
+    "message": "That doesn't look like a sticker pack link",
+    "description": "Toast shown when the entered sticker pack link cannot be parsed"
+  },
+  "StickerCreator--Toasts--errorImporting": {
+    "message": "Error importing sticker pack",
+    "description": "Toast shown when a sticker pack cannot be imported"
   },
   "StickerCreator--StickerPreview--light": {
     "message": "My sticker in light theme",

--- a/sticker-creator/src/routes/art/AppStage.tsx
+++ b/sticker-creator/src/routes/art/AppStage.tsx
@@ -1,7 +1,7 @@
 // Copyright 2023 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { useCallback, type ReactNode, type JSX } from 'react';
+import { useCallback, useMemo, type ReactNode, type JSX } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 import styles from './AppStage.module.scss';
@@ -74,6 +74,18 @@ export function AppStage(props: Props): JSX.Element {
 
   const dispatch = useDispatch();
   const toasts = useToasts();
+  const loaf = useMemo(
+    () =>
+      toasts.map((slice, id) => ({
+        id,
+        text: i18n(slice.key, slice.subs),
+      })),
+    [toasts, i18n]
+  );
+  const handleDismissToast = useCallback(
+    () => dispatch(dismissToast()),
+    [dispatch]
+  );
 
   return (
     <div className={styles.container}>
@@ -108,11 +120,8 @@ export function AppStage(props: Props): JSX.Element {
       </footer>
       <Toaster
         className={styles.toaster}
-        loaf={toasts.map((slice, id) => ({
-          id,
-          text: i18n(slice.key, slice.subs),
-        }))}
-        onDismiss={() => dispatch(dismissToast())}
+        loaf={loaf}
+        onDismiss={handleDismissToast}
       />
     </div>
   );

--- a/sticker-creator/src/routes/art/DropStage.module.scss
+++ b/sticker-creator/src/routes/art/DropStage.module.scss
@@ -28,3 +28,24 @@
   gap: 8px;
   justify-content: center;
 }
+
+.import {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+
+  label {
+    flex: 1;
+    max-width: 448px;
+  }
+}
+
+.import-status {
+  flex: 1;
+  max-width: 448px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/sticker-creator/src/routes/art/DropStage.module.scss
+++ b/sticker-creator/src/routes/art/DropStage.module.scss
@@ -35,6 +35,7 @@
   align-items: flex-end;
   gap: 8px;
   margin-top: 16px;
+  min-height: 56px;
 
   label {
     flex: 1;

--- a/sticker-creator/src/routes/art/DropStage.module.scss
+++ b/sticker-creator/src/routes/art/DropStage.module.scss
@@ -31,21 +31,18 @@
 
 .import {
   display: flex;
-  flex-direction: row;
   align-items: flex-end;
   gap: 8px;
   margin-top: 16px;
   min-height: 56px;
 
-  label {
+  > :first-child {
     flex: 1;
     max-width: 448px;
   }
 }
 
 .import-status {
-  flex: 1;
-  max-width: 448px;
   display: flex;
   flex-direction: column;
   gap: 8px;

--- a/sticker-creator/src/routes/art/DropStage.tsx
+++ b/sticker-creator/src/routes/art/DropStage.tsx
@@ -36,6 +36,7 @@ export function DropStage(): JSX.Element {
   }, [dispatch]);
 
   const handleImport = useCallback(async () => {
+    dispatch(resetStatus());
     setImporting(true);
     setImportProgress(undefined);
     try {

--- a/sticker-creator/src/routes/art/DropStage.tsx
+++ b/sticker-creator/src/routes/art/DropStage.tsx
@@ -1,26 +1,97 @@
 // Copyright 2023 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { useState, useEffect, type JSX } from 'react';
+import { useCallback, useState, useEffect, type JSX } from 'react';
 import { useDispatch } from 'react-redux';
+import createDebug from 'debug';
 import { AppStage } from './AppStage';
 import styles from './DropStage.module.scss';
 import { H2, Text } from '../../elements/Typography';
+import { LabeledInput } from '../../elements/LabeledInput';
+import { Button } from '../../elements/Button';
+import { ProgressBar } from '../../elements/ProgressBar';
 import { ArtGrid } from '../../components/ArtGrid';
-import { resetStatus } from '../../slices/art';
-import { useArtType, useArtReady } from '../../selectors/art';
+import { resetStatus, initializePack, addToast } from '../../slices/art';
+import { useArtType, useArtReady, useArtOrder } from '../../selectors/art';
+import { importPack, toInitializePackPayload, APIError } from '../../util/api';
 import { useI18n } from '../../contexts/I18n';
+
+const debug = createDebug('signal:routes:stickers:DropStage');
 
 export function DropStage(): JSX.Element {
   const i18n = useI18n();
   const dispatch = useDispatch();
   const artType = useArtType();
   const artReady = useArtReady();
+  const order = useArtOrder();
   const [showGuide, setShowGuide] = useState<boolean>(true);
+  const [importLink, setImportLink] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [importProgress, setImportProgress] = useState<
+    { done: number; total: number } | undefined
+  >();
 
   useEffect(() => {
     dispatch(resetStatus());
   }, [dispatch]);
+
+  const handleImport = useCallback(async () => {
+    setImporting(true);
+    setImportProgress(undefined);
+    try {
+      const contents = await importPack(importLink.trim(), (done, total) =>
+        setImportProgress({ done, total })
+      );
+      dispatch(initializePack(toInitializePackPayload(contents)));
+    } catch (e) {
+      debug('Error importing pack:', e);
+      dispatch(
+        addToast({
+          key:
+            e instanceof APIError
+              ? e.errorMessageI18nKey
+              : 'StickerCreator--Toasts--errorImporting',
+        })
+      );
+    } finally {
+      setImporting(false);
+    }
+  }, [dispatch, importLink]);
+
+  let importContent: JSX.Element;
+  if (importing) {
+    importContent = (
+      <div className={styles.importStatus}>
+        <Text>
+          {importProgress
+            ? i18n('StickerCreator--DropStage--import--progress', {
+                count: String(importProgress.done),
+                total: String(importProgress.total),
+              })
+            : i18n('StickerCreator--DropStage--import--loading')}
+        </Text>
+        <ProgressBar
+          count={importProgress?.done ?? 0}
+          total={importProgress?.total ?? 1}
+        />
+      </div>
+    );
+  } else {
+    importContent = (
+      <>
+        <LabeledInput
+          placeholder={i18n('StickerCreator--DropStage--import--placeholder')}
+          value={importLink}
+          onChange={setImportLink}
+        >
+          {i18n('StickerCreator--DropStage--import--label')}
+        </LabeledInput>
+        <Button onClick={handleImport} disabled={!importLink.trim()}>
+          {i18n('StickerCreator--DropStage--import--button')}
+        </Button>
+      </>
+    );
+  }
 
   return (
     <AppStage
@@ -39,6 +110,9 @@ export function DropStage(): JSX.Element {
       <div className={styles.main}>
         <ArtGrid mode="add" showGuide={showGuide} />
       </div>
+      {order.length === 0 ? (
+        <div className={styles.import}>{importContent}</div>
+      ) : null}
     </AppStage>
   );
 }

--- a/sticker-creator/src/routes/art/DropStage.tsx
+++ b/sticker-creator/src/routes/art/DropStage.tsx
@@ -59,40 +59,37 @@ export function DropStage(): JSX.Element {
     }
   }, [dispatch, importLink]);
 
-  let importContent: JSX.Element;
-  if (importing) {
-    importContent = (
-      <div className={styles.importStatus}>
-        <Text>
-          {importProgress
-            ? i18n('StickerCreator--DropStage--import--progress', {
-                count: String(importProgress.done),
-                total: String(importProgress.total),
-              })
-            : i18n('StickerCreator--DropStage--import--loading')}
-        </Text>
-        <ProgressBar
-          count={importProgress?.done ?? 0}
-          total={importProgress?.total ?? 1}
-        />
-      </div>
-    );
-  } else {
-    importContent = (
-      <>
-        <LabeledInput
-          placeholder={i18n('StickerCreator--DropStage--import--placeholder')}
-          value={importLink}
-          onChange={setImportLink}
-        >
-          {i18n('StickerCreator--DropStage--import--label')}
-        </LabeledInput>
-        <Button onClick={handleImport} disabled={!importLink.trim()}>
-          {i18n('StickerCreator--DropStage--import--button')}
-        </Button>
-      </>
-    );
-  }
+  const importStatus = (
+    <div className={styles.importStatus}>
+      <Text>
+        {importProgress
+          ? i18n('StickerCreator--DropStage--import--progress', {
+              count: String(importProgress.done),
+              total: String(importProgress.total),
+            })
+          : i18n('StickerCreator--DropStage--import--loading')}
+      </Text>
+      <ProgressBar
+        count={importProgress?.done ?? 0}
+        total={importProgress?.total ?? 1}
+      />
+    </div>
+  );
+
+  const importForm = (
+    <>
+      <LabeledInput
+        placeholder={i18n('StickerCreator--DropStage--import--placeholder')}
+        value={importLink}
+        onChange={setImportLink}
+      >
+        {i18n('StickerCreator--DropStage--import--label')}
+      </LabeledInput>
+      <Button onClick={handleImport} disabled={!importLink.trim()}>
+        {i18n('StickerCreator--DropStage--import--button')}
+      </Button>
+    </>
+  );
 
   return (
     <AppStage
@@ -112,7 +109,9 @@ export function DropStage(): JSX.Element {
         <ArtGrid mode="add" showGuide={showGuide} />
       </div>
       {order.length === 0 ? (
-        <div className={styles.import}>{importContent}</div>
+        <div className={styles.import}>
+          {importing ? importStatus : importForm}
+        </div>
       ) : null}
     </AppStage>
   );

--- a/sticker-creator/src/slices/art.ts
+++ b/sticker-creator/src/slices/art.ts
@@ -50,6 +50,17 @@ export type SetPackMetaPayload = Readonly<{
   key: string;
 }>;
 
+export type InitializePackPayload = Readonly<{
+  title: string;
+  author: string;
+  cover?: ArtImageData;
+  stickers: ReadonlyArray<{
+    path: ArtPath;
+    emoji?: EmojiData;
+    imageData: ArtImageData;
+  }>;
+}>;
+
 const initialState: ArtState = {
   artType: ArtType.Sticker,
   order: [],
@@ -88,6 +99,33 @@ const artSlice = createSlice({
           state.data[path] = {};
           state.order.push(path);
         }
+      }
+    },
+
+    initializePack: (
+      state,
+      { payload }: PayloadAction<InitializePackPayload>
+    ) => {
+      assert(state.artType === ArtType.Sticker, 'Unexpected art type');
+      if (state.order.length > 0) {
+        return;
+      }
+      for (const { path, emoji, imageData } of payload.stickers.slice(
+        0,
+        MAX_STICKERS
+      )) {
+        if (state.data[path]) {
+          continue;
+        }
+        state.data[path] = { emoji, imageData };
+        state.order.push(path);
+      }
+      state.title = payload.title;
+      state.author = payload.author;
+      if (payload.cover) {
+        state.cover = payload.cover;
+      } else {
+        adjustCover(state);
       }
     },
 
@@ -132,7 +170,9 @@ const artSlice = createSlice({
         toast.subs.count = newCount.toString();
       }
 
-      adjustCover(state);
+      if (!state.cover) {
+        adjustCover(state);
+      }
     },
 
     removeImage: (state, { payload }: PayloadAction<ArtPath>) => {
@@ -215,6 +255,7 @@ const artSlice = createSlice({
 export const {
   addImageData,
   initializeImages,
+  initializePack,
   removeImage,
   setCover,
   setEmoji,

--- a/sticker-creator/src/util/api.ts
+++ b/sticker-creator/src/util/api.ts
@@ -1,8 +1,12 @@
 // Copyright 2022 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import b64 from 'base64-js';
+
 import { type ArtType } from '../constants';
 import { type EncryptResult } from './crypto';
+import type { ArtImageData } from '../types.d';
+import type { InitializePackPayload } from '../slices/art';
 
 declare global {
   // eslint-disable-next-line no-restricted-syntax
@@ -14,6 +18,14 @@ declare global {
     ): Promise<string>;
     installStickerPack(packId: string, key: string): void;
     getFilePath(file: File): string;
+    importStickerPack(
+      link: string,
+      onProgress?: (done: number, total: number) => void
+    ): Promise<
+      | { contents: StickerPackContents }
+      | { error: 'invalidLink' | 'importFailed' }
+      | undefined
+    >;
   }
 }
 
@@ -50,6 +62,74 @@ export async function upload(
   return {
     key,
     packId,
+  };
+}
+
+export type ImportedSticker = Readonly<{
+  id: number;
+  emoji?: string;
+  data: Uint8Array<ArrayBuffer>;
+  contentType: string;
+}>;
+
+export type StickerPackContents = Readonly<{
+  title: string;
+  author: string;
+  coverStickerId?: number;
+  coverImage?: ImportedSticker;
+  stickers: ReadonlyArray<ImportedSticker>;
+}>;
+
+export async function importPack(
+  link: string,
+  onProgress?: (done: number, total: number) => void
+): Promise<StickerPackContents> {
+  const result = await window.importStickerPack(link, onProgress);
+  if (result && 'contents' in result) {
+    return result.contents;
+  }
+
+  const key =
+    result?.error === 'invalidLink'
+      ? 'StickerCreator--Toasts--invalidPackLink'
+      : 'StickerCreator--Toasts--errorImporting';
+  throw new APIError(`importPack: ${result?.error ?? 'no result'}`, key);
+}
+
+function toImageData({ id, data, contentType }: ImportedSticker): ArtImageData {
+  return {
+    buffer: data,
+    contentType,
+    src: `data:${contentType};base64,${b64.fromByteArray(data)}`,
+    path: `imported:${id}`,
+  };
+}
+
+export function toInitializePackPayload(
+  contents: StickerPackContents
+): InitializePackPayload {
+  const stickers = contents.stickers.map(sticker => {
+    const imageData = toImageData(sticker);
+    return {
+      path: imageData.path,
+      emoji: sticker.emoji
+        ? { emoji: sticker.emoji, name: '', sheetX: -1, sheetY: -1 }
+        : undefined,
+      imageData,
+    };
+  });
+
+  const coverIndex = contents.stickers.findIndex(
+    ({ id }) => id === contents.coverStickerId
+  );
+
+  return {
+    title: contents.title,
+    author: contents.author,
+    cover: contents.coverImage
+      ? toImageData(contents.coverImage)
+      : stickers[coverIndex]?.imageData,
+    stickers,
   };
 }
 

--- a/ts/test-node/types/Stickers_test.preload.ts
+++ b/ts/test-node/types/Stickers_test.preload.ts
@@ -4,6 +4,10 @@
 import { assert } from 'chai';
 import * as Stickers from '../../types/Stickers.preload.ts';
 import { isPackIdValid, redactPackId } from '../../util/Stickers.std.ts';
+import * as Bytes from '../../Bytes.std.ts';
+import { deriveStickerPackKey, encryptAttachment } from '../../Crypto.node.ts';
+import { SignalService as Proto } from '../../protobuf/index.std.ts';
+import { IMAGE_PNG } from '../../types/MIME.std.ts';
 
 describe('Stickers', () => {
   describe('getDataFromLink', () => {
@@ -141,6 +145,149 @@ describe('Stickers', () => {
         redactPackId('b9439fa5fdc8b9873fe64f01b88b8ccf'),
         '[REDACTED]ccf'
       );
+    });
+  });
+
+  describe('fetchStickerPackContents', () => {
+    const packId = 'b9439fa5fdc8b9873fe64f01b88b8ccf';
+    const packKey = new Uint8Array(32).fill(1);
+    const link = `https://signal.art/addstickers/#pack_id=${packId}&pack_key=${Bytes.toHex(packKey)}`;
+
+    const keys = deriveStickerPackKey(packKey);
+    const encrypt = (plaintext: Uint8Array<ArrayBuffer>) =>
+      encryptAttachment({ plaintext, keys }).ciphertext;
+
+    const png = (byte: number) =>
+      new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, byte]);
+
+    function fakeApi(pack: Proto.StickerPack.Params) {
+      return {
+        getManifest: async () => encrypt(Proto.StickerPack.encode(pack)),
+        getSticker: async (_: string, id: number) => encrypt(png(id)),
+      };
+    }
+
+    const emptyPack = {
+      title: null,
+      author: null,
+      cover: null,
+      stickers: null,
+    };
+
+    it('rejects links that are not sticker pack links', async () => {
+      await assert.isRejected(
+        Stickers.fetchStickerPackContents(
+          'https://example.com',
+          fakeApi(emptyPack)
+        )
+      );
+    });
+
+    it('preserves sticker order, emoji, and bytes', async () => {
+      const contents = await Stickers.fetchStickerPackContents(
+        link,
+        fakeApi({
+          ...emptyPack,
+          title: 'Cats',
+          author: 'Ehab',
+          cover: { id: 1, emoji: null },
+          stickers: [
+            { id: 0, emoji: '😀' },
+            { id: 1, emoji: '😾' },
+          ],
+        })
+      );
+
+      assert.strictEqual(contents.title, 'Cats');
+      assert.strictEqual(contents.author, 'Ehab');
+      assert.strictEqual(contents.coverStickerId, 1);
+      assert.isUndefined(contents.coverImage);
+      assert.deepEqual(
+        contents.stickers.map(({ id, emoji, contentType }) => ({
+          id,
+          emoji,
+          contentType,
+        })),
+        [
+          { id: 0, emoji: '😀', contentType: IMAGE_PNG },
+          { id: 1, emoji: '😾', contentType: IMAGE_PNG },
+        ]
+      );
+      assert.deepEqual(contents.stickers[0]?.data, png(0));
+    });
+
+    it('downloads a cover that is not in the sticker list', async () => {
+      const contents = await Stickers.fetchStickerPackContents(
+        link,
+        fakeApi({
+          ...emptyPack,
+          cover: { id: 5, emoji: null },
+          stickers: [{ id: 0, emoji: '😀' }],
+        })
+      );
+
+      assert.isUndefined(contents.coverStickerId);
+      assert.deepEqual(contents.coverImage?.data, png(5));
+    });
+
+    it('rejects when decryption fails', async () => {
+      await assert.isRejected(
+        Stickers.fetchStickerPackContents(link, {
+          getManifest: async () => new Uint8Array(64),
+          getSticker: async () => new Uint8Array(64),
+        })
+      );
+    });
+
+    it('reports progress including a distinct cover', async () => {
+      const seen: Array<[number, number]> = [];
+      await Stickers.fetchStickerPackContents(link, {
+        ...fakeApi({
+          ...emptyPack,
+          cover: { id: 5, emoji: null },
+          stickers: [
+            { id: 0, emoji: '😀' },
+            { id: 1, emoji: '😾' },
+          ],
+        }),
+        onProgress: (done, total) => seen.push([done, total]),
+      });
+
+      assert.deepEqual(seen, [
+        [1, 3],
+        [2, 3],
+        [3, 3],
+      ]);
+    });
+
+    it('does not count a cover from the sticker list twice', async () => {
+      const seen: Array<[number, number]> = [];
+      await Stickers.fetchStickerPackContents(link, {
+        ...fakeApi({
+          ...emptyPack,
+          cover: { id: 1, emoji: null },
+          stickers: [
+            { id: 0, emoji: '😀' },
+            { id: 1, emoji: '😾' },
+          ],
+        }),
+        onProgress: (done, total) => seen.push([done, total]),
+      });
+
+      assert.deepEqual(seen, [
+        [1, 2],
+        [2, 2],
+      ]);
+    });
+
+    it('reports no progress for an empty pack', async () => {
+      const seen: Array<[number, number]> = [];
+      await Stickers.fetchStickerPackContents(link, {
+        ...fakeApi(emptyPack),
+        onProgress: (done, total) => seen.push([done, total]),
+      });
+
+      assert.deepEqual(seen, []);
     });
   });
 });

--- a/ts/test-node/types/Stickers_test.preload.ts
+++ b/ts/test-node/types/Stickers_test.preload.ts
@@ -181,6 +181,12 @@ describe('Stickers', () => {
           fakeApi(emptyPack)
         )
       );
+      await assert.isRejected(
+        Stickers.fetchStickerPackContents(
+          `https://signal.art/addstickers/#pack_id=${packId}&pack_key=abc123`,
+          fakeApi(emptyPack)
+        )
+      );
     });
 
     it('preserves sticker order, emoji, and bytes', async () => {
@@ -228,6 +234,25 @@ describe('Stickers', () => {
 
       assert.isUndefined(contents.coverStickerId);
       assert.deepEqual(contents.coverImage?.data, png(5));
+    });
+
+    it('skips stickers without ids and keeps emoji optional', async () => {
+      const contents = await Stickers.fetchStickerPackContents(
+        link,
+        fakeApi({
+          ...emptyPack,
+          cover: { id: 0, emoji: null },
+          stickers: [
+            { id: 0, emoji: null },
+            { id: null, emoji: '😾' },
+          ],
+        })
+      );
+
+      assert.deepEqual(
+        contents.stickers.map(({ id, emoji }) => ({ id, emoji })),
+        [{ id: 0, emoji: undefined }]
+      );
     });
 
     it('rejects when decryption fails', async () => {
@@ -280,12 +305,14 @@ describe('Stickers', () => {
       ]);
     });
 
-    it('reports no progress for an empty pack', async () => {
+    it('rejects an empty pack without reporting progress', async () => {
       const seen: Array<[number, number]> = [];
-      await Stickers.fetchStickerPackContents(link, {
-        ...fakeApi(emptyPack),
-        onProgress: (done, total) => seen.push([done, total]),
-      });
+      await assert.isRejected(
+        Stickers.fetchStickerPackContents(link, {
+          ...fakeApi(emptyPack),
+          onProgress: (done, total) => seen.push([done, total]),
+        })
+      );
 
       assert.deepEqual(seen, []);
     });

--- a/ts/types/Stickers.preload.ts
+++ b/ts/types/Stickers.preload.ts
@@ -338,12 +338,20 @@ export async function fetchStickerPackContents(
     throw new InvalidStickerPackLinkError('Not a sticker pack link');
   }
   const { packId } = route.args;
-  const packKey = Bytes.toBase64(Bytes.fromHex(route.args.packKey));
+  const keyBytes = Bytes.fromHex(route.args.packKey);
+  if (
+    !isPackIdValid(packId) ||
+    keyBytes.byteLength !== STICKERPACK_KEY_BYTE_LEN
+  ) {
+    throw new InvalidStickerPackLinkError('Invalid pack id or key');
+  }
+  const packKey = Bytes.toBase64(keyBytes);
 
   const manifest = await getManifest(packId);
   const proto = Proto.StickerPack.decode(decryptSticker(packKey, manifest));
 
   const stickerProtos = proto.stickers.filter(({ id }) => isNumber(id));
+  strictAssert(stickerProtos.length > 0, 'Sticker pack has no stickers');
   const coverId = dropNull(proto.cover?.id);
   const coverInList = stickerProtos.some(({ id }) => id === coverId);
   const distinctCoverId = coverId != null && !coverInList ? coverId : undefined;

--- a/ts/types/Stickers.preload.ts
+++ b/ts/types/Stickers.preload.ts
@@ -53,6 +53,7 @@ import {
 } from '../textsecure/WebAPI.preload.ts';
 import { getExistingAttachmentDataForReuse } from '../util/attachments/deduplicateAttachment.preload.ts';
 import { Emoji } from '../axo/emoji.std.ts';
+import { parseSignalRoute } from '../util/signalRoutes.std.ts';
 
 const { isNumber, reject, groupBy, values, chunk } = lodash;
 
@@ -297,6 +298,92 @@ export function getDataFromLink(
   }
 
   return { id, key };
+}
+
+export class InvalidStickerPackLinkError extends Error {}
+
+export type ImportedStickerType = Readonly<{
+  id: number;
+  emoji: string | undefined;
+  data: Uint8Array<ArrayBuffer>;
+  contentType: MIMEType;
+}>;
+
+export type StickerPackContentsType = Readonly<{
+  title: string;
+  author: string;
+  coverStickerId: number | undefined;
+  coverImage: ImportedStickerType | undefined;
+  stickers: ReadonlyArray<ImportedStickerType>;
+}>;
+
+export type ImportStickerPackResultType =
+  | { contents: StickerPackContentsType }
+  | { error: 'invalidLink' | 'importFailed' };
+
+export async function fetchStickerPackContents(
+  link: string,
+  {
+    getManifest = getStickerPackManifest,
+    getSticker: fetchSticker = doGetSticker,
+    onProgress,
+  }: {
+    getManifest?: typeof getStickerPackManifest;
+    getSticker?: typeof doGetSticker;
+    onProgress?: (done: number, total: number) => void;
+  } = {}
+): Promise<StickerPackContentsType> {
+  const route = parseSignalRoute(link);
+  if (route == null || route.key !== 'artAddStickers') {
+    throw new InvalidStickerPackLinkError('Not a sticker pack link');
+  }
+  const { packId } = route.args;
+  const packKey = Bytes.toBase64(Bytes.fromHex(route.args.packKey));
+
+  const manifest = await getManifest(packId);
+  const proto = Proto.StickerPack.decode(decryptSticker(packKey, manifest));
+
+  const stickerProtos = proto.stickers.filter(({ id }) => isNumber(id));
+  const coverId = dropNull(proto.cover?.id);
+  const coverInList = stickerProtos.some(({ id }) => id === coverId);
+  const distinctCoverId = coverId != null && !coverInList ? coverId : undefined;
+
+  const total = stickerProtos.length + (distinctCoverId != null ? 1 : 0);
+  let done = 0;
+
+  const importSticker = async ({
+    id,
+    emoji,
+  }: Proto.StickerPack.Sticker.Params): Promise<ImportedStickerType> => {
+    strictAssert(isNumber(id), "Sticker id can't be null");
+    const data = decryptSticker(packKey, await fetchSticker(packId, id));
+    done += 1;
+    onProgress?.(done, total);
+    return {
+      id,
+      emoji: dropNull(emoji),
+      data,
+      contentType: sniffImageMimeType(data) ?? IMAGE_WEBP,
+    };
+  };
+
+  const [stickers, coverImage] = await Promise.all([
+    pMap(stickerProtos, importSticker, { concurrency: 3 }),
+    distinctCoverId != null
+      ? importSticker({
+          id: distinctCoverId,
+          emoji: proto.cover?.emoji ?? null,
+        })
+      : undefined,
+  ]);
+
+  return {
+    title: proto.title ?? '',
+    author: proto.author ?? '',
+    coverStickerId: coverInList ? coverId : undefined,
+    coverImage,
+    stickers,
+  };
 }
 
 export function downloadQueuedPacks(): void {

--- a/ts/util/createIPCEvents.preload.ts
+++ b/ts/util/createIPCEvents.preload.ts
@@ -8,6 +8,11 @@ import lodash from 'lodash';
 import type { ZoomFactorType } from '../types/StorageKeys.std.ts';
 import * as Errors from '../types/errors.std.ts';
 import * as Stickers from '../types/Stickers.preload.ts';
+import {
+  fetchStickerPackContents,
+  InvalidStickerPackLinkError,
+  type ImportStickerPackResultType,
+} from '../types/Stickers.preload.ts';
 import * as Settings from '../types/Settings.std.ts';
 
 import { resolveUsernameByLinkBase64 } from '../services/username.preload.ts';
@@ -59,6 +64,7 @@ export type IPCEventsCallbacksType = {
   getMediaAccessStatus: (
     mediaType: 'screen' | 'microphone' | 'camera'
   ) => Promise<ReturnType<SystemPreferences['getMediaAccessStatus']>>;
+  importStickerPack: (link: string) => Promise<ImportStickerPackResultType>;
   installStickerPack: (packId: string, key: string) => Promise<void>;
   requestCloseConfirmation: () => Promise<boolean>;
   setMediaPlaybackDisabled: (playbackDisabled: boolean) => void;
@@ -437,6 +443,26 @@ export function createIPCEvents(
     unknownSignalLink: () => {
       log.warn('unknownSignalLink: Showing error dialog');
       showUnknownSgnlLinkModal();
+    },
+    importStickerPack: async (
+      link: string
+    ): Promise<ImportStickerPackResultType> => {
+      try {
+        return {
+          contents: await fetchStickerPackContents(link, {
+            onProgress: (done, total) =>
+              ipcRenderer.send('art-creator:onImportProgress', { done, total }),
+          }),
+        };
+      } catch (error) {
+        log.error('importStickerPack:', Errors.toLogFormat(error));
+        return {
+          error:
+            error instanceof InvalidStickerPackLinkError
+              ? 'invalidLink'
+              : 'importFailed',
+        };
+      }
     },
     uploadStickerPack: (
       manifest: Uint8Array<ArrayBuffer>,

--- a/ts/windows/main/phase1-ipc.preload.ts
+++ b/ts/windows/main/phase1-ipc.preload.ts
@@ -574,6 +574,15 @@ ipc.on(
   }
 );
 
+ipc.on(
+  'art-creator:importStickerPack',
+  async (event, { link }: { link: string }) => {
+    const result = await window.Events?.importStickerPack(link);
+
+    event.sender.send('art-creator:importStickerPack:done', result);
+  }
+);
+
 const { promise: windowVisible, resolve: resolveWindowVisible } =
   explodePromise<void>();
 

--- a/ts/windows/sticker-creator/preload.preload.ts
+++ b/ts/windows/sticker-creator/preload.preload.ts
@@ -31,6 +31,33 @@ contextBridge.exposeInMainWorld(
     ipcRenderer.invoke('install-sticker-pack', packId, key)
 );
 
+let onImportProgress: ((done: number, total: number) => void) | undefined;
+
+ipcRenderer.on(
+  'art-creator:onImportProgress',
+  (_event, { done, total }: { done: number; total: number }) => {
+    onImportProgress?.(done, total);
+  }
+);
+
+contextBridge.exposeInMainWorld(
+  'importStickerPack',
+  async (
+    link: string,
+    newOnImportProgress: ((done: number, total: number) => void) | undefined
+  ): Promise<unknown> => {
+    onImportProgress = newOnImportProgress;
+
+    try {
+      return await ipcRenderer.invoke('art-creator:importStickerPack', {
+        link,
+      });
+    } finally {
+      onImportProgress = undefined;
+    }
+  }
+);
+
 contextBridge.exposeInMainWorld('getFilePath', (file: File) =>
   webUtils.getPathForFile(file)
 );


### PR DESCRIPTION
### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations.
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

Community discussion: https://community.signalusers.org/t/edit-sticker-packs/19371

Sticker packs are immutable on the server, so adding a sticker to an existing pack means rebuilding the whole pack in the sticker creator: re-dropping every image and re-assigning every emoji by hand. This change lets the creator start from an existing pack instead.

While the pack is still empty, the drop stage shows a field to paste a sticker pack link (`https://signal.art/addstickers/...` or `sgnl://addstickers?...`). The pack's stickers are downloaded from the CDN with per-sticker progress, decrypted, and loaded into the creator with their emoji, order, cover, title, and author intact. The user then adds new images, assigns emoji only to those, and uploads as usual. Imported bytes are passed through untouched, so unchanged stickers re-upload byte-identical.

Implementation mirrors the existing upload path in reverse: the creator window relays the raw link over IPC to the main window, which parses it with `parseSignalRoute` and reuses `getStickerPackManifest`, `getSticker`, and the existing sticker decryption. The creator gains no network or crypto code. Errors surface as toasts and leave the creator state untouched for retry; the import affordance only appears while no images have been added, so it never merges into an in-progress pack.


https://github.com/user-attachments/assets/f2021656-4875-4bd2-9704-167ebb6af697


