### PR TITLE
fix: Preserve official contact block state

### DIFF
--- a/ts/services/storageRecordOps.preload.ts
+++ b/ts/services/storageRecordOps.preload.ts
@@ -134,6 +134,7 @@ import { toNumber } from '../util/toNumber.std.ts';
 import { MAX_VALUE } from '../util/long.std.ts';
 import { isKnownProtoEnumMember } from '../util/isKnownProtoEnumMember.std.ts';
 import { Emoji } from '../axo/emoji.std.ts';
+import { SIGNAL_ACI } from '../types/SignalConversation.std.ts';
 
 const { isEqual } = lodash;
 
@@ -1369,6 +1370,14 @@ export async function mergeContactRecord(
   // Contacts should not have PNI as ACI
   if (aci && !isAciString(aci)) {
     return { shouldDrop: true, details: ['invalid aci'] };
+  }
+
+  // Official conversation state is stored in AccountRecord, never ContactRecord.
+  if (aci === SIGNAL_ACI) {
+    return {
+      shouldDrop: true,
+      details: ['official Signal conversation contact record'],
+    };
   }
 
   if (

--- a/ts/test-electron/services/storageRecordOps_test.preload.ts
+++ b/ts/test-electron/services/storageRecordOps_test.preload.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Signal Messenger, LLC
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { assert } from 'chai';
+
+import { SignalService as Proto } from '../../protobuf/index.std.ts';
+import { mergeContactRecord } from '../../services/storageRecordOps.preload.ts';
+import { SIGNAL_ACI } from '../../types/SignalConversation.std.ts';
+import { toAciObject } from '../../util/ServiceId.node.ts';
+
+describe('storageRecordOps', () => {
+  it('drops ContactRecords for the official Signal conversation', async () => {
+    const contactRecord = Proto.ContactRecord.decode(
+      Proto.ContactRecord.encode({
+        aci: null,
+        e164: null,
+        pni: null,
+        profileKey: null,
+        identityKey: null,
+        identityState: null,
+        givenName: null,
+        familyName: null,
+        username: null,
+        blocked: null,
+        whitelisted: null,
+        archived: null,
+        markedUnread: null,
+        mutedUntilTimestamp: null,
+        hideStory: null,
+        unregisteredAtTimestamp: null,
+        systemGivenName: null,
+        systemFamilyName: null,
+        systemNickname: null,
+        hidden: null,
+        pniSignatureVerified: null,
+        nickname: null,
+        note: null,
+        avatarColor: null,
+        aciBinary: toAciObject(SIGNAL_ACI).getRawUuidBytes(),
+        pniBinary: null,
+      })
+    );
+
+    assert.deepEqual(await mergeContactRecord('storage-id', 1, contactRecord), {
+      shouldDrop: true,
+      details: ['official Signal conversation contact record'],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
The official Signal conversation's block state is synchronized through
Storage Service's AccountRecord. Two legacy synchronization paths could
override that state:

- A legacy block-list sync could interpret the synthetic Signal ACI as
  remotely unblocked.
- An obsolete ContactRecord for the Signal ACI could apply ordinary contact
  message-request state after AccountRecord had blocked the conversation.

This change excludes the official Signal ACI from legacy block-list
reconciliation and drops ContactRecords for it, leaving AccountRecord as the
single authority.

## Testing

- `pnpm test-electron --grep "MessageReceiver|storageRecordOps"`
- `pnpm check:types`
- Prettier and Oxlint on changed files
- Manually reproduced a version-change sync with the official conversation
  blocked and deleted; it remained blocked after restart
  
 Fixes #7967