### PR TITLE
Sticker search: try to compare unknown emojis

### DIFF
--- a/ts/axo/emoji.std.ts
+++ b/ts/axo/emoji.std.ts
@@ -278,6 +278,8 @@ export namespace Emoji {
     FLAGS = 'FLAGS',
   }
 
+  const EMOJI_VARIATION_SElECTOR = '\u{FE0F}';
+
   export function getDebugLabel(input: string): string {
     return Array.from(input.slice(0, 12), char => {
       const num = char.codePointAt(0) ?? 0;
@@ -352,6 +354,15 @@ export namespace Emoji {
 
   export function ignorePreferredSkinTone(emoji: Emoji): Variant {
     return emoji as Variant;
+  }
+
+  export function normalizeForComparator(emoji: string): string {
+    return (
+      emoji
+        .normalize('NFD')
+        // Strip variation selectors for comparison (https://github.com/signalapp/Signal-Desktop/issues/8009)
+        .replaceAll(EMOJI_VARIATION_SElECTOR, '')
+    );
   }
 
   export const BAR_CHART = PARENT_AND_ONLY_VARIANT('📊');

--- a/ts/components/fun/panels/FunPanelStickers.dom.tsx
+++ b/ts/components/fun/panels/FunPanelStickers.dom.tsx
@@ -244,17 +244,19 @@ export function FunPanelStickers({
 
   const sections = useMemo(() => {
     if (searchQuery !== '') {
-      const emojis = new Set<Emoji.Parent>(Emoji.search(searchQuery));
+      const emojis = new Set<string>(
+        Emoji.search(searchQuery).map(emoji => {
+          return Emoji.normalizeForComparator(emoji);
+        })
+      );
 
       const allStickers = installedStickerPacks.flatMap(pack => pack.stickers);
       const matchingStickers = allStickers.filter(sticker => {
         if (sticker.emoji == null) {
           return false;
         }
-        if (!Emoji.isParent(sticker.emoji)) {
-          return false;
-        }
-        return emojis.has(sticker.emoji);
+        const stickerEmoji = Emoji.normalizeForComparator(sticker.emoji);
+        return emojis.has(stickerEmoji);
       });
 
       return [


### PR DESCRIPTION


<!--
Thanks for contributing to the project!
Please help us keep this project in good shape by going through this checklist.
Replace the empty checkboxes [ ] below with checked ones [X] as they are completed
Remember, you can preview this before saving it.
-->

<!-- You can remove this first section if you have contributed before -->

### First time contributor checklist:

- [x] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/main/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md)
- [x] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [x] My contribution is **not** related to translations.
- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`main`](https://github.com/signalapp/Signal-Desktop/tree/main) branch
- [x] A `pnpm run ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/main/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

If the emoji byte sequence does not exactly match one of the emojis defined in Signal's emoji list, we try and do a `localeCompare` to the found emojis instead of returning false.

We do this because sometimes, the variation selector character's presence differs from what is defined in a sticker pack, and doing a strict comparison will result in that sticker not being able to be searched for

Fixes #8009 

This change implements a divergence in behaviour from Signal Android & iOS clients, however, I think it would be best to resolve this issue in those clients too.