### PR TITLE
Remove unused optional props and arguments

### DIFF
--- a/ts/Crypto.node.ts
+++ b/ts/Crypto.node.ts
@@ -431,14 +431,12 @@ export function decryptAesCtr(
 function encryptAesGcm(
   key: Uint8Array<ArrayBuffer>,
   iv: Uint8Array<ArrayBuffer>,
-  plaintext: Uint8Array<ArrayBuffer>,
-  aad?: Uint8Array<ArrayBuffer>
+  plaintext: Uint8Array<ArrayBuffer>
 ): Uint8Array<ArrayBuffer> {
   return encrypt(CipherType.AES256GCM, {
     key,
     plaintext,
     iv,
-    aad,
   });
 }
 

--- a/ts/axo/_internal/AxoMath.dom.tsx
+++ b/ts/axo/_internal/AxoMath.dom.tsx
@@ -15,15 +15,10 @@ export namespace AxoMath {
   }
 
   /** Works the same way as CSS `progress([no-clamp] <min> <value> <max>)` */
-  export function progress(
-    value: number,
-    min: number,
-    max: number,
-    noClamp?: boolean
-  ): number {
+  export function progress(value: number, min: number, max: number): number {
     assert(max > min, 'max must be greater than min');
     const result = (value - min) / (max - min);
-    return noClamp ? result : clamp(result, 0, 1);
+    return clamp(result, 0, 1);
   }
 
   export function circumference(radius: number): number {

--- a/ts/components/Button.dom.tsx
+++ b/ts/components/Button.dom.tsx
@@ -37,7 +37,6 @@ export type PropsType = {
   size?: ButtonSize;
   style?: CSSProperties;
   tabIndex?: number;
-  testId?: string;
   theme?: Theme;
   variant?: ButtonVariant;
   'aria-disabled'?: boolean;
@@ -98,7 +97,6 @@ export const Button = forwardRef<HTMLButtonElement, PropsType>(
       discouraged = false,
       style,
       tabIndex,
-      testId,
       theme,
       variant = ButtonVariant.Primary,
       size = ButtonSize.Medium,
@@ -136,7 +134,6 @@ export const Button = forwardRef<HTMLButtonElement, PropsType>(
           className,
           className && discouraged ? `${className}--discouraged` : undefined
         )}
-        data-testid={testId}
         disabled={disabled}
         onClick={onClick}
         form={form}

--- a/ts/components/CallParticipantCount.dom.tsx
+++ b/ts/components/CallParticipantCount.dom.tsx
@@ -10,7 +10,6 @@ export type PropsType = {
   callMode: CallMode.Group | CallMode.Adhoc;
   i18n: LocalizerType;
   isAdhocJoinRequestPending?: boolean;
-  groupMemberCount?: number;
   participantCount: number;
   toggleParticipants: () => void;
 };

--- a/ts/components/GroupMembersNames.dom.tsx
+++ b/ts/components/GroupMembersNames.dom.tsx
@@ -14,7 +14,6 @@ const { take } = lodash;
 
 type PropsType = {
   i18n: LocalizerType;
-  nameClassName?: string;
   memberships: ReadonlyArray<GroupV2Membership>;
   invitesCount?: number;
   onOtherMembersClick?: () => void;
@@ -170,7 +169,6 @@ function MemberList({
 
 export function GroupMembersNames({
   i18n,
-  nameClassName,
   memberships,
   invitesCount,
   onOtherMembersClick,
@@ -203,11 +201,11 @@ export function GroupMembersNames({
     ).map((name, i) => (
       // We cannot guarantee uniqueness of member names
       // oxlint-disable-next-line react/no-array-index-key
-      <span key={i} className={nameClassName}>
+      <span key={i}>
         <UserText text={name ?? i18n('icu:unknownContactShort')} />
       </span>
     ));
-  }, [otherMemberNames, nameClassName, i18n]);
+  }, [otherMemberNames, i18n]);
 
   const memberListElement = (
     <MemberList

--- a/ts/components/SharedGroupNames.dom.tsx
+++ b/ts/components/SharedGroupNames.dom.tsx
@@ -13,19 +13,17 @@ const { take } = lodash;
 
 type PropsType = {
   i18n: LocalizerType;
-  nameClassName?: string;
   sharedGroupNames: ReadonlyArray<string>;
 };
 
 export function SharedGroupNames({
   i18n,
-  nameClassName,
   sharedGroupNames,
 }: PropsType): JSX.Element {
   const firstThreeGroups = take(sharedGroupNames, 3).map((group, i) => (
     // We cannot guarantee uniqueness of group names
     // oxlint-disable-next-line react/no-array-index-key
-    <strong key={i} className={nameClassName}>
+    <strong key={i}>
       <UserText text={group} />
     </strong>
   ));

--- a/ts/components/StoryViewsNRepliesModal.dom.tsx
+++ b/ts/components/StoryViewsNRepliesModal.dom.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 Signal Messenger, LLC
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import type { ReactNode, JSX, RefObject, MouseEvent } from 'react';
+import type { ReactNode, JSX, RefObject } from 'react';
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import lodash from 'lodash';
@@ -546,7 +546,6 @@ type ReplyOrReactionMessageProps = {
   id: string;
   isInternalUser?: boolean;
   isSpoilerExpanded: Record<number, boolean>;
-  onContextMenu?: (ev: MouseEvent) => void;
   reply: ReplyType;
   shouldCollapseAbove: boolean;
   shouldCollapseBelow: boolean;

--- a/ts/components/conversation/ContactName.dom.tsx
+++ b/ts/components/conversation/ContactName.dom.tsx
@@ -29,8 +29,7 @@ export type ContactNameData = {
 };
 
 export function useContactNameData(
-  conversation: ConversationType | null,
-  contactNameColor?: ContactNameColorType
+  conversation: ConversationType | null
 ): ContactNameData | null {
   const { firstName, title, isMe } = conversation ?? {};
   const isSignalConversation =
@@ -40,17 +39,15 @@ export function useContactNameData(
       return null;
     }
     return {
-      contactNameColor,
       firstName,
       isSignalConversation,
       isMe,
       title,
     };
-  }, [contactNameColor, firstName, isSignalConversation, isMe, title]);
+  }, [firstName, isSignalConversation, isMe, title]);
 }
 
 export type PropsType = ContactNameData & {
-  fontSizeOverride?: number;
   module?: string;
   preferFirstName?: boolean;
   onClick?: VoidFunction;
@@ -121,15 +118,13 @@ export function GroupMemberLabel({
   contactLabel,
   contactNameColor,
   context,
-  module,
 }: {
   emojiSize?: FunStaticEmojiSize;
   contactLabel?: MemberLabelType;
   contactNameColor?: ContactNameColorType;
   context: Context;
-  module?: string;
 }): ReactNode {
-  const getClassName = getClassNamesFor('module-contact-name', module);
+  const getClassName = getClassNamesFor('module-contact-name');
 
   if (!contactLabel) {
     return null;

--- a/ts/messages/copyQuote.preload.ts
+++ b/ts/messages/copyQuote.preload.ts
@@ -40,16 +40,11 @@ export type MinimalMessageCache = Readonly<{
   register: (message: MessageModel) => MessageModel;
 }>;
 
-export type CopyQuoteOptionsType = Readonly<{
-  messageCache?: MinimalMessageCache;
-}>;
-
 export const copyFromQuotedMessage = async (
   quote: ProcessedQuote,
-  conversationId: string,
-  options: CopyQuoteOptionsType = {}
+  conversationId: string
 ): Promise<QuotedMessageType> => {
-  const { messageCache = window.MessageCache } = options;
+  const messageCache = window.MessageCache;
   const { id } = quote;
   strictAssert(id, 'Quote must have an id');
 
@@ -80,7 +75,7 @@ export const copyFromQuotedMessage = async (
   }
 
   if (queryMessage) {
-    await copyQuoteContentFromOriginal(queryMessage, result, options);
+    await copyQuoteContentFromOriginal(queryMessage, result);
   }
 
   return result;
@@ -88,9 +83,9 @@ export const copyFromQuotedMessage = async (
 
 export const copyQuoteContentFromOriginal = async (
   message: MessageModel,
-  quote: QuotedMessageType,
-  { messageCache = window.MessageCache }: CopyQuoteOptionsType = {}
+  quote: QuotedMessageType
 ): Promise<void> => {
+  const messageCache = window.MessageCache;
   const { attachments } = quote;
   const quoteAttachment = attachments ? attachments[0] : undefined;
 

--- a/ts/models/conversations.preload.ts
+++ b/ts/models/conversations.preload.ts
@@ -52,7 +52,6 @@ import { hasDraft } from '../util/hasDraft.std.ts';
 import { getStoryReplyContext } from '../util/getStoryReplyContext.std.ts';
 import { normalizeProfileName } from '../util/normalizeProfileName.std.ts';
 import type {
-  StickerType,
   StickerWithHydratedData,
 } from '../types/Stickers.preload.ts';
 import * as Stickers from '../types/Stickers.preload.ts';
@@ -4017,11 +4016,9 @@ export class ConversationModel {
   }
 
   // TODO(DESKTOP-9497): This will not include `ourAci` in 1:1 chats
-  getMembers(
-    options: { includePendingMembers?: boolean } = {}
-  ): Array<ConversationModel> {
+  getMembers(): Array<ConversationModel> {
     return compact(
-      getConversationMembers(this.attributes, options).map(conversationAttrs =>
+      getConversationMembers(this.attributes).map(conversationAttrs =>
         window.ConversationController.get(conversationAttrs.id)
       )
     );
@@ -4061,8 +4058,7 @@ export class ConversationModel {
 
   async getQuoteAttachment(
     attachments?: Array<AttachmentType>,
-    preview?: Array<LinkPreviewType>,
-    sticker?: StickerType
+    preview?: Array<LinkPreviewType>
   ): Promise<
     Array<{
       contentType: MIMEType;
@@ -4070,7 +4066,7 @@ export class ConversationModel {
       thumbnail?: ThumbnailType | null;
     }>
   > {
-    return getQuoteAttachment(attachments, preview, sticker);
+    return getQuoteAttachment(attachments, preview);
   }
 
   async sendStickerMessage(
@@ -5672,8 +5668,8 @@ export class ConversationModel {
     log.info(`${logId}: Delete complete`);
   }
 
-  getTitle(options?: { isShort?: boolean }): string {
-    return getTitle(this.attributes, options);
+  getTitle(): string {
+    return getTitle(this.attributes);
   }
 
   getTitleNoDefault(options?: { isShort?: boolean }): string | undefined {

--- a/ts/util/canvasToBytes.std.ts
+++ b/ts/util/canvasToBytes.std.ts
@@ -6,9 +6,8 @@ import type { MIMEType } from '../types/MIME.std.ts';
 
 export async function canvasToBytes(
   canvas: HTMLCanvasElement,
-  mimeType?: MIMEType,
-  quality?: number
+  mimeType?: MIMEType
 ): Promise<Uint8Array<ArrayBuffer>> {
-  const blob = await canvasToBlob(canvas, mimeType, quality);
+  const blob = await canvasToBlob(canvas, mimeType);
   return new Uint8Array(await blob.arrayBuffer());
 }

--- a/ts/util/generateDonationReceipt.dom.ts
+++ b/ts/util/generateDonationReceipt.dom.ts
@@ -29,41 +29,14 @@ const COLORS = {
  * NOTE: letterSpacing does not work for arabic, breaks the script
  * @param params - Object containing original values to scale
  * @param params.fontSize - Original font size in pixels
- * @param params.height - Optional original height/margin/padding in pixels
- * @param params.letterSpacing - Optional original letter spacing in pixels
  * @returns Scaled values for use in FabricJS
  */
-function scaleValues(params: {
+function scaleValues(params: { fontSize: number }): {
   fontSize: number;
-  height?: number;
-  letterSpacing?: number;
-}): {
-  fontSize: number;
-  height?: number;
-  charSpacing?: number;
 } {
-  const result: {
-    fontSize: number;
-    height?: number;
-    charSpacing?: number;
-  } = {
+  return {
     fontSize: params.fontSize * SCALING_FACTOR,
   };
-
-  if (params.height !== undefined) {
-    result.height = params.height * SCALING_FACTOR;
-  }
-
-  if (params.letterSpacing !== undefined) {
-    // FabricJS charSpacing is in thousandths of em units
-    // Formula: (letterSpacingPx * 1000) / fontSizePx
-    // This converts pixel-based letter spacing to em-based units
-    // For example: -0.13px letter spacing on 12px font =
-    //    (-0.13 * 1000) / 12 = -10.83 thousandths of em
-    result.charSpacing = (params.letterSpacing * 1000) / params.fontSize;
-  }
-
-  return result;
 }
 
 const SIGNAL_LOGO_SVG = `<svg width="417" height="121" viewBox="0 0 560 160" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/ts/util/getTestMegaphone.std.ts
+++ b/ts/util/getTestMegaphone.std.ts
@@ -11,9 +11,7 @@ import { DAY } from './durations/index.std.ts';
 const INTERNAL_TEST_ID = 'INTERNAL_TEST' as RemoteMegaphoneId;
 export const TEST_MEGAPHONE_IMAGE = 'images/donate-heart.png';
 
-export function internalGetTestMegaphone(
-  props?: Partial<VisibleRemoteMegaphoneType>
-): VisibleRemoteMegaphoneType {
+export function internalGetTestMegaphone(): VisibleRemoteMegaphoneType {
   return {
     priority: 100,
     desktopMinVersion: '1.0.0',
@@ -35,7 +33,6 @@ export function internalGetTestMegaphone(
     snoozedAt: null,
     shownAt: null,
     isFinished: false,
-    ...props,
     id: INTERNAL_TEST_ID,
   };
 }

--- a/ts/util/numbers.std.ts
+++ b/ts/util/numbers.std.ts
@@ -21,16 +21,10 @@ export function safeParseNumber(value: number | string): number | null {
   return parsed;
 }
 
-export function safeParseInteger(
-  value: number | string,
-  trunc = false
-): number | null {
+export function safeParseInteger(value: number | string): number | null {
   const parsed = safeParseNumber(value);
   if (parsed == null) {
     return null;
-  }
-  if (trunc) {
-    return Math.trunc(parsed);
   }
   if (!Number.isInteger(parsed)) {
     return null;

--- a/ts/util/search.std.ts
+++ b/ts/util/search.std.ts
@@ -9,11 +9,6 @@ export const SNIPPET_TRUNCATION_PLACEHOLDER = '<<truncation>>';
  * Generate a snippet suitable for rendering search results, in the style returned from
  * FTS's snippet() function.
  *
- * @param approxSnippetLength - If generating a snippet from a mention, the approximate
- * length of snippet (not including any hydrated mentions that might occur when rendering)
- * @param maxCharsBeforeHighlight - Max chars to show before the highlight, to ensure the
- * highlight is visible even at narrow search result pane widths
- *
  * If generating a snippet from a mention, will not truncate in the middle of a word.
  *
  * @returns Return a snippet suitable for rendering search results, e.g.
@@ -23,21 +18,17 @@ export function generateSnippetAroundMention({
   body,
   mentionStart,
   mentionLength,
-  approxSnippetLength = 50,
-  maxCharsBeforeHighlight = 30,
 }: {
   body: string;
   mentionStart: number;
   mentionLength: number;
-  approxSnippetLength?: number;
-  maxCharsBeforeHighlight?: number;
 }): string {
   const segmenter = new Intl.Segmenter([], { granularity: 'word' });
 
   // Grab a substring of the body around the mention, larger than the desired snippet
   const bodyAroundMention = body.substring(
-    mentionStart - 2 * approxSnippetLength,
-    mentionStart + mentionLength + 2 * approxSnippetLength
+    mentionStart - 2 * 50,
+    mentionStart + mentionLength + 2 * 50
   );
 
   const words = [...segmenter.segment(bodyAroundMention)].filter(
@@ -68,13 +59,13 @@ export function generateSnippetAroundMention({
     const lengthAfterMention = snippetEndIdx - mentionStart - mentionLength;
 
     if (
-      lengthBeforeMention + lengthAfterMention <= approxSnippetLength &&
-      lengthBeforeMention <= maxCharsBeforeHighlight
+      lengthBeforeMention + lengthAfterMention <= 50 &&
+      lengthBeforeMention <= 30
     ) {
       break;
     }
 
-    if (lengthBeforeMention > maxCharsBeforeHighlight) {
+    if (lengthBeforeMention > 30) {
       leftWordIdx += 1;
     } else if (lengthBeforeMention > lengthAfterMention) {
       leftWordIdx += 1;

--- a/ts/util/setupI18n.dom.tsx
+++ b/ts/util/setupI18n.dom.tsx
@@ -6,7 +6,6 @@ import type { JSX } from 'react';
 import type { LocaleMessagesType } from '../types/I18N.std.ts';
 import type { LocalizerType } from '../types/Util.std.ts';
 import { setupI18n as setupI18nMain } from './setupI18nMain.std.ts';
-import type { SetupI18nOptionsType } from './setupI18nMain.std.ts';
 import { strictAssert } from './assert.std.ts';
 
 function renderEmojify(parts: ReadonlyArray<unknown>): JSX.Element {
@@ -29,14 +28,9 @@ function getHourCyclePreference() {
 
 export function setupI18n(
   locale: string,
-  messages: LocaleMessagesType,
-  options: Omit<
-    SetupI18nOptionsType,
-    'renderEmojify' | 'getLocaleDirection' | 'getHourCyclePreference'
-  > = {}
+  messages: LocaleMessagesType
 ): LocalizerType {
   return setupI18nMain(locale, messages, {
-    ...options,
     renderEmojify,
     getLocaleDirection,
     getHourCyclePreference,

--- a/ts/util/shouldShowInvalidMessageToast.preload.ts
+++ b/ts/util/shouldShowInvalidMessageToast.preload.ts
@@ -14,11 +14,8 @@ import {
 } from './whatTypeOfConversation.dom.ts';
 import { itemStorage } from '../textsecure/Storage.preload.ts';
 
-const MAX_MESSAGE_BODY_LENGTH = 64 * 1024;
-
 export function shouldShowInvalidMessageToast(
-  conversationAttributes: ConversationAttributesType,
-  messageText?: string
+  conversationAttributes: ConversationAttributesType
 ): AnyToast | undefined {
   const state = window.reduxStore.getState();
   if (hasExpired(state)) {
@@ -60,10 +57,6 @@ export function shouldShowInvalidMessageToast(
     conversationAttributes.left
   ) {
     return { toastType: ToastType.LeftGroup };
-  }
-
-  if (messageText && messageText.length > MAX_MESSAGE_BODY_LENGTH) {
-    return { toastType: ToastType.MessageBodyTooLong };
   }
 
   return undefined;

--- a/ts/util/uploads/uploads.node.ts
+++ b/ts/util/uploads/uploads.node.ts
@@ -3,7 +3,7 @@
 import fetch from 'node-fetch';
 import { createReadStream, createWriteStream } from 'node:fs';
 import { pipeline } from 'node:stream/promises';
-import type { TusFileReader, FetchFunctionType } from './tusProtocol.node.ts';
+import type { TusFileReader } from './tusProtocol.node.ts';
 import { tusResumeUpload, tusUpload } from './tusProtocol.node.ts';
 import { HTTPError } from '../../types/HTTPError.std.ts';
 
@@ -88,15 +88,13 @@ async function _doDownload({
   headers = {},
   filePath,
   signal,
-  fetchFn = fetch,
 }: {
   endpoint: string;
   filePath: string;
   headers?: Record<string, string>;
   signal?: AbortSignal;
-  fetchFn?: FetchFunctionType;
 }): Promise<void> {
-  const response = await fetchFn(endpoint, {
+  const response = await fetch(endpoint, {
     method: 'GET',
     signal,
     redirect: 'error',


### PR DESCRIPTION
Hey folks, I'm working on an experimental CLI which uses the tsgo toolchain to find optional component and function signatures that are in practice never passed. This is essentially dead code elimination, and a complementary workflow to run alongside a tool like knip.

The changeset in this PR has been done using the script as the reporting tool, and an agent validator loop walking through each reported line one by one to first inspect the report, analyze the call sites, removing them, and later re-running ts. If done correctly, the code that has been removed should have been effectively dead.

The reporting script heavily relies on type quality and only reports on types whos members are statically enumerable.

Deliberately left out of this PR:
- everything under `ts/sql/` (the DataReader/DataWriter IPC dispatch hides call sites from static analysis)
- test/CI/mock-server helpers
- arguments on callbacks that escape as values (e.g. handlers passed into props), where a removal is type-safe even when wrong
- the `onProgress`/`maxRetries` plumbing in `tusProtocol` since it forms a coherent capability

I'm opening this PR in an effort to help you eliminate dead code, but also to gain feedback on the script and the detection mechanisms. There are always risks of false positive reports, and removal of code that is actually still required at runtime.

Some references of PRs opened to other repositories that have been merged or are still open:
✅ [Sentry (4k loc removed)](https://github.com/getsentry/sentry/pull/122234/)
⏳ [Sentry (followup 1k loc removed)](https://github.com/getsentry/sentry/pull/122373)
⏳ [Tanstack](https://github.com/TanStack/tanstack.com/pull/1173)
⏳ [npmx](https://github.com/npmx-dev/npmx.dev/pull/3195)

Would love to hear your feedback 🙏🏼

Made with [Cursor](https://cursor.com)